### PR TITLE
ci: enable docker builds as part of tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,3 +60,25 @@ jobs:
       - name: Run integration tests for ${{ matrix.provider }}
         run: |
           make ${{ matrix.provider }}-integration-tests
+
+  docker-builds:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - package: cli
+            dockerfile: cli/Dockerfile
+          - package: gitops
+            dockerfile: gitops/Dockerfile.lambda
+          - package: reconciler
+            dockerfile: reconciler/Dockerfile.lambda
+          - package: terraform_runner
+            dockerfile: terraform_runner/Dockerfile
+          - package: webserver-openapi
+            dockerfile: webserver-openapi/Dockerfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.package }} package using ${{ matrix.dockerfile }}
+        run: docker build -f ${{ matrix.dockerfile }} .


### PR DESCRIPTION
This pull request adds a new job to the GitHub Actions workflow to build Docker containers for different components. 

New Docker build job:

* [`.github/workflows/tests.yaml`]: Added a `docker-builds` job that runs on `ubuntu-latest` and uses a matrix strategy to build containers for `cli`, `gitops`, `reconciler`, `runner`, and `webserver-openapi`. This includes steps to checkout the code and build the specified container.
* `operator` is intentionally left out as it is currently failing (fixed in https://github.com/infraweave-io/infraweave/pull/5)