### PR TITLE
ci: enable integration tests for azure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Regression Tests
+name: Tests
 
 on:
   pull_request:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        provider: [aws] # TODO: enable azure
+        provider: [aws,azure]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ azure-integration-tests:
 	@echo "Running Azure integration tests..."
 	PROVIDER=azure \
 	INFRAWEAVE_API_FUNCTION=function \
+	AZURE_CLIENT_ID=dummy \
+	AZURE_CLIENT_SECRET=dummy \
+	AZURE_TENANT_ID=dummy \
 	REGION=westus2 \
 	TEST_MODE=true \
 	cargo test -p integration-tests -- --test-threads=1

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use anyhow::Result;
 use azure_core::auth::TokenCredential;
-use azure_identity::AzureCliCredential;
+use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 use env_defs::{
     get_change_record_identifier, get_deployment_identifier, get_event_identifier,
     get_module_identifier, get_policy_identifier, GenericFunctionResponse,
@@ -57,7 +57,10 @@ pub async fn run_function(
             .get_token(&["https://management.azure.com/.default"])
             .await
     } else {
-        let credential = AzureCliCredential::default();
+        let credential = DefaultAzureCredential::create(
+            // TODO: Check if this can replace the above
+            TokenCredentialOptions::default(),
+        )?;
         credential
             .get_token(&["https://management.azure.com/.default"])
             .await


### PR DESCRIPTION
This pull request includes several changes to improve the integration and testing processes, particularly with Azure integration. The most important changes include renaming and updating the GitHub Actions workflow, adding Azure credentials to the Makefile, and updating the Azure credential handling in the Rust code.

### GitHub Actions Workflow Updates:
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191L1-R1): Renamed from `regression-tests.yaml` and updated the workflow name from "Regression Tests" to "Tests".
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191L49-R49): Updated the job matrix to include both AWS and Azure providers.

### Makefile Updates:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R26-R28): Added dummy Azure credentials required for running Azure integration tests.

### Azure Credential Handling Updates:
* [`env_azure/src/api.rs`](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL5-R5): Replaced `AzureCliCredential` with `DefaultAzureCredential` for better credential management. [[1]](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL5-R5) [[2]](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL60-R63)