### PR TITLE
ci: add regression tests

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -1,0 +1,62 @@
+name: Regression Tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo fmt
+        run: cargo fmt
+
+      - name: Run cargo clippy
+        run: cargo clippy
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run unit tests
+        run: make unit-tests
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        provider: [aws] # TODO: enable azure
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run integration tests for ${{ matrix.provider }}
+        run: |
+          make ${{ matrix.provider }}-integration-tests


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to run regression tests on the codebase. The workflow includes jobs for linting, unit tests, and integration tests, ensuring code quality and functionality across different stages.

It runs on pull requests and main

New GitHub Actions workflow:

* [`.github/workflows/regression-tests.yaml`](diffhunk://#diff-309511f2e30a824af599270040d3985dcbd2a87fe42e7da00a13b8e21e264fddR1-R62): Added a new workflow named "Regression Tests" that triggers on pull requests and pushes to the main branch. It includes jobs for running `cargo fmt`, `cargo clippy`, unit tests, and integration tests with a matrix strategy for different providers.

<img width="641" alt="Screenshot 2025-03-12 at 20 14 53" src="https://github.com/user-attachments/assets/1bfa634f-965a-42bc-b119-dc08cc130ee8" />
