### PR TITLE
feature: publish modules and stacks to all regions

### DIFF
--- a/defs/src/provider.rs
+++ b/defs/src/provider.rs
@@ -39,6 +39,7 @@ pub trait CloudProvider: Send + Sync {
     fn get_project_id(&self) -> &str;
     async fn get_user_id(&self) -> Result<String, anyhow::Error>;
     fn get_region(&self) -> &str;
+    fn get_function_endpoint(&self) -> Option<String>;
     fn get_cloud_provider(&self) -> &str;
     fn get_backend_provider(&self) -> &str;
     async fn set_backend(
@@ -49,6 +50,7 @@ pub trait CloudProvider: Send + Sync {
     );
     async fn get_current_job_id(&self) -> Result<String, anyhow::Error>;
     async fn get_project_map(&self) -> Result<Value, anyhow::Error>;
+    async fn get_all_regions(&self) -> Result<Vec<String>, anyhow::Error>;
     // Function
     async fn run_function(&self, payload: &Value)
         -> Result<GenericFunctionResponse, anyhow::Error>;

--- a/env_aws/src/api.rs
+++ b/env_aws/src/api.rs
@@ -517,3 +517,13 @@ pub fn get_project_map_query() -> Value {
         "Limit": 1,
     })
 }
+
+pub fn get_all_regions_query() -> Value {
+    json!({
+        "KeyConditionExpression": "PK = :all_regions",
+        "ExpressionAttributeValues": {
+            ":all_regions": "all_regions",
+        },
+        "Limit": 1,
+    })
+}

