### PR TITLE
feature: add region parameter in deployment claim

### DIFF
--- a/cli/src/defs.rs
+++ b/cli/src/defs.rs
@@ -1,0 +1,6 @@
+pub struct ClaimJobStruct {
+    pub job_id: String,
+    pub deployment_id: String,
+    pub environment: String,
+    pub region: String,
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,7 +1,9 @@
+mod defs;
 mod plan;
 mod run;
 mod utils;
 
+pub use defs::ClaimJobStruct;
 pub use plan::follow_plan;
 pub use run::run_claim_file;
-pub use utils::{get_environment, handler};
+pub use utils::{current_region_handler, get_environment};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::vec;
 
 use clap::{App, Arg, SubCommand};
-use cli::{get_environment, handler, run_claim_file};
+use cli::{current_region_handler, get_environment, run_claim_file};
 use env_common::{
     errors::ModuleError,
     interface::initialize_project_id_and_region,
@@ -390,7 +390,7 @@ async fn main() {
                 let track = run_matches.value_of("track").expect("Track is required");
                 let version = run_matches.value_of("version");
                 let no_fail_on_exist = run_matches.is_present("no-fail-on-exist");
-                match publish_module(&handler().await, path, track, version)
+                match publish_module(&current_region_handler().await, path, track, version)
                     .await
                 {
                     Ok(_) => {
@@ -428,7 +428,7 @@ async fn main() {
             }
             Some(("list", run_matches)) => {
                 let environment = run_matches.value_of("track").unwrap();
-                let modules = handler().await.get_all_latest_module(environment)
+                let modules = current_region_handler().await.get_all_latest_module(environment)
                     .await
                     .unwrap();
                 println!(
@@ -450,7 +450,7 @@ async fn main() {
                 let module = run_matches.value_of("module").unwrap();
                 let version = run_matches.value_of("version").unwrap();
                 let track = "dev".to_string();
-                handler().await.get_module_version(module, &track, version)
+                current_region_handler().await.get_module_version(module, &track, version)
                     .await
                     .unwrap();
             }
@@ -461,7 +461,7 @@ async fn main() {
         Some(("stack", stack_matches)) => match stack_matches.subcommand() {
             Some(("preview", run_matches)) => {
                 let path = run_matches.value_of("path").expect("Path is required");
-                match get_stack_preview(&handler().await, &path.to_string())
+                match get_stack_preview(&current_region_handler().await, &path.to_string())
                     .await
                 {
                     Ok(stack_module) => {
@@ -478,7 +478,7 @@ async fn main() {
                 let track = run_matches.value_of("track").expect("Track is required");
                 let version = run_matches.value_of("version");
                 let no_fail_on_exist = run_matches.is_present("no-fail-on-exist");
-                match publish_stack(&handler().await, path, track, version)
+                match publish_stack(&current_region_handler().await, path, track, version)
                     .await
                 {
                     Ok(_) => {
@@ -504,7 +504,7 @@ async fn main() {
             Some(("publish", run_matches)) => {
                 let file = run_matches.value_of("file").unwrap();
                 let environment = run_matches.value_of("environment").unwrap();
-                match publish_policy(&handler().await, file, environment)
+                match publish_policy(&current_region_handler().await, file, environment)
                     .await
                 {
                     Ok(_) => {
@@ -517,7 +517,7 @@ async fn main() {
             }
             Some(("list", run_matches)) => {
                 let environment = run_matches.value_of("environment").unwrap();
-                handler().await.get_all_policies(environment)
+                current_region_handler().await.get_all_policies(environment)
                     .await
                     .unwrap();
             }
@@ -525,7 +525,7 @@ async fn main() {
                 let policy = run_matches.value_of("policy").unwrap();
                 let environment = run_matches.value_of("environment").unwrap();
                 let version = run_matches.value_of("version").unwrap();
-                handler().await.get_policy(
+                current_region_handler().await.get_policy(
                         policy,
                         environment,
                         version,
@@ -565,7 +565,7 @@ async fn main() {
                     }
                 }),
             };
-            match handler().await.set_project(&project).await {
+            match current_region_handler().await.set_project(&project).await {
                 Ok(_) => {
                     info!("Project inserted");
                 }
@@ -575,7 +575,7 @@ async fn main() {
             }
         }
         Some(("get-current-project", _run_matches)) => {
-            match handler().await.get_current_project().await {
+            match current_region_handler().await.get_current_project().await {
                 Ok(project) => {
                     println!("Project: {}", serde_json::to_string_pretty(&project).unwrap());
                 }
@@ -585,7 +585,7 @@ async fn main() {
             }
         }
         Some(("get-all-projects", _run_matches)) => {
-            match handler().await.get_all_projects().await {
+            match current_region_handler().await.get_all_projects().await {
                 Ok(projects) => {
                     for project in projects {
                         println!("Project: {}", serde_json::to_string_pretty(&project).unwrap());
@@ -610,7 +610,7 @@ async fn main() {
             let environment_arg = run_matches.value_of("environment").unwrap();
             let environment = get_environment(environment_arg);
             let remediate = run_matches.is_present("remediate");
-            match driftcheck_infra(&handler().await, deployment_id, &environment, remediate, ExtraData::None).await {
+            match driftcheck_infra(&current_region_handler().await, deployment_id, &environment, remediate, ExtraData::None).await {
                 Ok(_) => {
                     info!("Successfully requested drift check");
                     Ok(())
@@ -632,7 +632,7 @@ async fn main() {
             let deployment_id = run_matches.value_of("deployment_id").unwrap();
             let environment_arg = run_matches.value_of("environment").unwrap();
             let environment = get_environment(environment_arg);
-            match destroy_infra(&handler().await, deployment_id, &environment, ExtraData::None).await {
+            match destroy_infra(&current_region_handler().await, deployment_id, &environment, ExtraData::None).await {
                 Ok(_) => {
                     info!("Successfully requested destroying deployment");
                     Ok(())
@@ -647,7 +647,7 @@ async fn main() {
                 let deployment_id = run_matches.value_of("deployment_id").unwrap();
                 let environment_arg = run_matches.value_of("environment").unwrap();
                 let environment = environment_arg.to_string();
-                let (deployment, _) = handler().await.get_deployment_and_dependents(deployment_id, &environment, false)
+                let (deployment, _) = current_region_handler().await.get_deployment_and_dependents(deployment_id, &environment, false)
                     .await
                     .unwrap();
                 if deployment.is_some() {
@@ -656,7 +656,7 @@ async fn main() {
                 }
             }
             Some(("list", _run_matches)) => {
-                let deployments = handler().await.get_all_deployments("").await.unwrap();
+                let deployments = current_region_handler().await.get_all_deployments("").await.unwrap();
                 println!(
                     "{:<50} {:<20} {:<20} {:<35} {:<10}",
                     "Deployment ID", "Module", "Version", "Environment", "Status"

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,4 +1,5 @@
 use env_common::interface::GenericCloudHandler;
+
 pub fn get_environment(environment_arg: &str) -> String {
     if !environment_arg.contains('/') {
         format!("{}/infraweave_cli", environment_arg)
@@ -7,6 +8,6 @@ pub fn get_environment(environment_arg: &str) -> String {
     }
 }
 
-pub async fn handler() -> GenericCloudHandler {
+pub async fn current_region_handler() -> GenericCloudHandler {
     GenericCloudHandler::default().await
 }

--- a/crd-templator/templates/module_crd_template.yaml
+++ b/crd-templator/templates/module_crd_template.yaml
@@ -25,6 +25,8 @@ spec:
                   type: "string"
                 stackVersion:
                   type: "string"
+                region:
+                  type: "string"
                 variables:
                   type: "object"
                   x-kubernetes-preserve-unknown-fields: true
@@ -47,6 +49,7 @@ spec:
                           message:
                             type: "string"
               required:
+                - "region"
                 - "variables"
             status:
               type: object

--- a/defs/src/deployment.rs
+++ b/defs/src/deployment.rs
@@ -23,6 +23,8 @@ pub fn get_deployment_identifier(
 pub struct Metadata {
     pub name: String,
     pub namespace: Option<String>,
+    pub annotations: Option<serde_yaml::Mapping>,
+    pub labels: Option<serde_yaml::Mapping>,
     // pub group: String,
 }
 
@@ -39,11 +41,16 @@ pub struct DeploymentManifest {
 pub struct DeploymentSpec {
     // pub name: String,
     #[serde(rename = "moduleVersion")]
-    pub module_version: String,
+    pub module_version: Option<String>,
+    #[serde(rename = "stackVersion")]
+    pub stack_version: Option<String>,
+    pub region: String,
     // pub description: String,
-    // pub reference: String,
+    pub reference: Option<String>,
     pub variables: serde_yaml::Mapping,
     pub dependencies: Option<Vec<DependencySpec>>,
+    #[serde(rename = "driftDetection")]
+    pub drift_detection: Option<DriftDetection>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/defs/src/gitprovider.rs
+++ b/defs/src/gitprovider.rs
@@ -56,6 +56,7 @@ pub struct CheckRunAnnotation {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct JobDetails {
+    pub region: String,
     pub environment: String,
     pub deployment_id: String,
     pub job_id: String,

--- a/gitops/src/defs.rs
+++ b/gitops/src/defs.rs
@@ -19,6 +19,7 @@ pub struct GroupKey {
     pub kind: String,
     pub name: String,
     pub namespace: String,
+    pub region: String,
 }
 
 /// Represents a grouped file with its manifest key and both before/after versions if available.

--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -362,7 +362,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
 
     let (project_id, _region, project_id_found) =
         match get_project_id_for_repository_path(repo_full_name).await {
-            Ok((project_id, region)) => (project_id, region, true),
+            Ok((project_id, _region)) => (project_id, _region, true),
             Err(e) => {
                 println!("Error getting project id: {:?}", e);
                 (
@@ -428,6 +428,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                         output: None,
                     },
                     job_details: JobDetails {
+                        region: "OVERRIDE".to_string(),
                         environment: "OVERRIDE".to_string(),
                         deployment_id: "OVERRIDE".to_string(),
                         job_id: "OVERRIDE".to_string(),

--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -460,9 +460,14 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                     if let ExtraData::GitHub(ref mut github_check_run) = extra_data {
                         github_check_run.job_details.file_path = active.path.clone();
                         github_check_run.job_details.manifest_yaml = canonical.clone();
+                        let region = if let Some(region) = yaml["spec"]["region"].as_str() {
+                            region.to_string()
+                        } else {
+                            "unknown_region".to_string()
+                        };
                         if let Some(new_name) = yaml["metadata"]["name"].as_str() {
                             github_check_run.check_run.name =
-                                get_check_run_name(new_name, &active.path);
+                                get_check_run_name(new_name, &active.path, &region);
                         }
                         github_check_run.check_run.output = Some(CheckRunOutput {
                             title: format!("{} job initiated", command),
@@ -566,9 +571,14 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                     if let ExtraData::GitHub(ref mut github_check_run) = extra_data {
                         github_check_run.job_details.file_path = deleted.path.clone();
                         github_check_run.job_details.manifest_yaml = canonical.clone();
+                        let region = if let Some(region) = yaml["spec"]["region"].as_str() {
+                            region.to_string()
+                        } else {
+                            "unknown_region".to_string()
+                        };
                         if let Some(new_name) = yaml["metadata"]["name"].as_str() {
                             github_check_run.check_run.name =
-                                get_check_run_name(new_name, &deleted.path);
+                                get_check_run_name(new_name, &deleted.path, &region);
                         }
                         github_check_run.check_run.output = Some(CheckRunOutput {
                             title: format!("{} job initiated", command),
@@ -783,8 +793,8 @@ pub async fn get_check_run_rerequested_data(
     Ok(push_payload)
 }
 
-fn get_check_run_name(name: &str, path: &str) -> String {
-    format!("{} ({})", name, path)
+fn get_check_run_name(name: &str, path: &str, region: &str) -> String {
+    format!("{} ({}) - {}", name, region, path)
 }
 
 async fn inform_missing_project_configuration(

--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -490,7 +490,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                             match run_claim(
                                 &handler,
                                 &yaml,
-                                "git",
+                                &format!("git/{}", repo_full_name),
                                 command,
                                 flags,
                                 extra_data.clone(),
@@ -600,7 +600,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                             match run_claim(
                                 &handler,
                                 &yaml,
-                                "git",
+                                &format!("git/{}", repo_full_name),
                                 command,
                                 flags,
                                 extra_data.clone(),

--- a/gitops/src/gitops.rs
+++ b/gitops/src/gitops.rs
@@ -28,6 +28,12 @@ fn extract_manifest_changes(file: &FileChange) -> Vec<ManifestChange> {
                     file: file.clone(),
                 });
             }
+        } else {
+            log::warn!(
+                "Failed to parse manifest from file: {}\nManifest content: {}",
+                file.path,
+                file.content
+            );
         }
     }
     changes

--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -121,13 +121,14 @@ async fn process_runner_event(payload: Value) -> Result<Value, Error> {
         ExtraData::GitHub(mut github_event) => {
             println!("GitHub Event: {:?}", github_event);
 
-            let (project_id, region) =
+            let (project_id, _region) =
                 get_project_id_for_repository_path(&github_event.repository.full_name).await?;
+            let region = &github_event.job_details.region;
             println!(
                 "Found project id: {}, region: {} for path: {}",
                 project_id, region, &github_event.repository.full_name
             );
-            let handler = GenericCloudHandler::workload(&project_id, &region).await;
+            let handler = GenericCloudHandler::workload(&project_id, region).await;
 
             let status = github_event.job_details.status.as_str();
 

--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -31,8 +31,15 @@ async fn handle_sqs_run_response(sqs_event: SqsEvent) -> Result<Value, Error> {
         println!("Subject: {:?}", subject);
         println!("Message: {:?}", message);
 
-        let payload =
-            serde_json::from_str::<Value>(message).expect("Failed to parse message payload");
+        let payload = match serde_json::from_str::<Value>(message) {
+            Ok(payload) => payload,
+            Err(e) => {
+                println!("Failed to parse message payload: {:?}", e);
+                return Ok(
+                    serde_json::json!({ "status": format!("Failed to parse message payload: {:?}. Skipping this event.", e) }),
+                );
+            }
+        };
 
         println!("Processing {} event", subject);
         match subject {

--- a/integration-tests/claims/s3bucket-dev-claim.yaml
+++ b/integration-tests/claims/s3bucket-dev-claim.yaml
@@ -3,6 +3,7 @@ kind: S3Bucket
 metadata:
   name: my-s3bucket2
 spec:
+  region: us-west-2
   moduleVersion: 0.1.2-dev+test.10
   reference: https://github.com/some-repo/some-path/claim.yaml
   variables:

--- a/integration-tests/claims/s3bucket-stable-claim.yaml
+++ b/integration-tests/claims/s3bucket-stable-claim.yaml
@@ -3,6 +3,7 @@ kind: S3Bucket
 metadata:
   name: my-s3bucket2
 spec:
+  region: us-west-2
   moduleVersion: 0.1.2
   variables:
     bucketName: dev-my-unique-bucket-name-1234-playground

--- a/integration-tests/stacks/bucketcollection-dev/bucket1a.yaml
+++ b/integration-tests/stacks/bucketcollection-dev/bucket1a.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bucket1a
 spec:
   moduleVersion: 0.1.2-dev+test.10
+  region: N/A
   variables:
     bucketName: my-temp-bucket1a
     tags:

--- a/integration-tests/stacks/bucketcollection-dev/bucket2.yaml
+++ b/integration-tests/stacks/bucketcollection-dev/bucket2.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bucket2
 spec:
   moduleVersion: 0.1.3-dev+test.10
+  region: N/A
   variables:
     bucketName: "{{ S3Bucket::bucket1a::bucketName }}-after"
     tags:

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -94,6 +94,7 @@ metadata:
   namespace: {}
 spec:
   moduleVersion: 0.1.2-dev+test.10
+  region: us-west-2
   variables:
     bucketName: "test-bucket"
     tags:

--- a/terraform_runner/src/main.rs
+++ b/terraform_runner/src/main.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match extra_data {
         ExtraData::GitHub(ref mut github_data) => {
             github_data.job_details = JobDetails {
+                region: payload.region.clone(),
                 environment: payload.environment.clone(),
                 deployment_id: payload.deployment_id.clone(),
                 job_id: job_id.clone(),
@@ -85,6 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         ExtraData::GitLab(ref mut gitlab_data) => {
             gitlab_data.job_details = JobDetails {
+                region: payload.region.clone(),
                 environment: payload.environment.clone(),
                 deployment_id: payload.deployment_id.clone(),
                 job_id: job_id.clone(),


### PR DESCRIPTION
This pull request introduces `region` as a parameter in the deployment claim to support deploying to different regions in the same file.

### Deployment Manifest Enhancements:
* Added `region` and other optional fields to `DeploymentSpec` in `defs/src/deployment.rs` to support region-specific deployments.

### Handler Refactoring:
* Replaced `handler` with `current_region_handler` across multiple functions in `cli/src/main.rs` to ensure the correct region context is used for operations.

### Introduction of `ClaimJobStruct`:
* Added `ClaimJobStruct` to `cli/src/defs.rs` to encapsulate job-related information including job ID, deployment ID, environment, and region.

### Deployment and Plan Handling:
* Updated `follow_plan` function in `cli/src/plan.rs` to use `ClaimJobStruct` and handle regions appropriately.
* Modified `run_claim_file` function in `cli/src/run.rs` to use `ClaimJobStruct` and include region information.

### CRD Template Update:
* Included `region` field in the CRD template for module definitions in `crd-templator/templates/module_crd_template.yaml`.

### GroupKey Update:
* Added region to `GroupKey` to treat two manifests with different regions as different files, since they are sent to different regions
* Will now correctly create two status jobs if region is modified in an existing manifest (apply in new region + delete in old region)