### PR TITLE
fix: improve docker builds copy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore target directories
+**/target/
+env_aws/target
+env_common/target
+crd-templator/target
+infraweave_operator/target
+infraweave_py/venv
+.git*
+.terraform
+**/.terraform
+.terraform/**

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -13,16 +13,9 @@ RUN apk add --no-cache \
 RUN mkdir /app
 WORKDIR /app
 
-COPY ./cli/Cargo.toml /app/cli/
-COPY ./Cargo.lock /app/cli/
-COPY ./cli/src /app/cli/src/
-COPY ./env_aws/ /app/env_aws/
-COPY ./env_azure/ /app/env_azure/
-COPY ./env_common/ /app/env_common/
-COPY ./defs/ /app/defs/
-COPY ./utils/ /app/utils/
+COPY . /app/
 
-RUN cd cli && cargo build --release
+RUN cargo build --release -p cli
 
 # Copy jq binary from jq image to inherit architecture
 FROM ghcr.io/jqlang/jq:1.7.1 AS jq
@@ -36,6 +29,6 @@ COPY --from=jq /jq /usr/local/bin/jq
 
 WORKDIR /app
 
-COPY --from=builder /app/cli/target/release/cli /usr/local/bin/cli
+COPY --from=builder /app/target/release/cli /usr/local/bin/cli
 
 CMD ["cli"]

--- a/gitops/Dockerfile.generic
+++ b/gitops/Dockerfile.generic
@@ -5,16 +5,9 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev wget unzip make
 RUN mkdir /app
 WORKDIR /app
 
-COPY ./gitops/Cargo.toml /app/gitops/
-COPY ./Cargo.lock /app/gitops/
-COPY ./gitops/src /app/gitops/src/
-COPY ./env_aws/ /app/env_aws/
-COPY ./env_azure/ /app/env_azure/
-COPY ./env_common/ /app/env_common/
-COPY ./defs/ /app/defs/
-COPY ./utils/ /app/utils/
+COPY . /app/
 
-RUN cd gitops && cargo build --release
+RUN cargo build --release -p gitops
 
 # Create empty directory to copy to final image
 RUN mkdir /app/app
@@ -26,6 +19,6 @@ COPY --from=builder /app/app /app
 
 WORKDIR /app
 
-COPY --from=builder /app/gitops/target/release/gitops /usr/local/bin/gitops
+COPY --from=builder /app/target/release/gitops /usr/local/bin/gitops
 
 CMD ["gitops"]

--- a/gitops/Dockerfile.lambda
+++ b/gitops/Dockerfile.lambda
@@ -5,23 +5,16 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev wget unzip make
 RUN mkdir /app
 WORKDIR /app
 
-COPY ./gitops/Cargo.toml /app/gitops/
-COPY ./Cargo.lock /app/gitops/
-COPY ./gitops/src /app/gitops/src/
-COPY ./env_aws/ /app/env_aws/
-COPY ./env_azure/ /app/env_azure/
-COPY ./env_common/ /app/env_common/
-COPY ./defs/ /app/defs/
-COPY ./utils/ /app/utils/
+COPY . /app/
 
-RUN cd gitops && cargo build --release
+RUN cargo build --release -p gitops
 
 # Create empty directory to copy to final image
 RUN mkdir /app/app
 
 FROM gcr.io/distroless/cc-debian12
 
-COPY --from=builder /app/gitops/target/release/gitops /usr/local/bin/bootstrap
+COPY --from=builder /app/target/release/gitops /usr/local/bin/bootstrap
 
 # Lambda requires this
 ENV AWS_LAMBDA_RUNTIME_API="aws-runtime-interface.emulator"

--- a/operator/.dockerignore
+++ b/operator/.dockerignore
@@ -1,6 +1,0 @@
-# Ignore target directories
-target/
-env_aws/target
-env_common/target
-crd-templator/target
-infraweave_operator/target

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.4
-
 FROM rust:slim-bullseye AS builder
 
 ENV K8S_OPENAPI_ENABLED_VERSION=v1.31
@@ -8,22 +6,12 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev make
 
 WORKDIR /app
 
-COPY ./Cargo.lock /app/
-COPY ./env_aws /app/env_aws/
-COPY ./env_azure /app/env_azure/
-COPY ./defs /app/defs/
-COPY ./utils /app/utils/
-COPY ./env_common /app/env_common/
-COPY ./crd-templator /app/crd-templator/
-COPY ./operator/Cargo.toml /app/operator/
-COPY ./operator/src /app/operator/src/
+COPY . /app/
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target \
-    cd operator && cargo build --release
+RUN cargo build --release -p operator
 
 FROM gcr.io/distroless/cc-debian12
 
-COPY --from=builder /app/operator/target/release/operator /usr/local/bin/operator
+COPY --from=builder /app/target/release/operator /usr/local/bin/operator
 
 CMD ["operator"]

--- a/reconciler/Dockerfile.generic
+++ b/reconciler/Dockerfile.generic
@@ -5,16 +5,9 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev wget unzip make
 RUN mkdir /app
 WORKDIR /app
 
-COPY ./reconciler/Cargo.toml /app/reconciler/
-COPY ./Cargo.lock /app/reconciler/
-COPY ./reconciler/src /app/reconciler/src/
-COPY ./env_aws/ /app/env_aws/
-COPY ./env_azure/ /app/env_azure/
-COPY ./env_common/ /app/env_common/
-COPY ./defs/ /app/defs/
-COPY ./utils/ /app/utils/
+COPY . /app/
 
-RUN cd reconciler && cargo build --release
+RUN cargo build --release -p reconciler
 
 # Create empty directory to copy to final image
 RUN mkdir /app/app
@@ -26,6 +19,6 @@ COPY --from=builder /app/app /app
 
 WORKDIR /app
 
-COPY --from=builder /app/reconciler/target/release/reconciler /usr/local/bin/reconciler
+COPY --from=builder /app/target/release/reconciler /usr/local/bin/reconciler
 
 CMD ["reconciler"]

--- a/reconciler/Dockerfile.lambda
+++ b/reconciler/Dockerfile.lambda
@@ -5,23 +5,16 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev wget unzip make
 RUN mkdir /app
 WORKDIR /app
 
-COPY ./reconciler/Cargo.toml /app/reconciler/
-COPY ./Cargo.lock /app/reconciler/
-COPY ./reconciler/src /app/reconciler/src/
-COPY ./env_aws/ /app/env_aws/
-COPY ./env_azure/ /app/env_azure/
-COPY ./env_common/ /app/env_common/
-COPY ./defs/ /app/defs/
-COPY ./utils/ /app/utils/
+COPY . /app/
 
-RUN cd reconciler && cargo build --release
+RUN cargo build --release -p reconciler
 
 # Create empty directory to copy to final image
 RUN mkdir /app/app
 
 FROM gcr.io/distroless/cc-debian12
 
-COPY --from=builder /app/reconciler/target/release/reconciler /usr/local/bin/bootstrap
+COPY --from=builder /app/target/release/reconciler /usr/local/bin/bootstrap
 
 # Lambda requires this
 ENV AWS_LAMBDA_RUNTIME_API="aws-runtime-interface.emulator"

--- a/terraform_runner/Dockerfile
+++ b/terraform_runner/Dockerfile
@@ -26,18 +26,11 @@ RUN wget https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_${
 RUN wget https://github.com/open-policy-agent/opa/releases/download/v0.69.0/opa_linux_${ARCH}_static \
     -O /usr/local/bin/opa && chmod +x /usr/local/bin/opa
 
-COPY ./terraform_runner/Cargo.toml /app/terraform_runner/
-COPY ./Cargo.lock /app/
-COPY ./terraform_runner/src /app/terraform_runner/src/
-COPY ./env_aws/ /app/env_aws/
-COPY ./env_azure/ /app/env_azure/
-COPY ./env_common/ /app/env_common/
-COPY ./defs/ /app/defs/
-COPY ./utils/ /app/utils/
+COPY . /app/
 
 RUN rustup target add aarch64-unknown-linux-musl
 
-RUN cd terraform_runner && cargo build --release
+RUN cargo build --release -p terraform_runner
 
 FROM alpine:3.20
 
@@ -50,7 +43,7 @@ RUN chown runner:runner /app
 
 COPY --from=builder /usr/local/bin/terraform /usr/local/bin/terraform
 COPY --from=builder /usr/local/bin/opa /usr/local/bin/opa
-COPY --from=builder /app/terraform_runner/target/release/terraform_runner /usr/local/bin/terraform_runner
+COPY --from=builder /app/target/release/terraform_runner /usr/local/bin/terraform_runner
 
 RUN chown -R 1000:1000 /app
 

--- a/webserver-openapi/Dockerfile
+++ b/webserver-openapi/Dockerfile
@@ -5,16 +5,9 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev wget unzip make c
 RUN mkdir /app
 WORKDIR /app
 
-COPY ./webserver-openapi/Cargo.toml /app/webserver-openapi/
-COPY ./Cargo.lock /app/webserver-openapi/
-COPY ./webserver-openapi/src /app/webserver-openapi/src/
-COPY ./env_aws/ /app/env_aws/
-COPY ./env_azure/ /app/env_azure/
-COPY ./env_common/ /app/env_common/
-COPY ./defs/ /app/defs/
-COPY ./utils/ /app/utils/
+COPY . /app/
 
-RUN cd webserver-openapi && cargo build --release
+RUN cargo build --release -p webserver-openapi
 
 # Create empty directory to copy to final image
 RUN mkdir /app/app
@@ -26,7 +19,7 @@ COPY --from=builder /app/app /app
 
 WORKDIR /app
 
-COPY --from=builder /app/webserver-openapi/target/release/webserver-openapi /usr/local/bin/webserver-openapi
+COPY --from=builder /app/target/release/webserver-openapi /usr/local/bin/webserver-openapi
 
 EXPOSE 8081
 


### PR DESCRIPTION
This pull request includes several changes to Dockerfiles and `.dockerignore` file to streamline the build process and improve efficiency.

* These changes aim to simplify the Docker build process, reduce redundancy, and ensure that only necessary files are included in the Docker context. 
* It also resolves a bug where the Cargo.lock was not respected causing troubles with `operator` using k8s-openapi 0.24.0 instead of 0.23.0 as specified.

### Dockerfile Improvements:
* Simplified the `COPY` commands by copying the entire project directory instead of individual files and directories in `cli/Dockerfile`, `gitops/Dockerfile.generic`, `gitops/Dockerfile.lambda`, `operator/Dockerfile`, `reconciler/Dockerfile.generic`, `reconciler/Dockerfile.lambda`, `terraform_runner/Dockerfile`, and `webserver-openapi/Dockerfile`. 

* Updated the paths in the `COPY --from=builder` commands to reflect the new directory structure in `cli/Dockerfile`, `gitops/Dockerfile.generic`, `gitops/Dockerfile.lambda`, `operator/Dockerfile`, `reconciler/Dockerfile.generic`, `reconciler/Dockerfile.lambda`, `terraform_runner/Dockerfile`, and `webserver-openapi/Dockerfile`. 

### .dockerignore Updates:
* Added entries to ignore target directories and other unnecessary files in `.dockerignore`. 