--- a/env_aws/src/lib.rs
+++ b/env_aws/src/lib.rs
@@ -14,6 +14,7 @@ pub use api::{
     get_all_module_versions_query,
     get_all_policies_query,
     get_all_projects_query,
+    get_all_regions_query,
     get_all_stack_versions_query,
     get_change_records_query,
     get_current_project_query,

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -527,6 +527,12 @@ pub fn get_policy_query(policy: &str, environment: &str, version: &str) -> Value
 
 pub fn get_project_map_query() -> Value {
     json!({
-        "query": "SELECT * FROM c WHERE c.PK = project_map",
+        "query": "SELECT * FROM c WHERE c.PK = 'project_map'",
+    })
+}
+
+pub fn get_all_regions_query() -> Value {
+    json!({
+        "query": "SELECT * FROM c WHERE c.PK = 'all_regions'",
     })
 }

--- a/env_azure/src/lib.rs
+++ b/env_azure/src/lib.rs
@@ -14,6 +14,7 @@ pub use api::{
     get_all_module_versions_query,
     get_all_policies_query,
     get_all_projects_query,
+    get_all_regions_query,
     get_all_stack_versions_query,
     get_change_records_query,
     get_current_project_query,

--- a/env_azure/src/provider.rs
+++ b/env_azure/src/provider.rs
@@ -29,6 +29,9 @@ impl CloudProvider for AzureCloudProvider {
     fn get_region(&self) -> &str {
         &self.region
     }
+    fn get_function_endpoint(&self) -> Option<String> {
+        self.function_endpoint.clone()
+    }
     fn get_cloud_provider(&self) -> &str {
         "azure"
     }
@@ -50,6 +53,23 @@ impl CloudProvider for AzureCloudProvider {
         self.read_db_generic("config", &crate::get_project_map_query())
             .await
             .map(|mut items| items.pop().expect("No project map found"))
+    }
+
+    async fn get_all_regions(&self) -> Result<Vec<String>, anyhow::Error> {
+        self.read_db_generic("config", &crate::get_all_regions_query())
+            .await
+            .map(|mut items| items.pop().expect("No all_regions item found"))
+            .map(|item| {
+                item.get("data")
+                    .expect("No data field in response")
+                    .get("regions")
+                    .expect("No regions field in response")
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|region| region.as_str().unwrap().to_string())
+                    .collect()
+            })
     }
     async fn run_function(&self, items: &Value) -> Result<GenericFunctionResponse, anyhow::Error> {
         crate::run_function(

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -85,6 +85,17 @@ impl GenericCloudHandler {
         };
         Self { provider }
     }
+
+    pub async fn copy_with_region(&self, new_region: &str) -> Self {
+        let project_id = self.get_project_id().to_string();
+        let function_endpoint = self.get_function_endpoint();
+        Self::factory(
+            Some(project_id),
+            Some(new_region.to_string()),
+            function_endpoint,
+        )
+        .await
+    }
 }
 
 #[async_trait]
@@ -138,6 +149,9 @@ impl CloudProvider for GenericCloudHandler {
     fn get_region(&self) -> &str {
         self.provider.get_region()
     }
+    fn get_function_endpoint(&self) -> Option<String> {
+        self.provider.get_function_endpoint()
+    }
     fn get_cloud_provider(&self) -> &str {
         self.provider.get_cloud_provider()
     }
@@ -159,6 +173,9 @@ impl CloudProvider for GenericCloudHandler {
     }
     async fn get_project_map(&self) -> Result<Value, anyhow::Error> {
         self.provider.get_project_map().await
+    }
+    async fn get_all_regions(&self) -> Result<Vec<String>, anyhow::Error> {
+        self.provider.get_all_regions().await
     }
     async fn run_function(
         &self,

--- a/integration-tests/azure-function-code/bootstrap.py
+++ b/integration-tests/azure-function-code/bootstrap.py
@@ -1,3 +1,4 @@
+import json
 import os
 from azure.cosmos import CosmosClient, PartitionKey
 from azure.storage.blob import BlobServiceClient
@@ -26,6 +27,7 @@ def bootstrap_tables():
     policies_container_name = "policies"
     change_records_container_name = "change-records"
     deployments_container_name = "deployments"
+    config_container_name = "config"
 
     # Events container
     database.create_container_if_not_exists(
@@ -62,6 +64,23 @@ def bootstrap_tables():
         offer_throughput=400
     )
 
+    # Configs container
+    database.create_container_if_not_exists(
+        id=config_container_name,
+        partition_key=PartitionKey(path="/PK"),
+        offer_throughput=400
+    )
+
+    container = database.get_container_client(config_container_name)
+
+    config_item = {
+        "id": "all_regions",
+        "PK": "all_regions",
+        "data": {
+            "regions": ["eastus"]
+        }
+    }
+    container.upsert_item(config_item)
 
 def bootstrap_buckets():
     conn_str = os.environ["AZURITE_CONNECTION_STRING"]

--- a/integration-tests/lambda-code/bootstrap.py
+++ b/integration-tests/lambda-code/bootstrap.py
@@ -18,6 +18,7 @@ def bootstrap_tables():
     policies_table_name = "policies"
     deployments_table_name = "deployments"
     change_records_table_name = "change-records"
+    config_table_name = "config"
 
     # Events table
     client.create_table(
@@ -163,6 +164,41 @@ def bootstrap_tables():
         Tags=[
             {'Key': 'Name', 'Value': 'DeploymentsTable'}
         ]
+    )
+
+    # Config table
+    client.create_table(
+        TableName=config_table_name,
+        AttributeDefinitions=[
+            {'AttributeName': 'PK', 'AttributeType': 'S'},
+        ],
+        KeySchema=[
+            {'AttributeName': 'PK', 'KeyType': 'HASH'},
+        ],
+        BillingMode='PAY_PER_REQUEST',
+        Tags=[
+            {'Key': 'Name', 'Value': 'ConfigTable'}
+        ]
+    )
+
+    client.put_item(
+        TableName=config_table_name,
+        Item={
+            "PK": {
+                "S": "all_regions"
+            },
+            "data": {
+                "M": {
+                "regions": {
+                    "L": [
+                    {
+                        "S": "us-west-2"
+                    }
+                    ]
+                }
+                }
+            }
+        }
     )
 
     # Terraform Locks table is not relevant for as it is used by Terraform

--- a/integration-tests/lambda-code/test-api.py
+++ b/integration-tests/lambda-code/test-api.py
@@ -31,7 +31,8 @@ tables = {
     'modules': os.environ.get('DYNAMODB_MODULES_TABLE_NAME'),
     'policies': os.environ.get('DYNAMODB_POLICIES_TABLE_NAME'),
     'deployments': os.environ.get('DYNAMODB_DEPLOYMENTS_TABLE_NAME'),
-    'change_records': os.environ.get('DYNAMODB_CHANGE_RECORDS_TABLE_NAME')
+    'change_records': os.environ.get('DYNAMODB_CHANGE_RECORDS_TABLE_NAME'),
+    'config': os.environ.get('DYNAMODB_CONFIG_TABLE_NAME'),
 }
 
 ecs_cluster_name = os.environ.get('ECS_CLUSTER_NAME')

--- a/integration-tests/tests/utils.rs
+++ b/integration-tests/tests/utils.rs
@@ -107,6 +107,7 @@ pub async fn start_lambda(
         .with_env_var("DYNAMODB_POLICIES_TABLE_NAME", "policies")
         .with_env_var("DYNAMODB_DEPLOYMENTS_TABLE_NAME", "deployments")
         .with_env_var("DYNAMODB_CHANGE_RECORDS_TABLE_NAME", "change-records")
+        .with_env_var("DYNAMODB_CONFIG_TABLE_NAME", "config")
         .with_env_var("MINIO_ENDPOINT", minio_endpoint)
         .with_env_var("MINIO_ACCESS_KEY", "minio")
         .with_env_var("MINIO_SECRET_KEY", "minio123")


### PR DESCRIPTION
This pull request introduces a change that whenever a module or stack is published, it will be published to all available regions in the same command.

### Enhancements to CloudProvider Trait:
* Added `get_function_endpoint` and `get_all_regions` methods to the `CloudProvider` trait in `defs/src/provider.rs`. [[1]](diffhunk://#diff-89b7226cf04a3e2503474c49a8ea3a0dedd488c89f29a81bcaf25c0e14faf423R42) [[2]](diffhunk://#diff-89b7226cf04a3e2503474c49a8ea3a0dedd488c89f29a81bcaf25c0e14faf423R53)

### AWS Cloud Provider:
* Implemented `get_function_endpoint` and `get_all_regions` methods for `AwsCloudProvider` in `env_aws/src/provider.rs`. [[1]](diffhunk://#diff-b3a53a302ae9534b38dbf2b6144fce8af1ff0c6a709391ac41749f7876507dd0R32-R34) [[2]](diffhunk://#diff-b3a53a302ae9534b38dbf2b6144fce8af1ff0c6a709391ac41749f7876507dd0R57-R72)
* Added `get_all_regions_query` function in `env_aws/src/api.rs` to support fetching all regions.
* Updated `env_aws/src/lib.rs` to export `get_all_regions_query`.

### Azure Cloud Provider:
* Implemented `get_function_endpoint` and `get_all_regions` methods for `AzureCloudProvider` in `env_azure/src/provider.rs`. [[1]](diffhunk://#diff-e353cace0e989e1dc552e6d01e1b66dc2c20e66822d8fc401e6c03f4b1a0183bR32-R34) [[2]](diffhunk://#diff-e353cace0e989e1dc552e6d01e1b66dc2c20e66822d8fc401e6c03f4b1a0183bR57-R73)
* Added `get_all_regions_query` function in `env_azure/src/api.rs` to support fetching all regions.
* Updated `env_azure/src/lib.rs` to export `get_all_regions_query`.

### Common Cloud Handler:
* Added `copy_with_region` method and implemented `get_function_endpoint` and `get_all_regions` for `GenericCloudHandler` in `env_common/src/interface/cloud_handlers.rs`. [[1]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7R88-R98) [[2]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7R152-R154) [[3]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7R177-R179)
* Updated `publish_module` function to publish in all regions in `env_common/src/logic/api_module.rs`.

### Integration Tests:
* Added configuration for `config` container/table in `integration-tests/azure-function-code/bootstrap.py` and `integration-tests/lambda-code/bootstrap.py`. [[1]](diffhunk://#diff-504d88486a258de85297e62e7d0a86244319f299bc3b9981be8d36310920cfceR1) [[2]](diffhunk://#diff-0d07169fd228e3b2c2eadd90f5484abc558e73b49742fd6a8659a4737147f3d5R21) [[3]](diffhunk://#diff-0d07169fd228e3b2c2eadd90f5484abc558e73b49742fd6a8659a4737147f3d5R169-R203)
* Updated environment variables to include `DYNAMODB_CONFIG_TABLE_NAME` in `integration-tests/lambda-code/test-api.py` and `integration-tests/tests/utils.rs`. [[1]](diffhunk://#diff-08647333a3f03ef481af63bc5dc0c1204803535db05a0f6ad1a6382f8dba9e56L34-R35) [[2]](diffhunk://#diff-221bca671a41e910fc8f4b9387c0ed32ec1b5241f4154f36bc7f9a8a1453da1cR110)

### Considerations
AWS has features such as global tables which would make this unnecessary, however other cloud providers might not. Azure does not provide such feature for its serverless offering. To keep it uniform it is now instead publishing the module to each region. There are known downsides of this decision such as if a new region is added, it will have to be synced, but this is acceptable.