### PR TITLE
fix: validate module claims when publishing stacks

### DIFF
--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -18,7 +18,8 @@ mod stack;
 pub use api::GenericFunctionResponse;
 pub use deployment::{
     get_deployment_identifier, Dependency, Dependent, DeploymentManifest, DeploymentResp,
-    DriftDetection, ProjectData, Webhook, DEFAULT_DRIFT_DETECTION_INTERVAL,
+    DeploymentSpec, DriftDetection, Metadata as DeploymentMetadata, ProjectData, Webhook,
+    DEFAULT_DRIFT_DETECTION_INTERVAL,
 };
 pub use environment::EnvironmentResp;
 pub use errors::CloudHandlerError;

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -31,6 +31,15 @@ pub enum ModuleError {
     #[error("Module example has invalid variable: {0}")]
     InvalidExampleVariable(String),
 
+    #[error("Stack validation error: {0}")]
+    ValidationError(String),
+
+    #[error("Module version is not set: {0}")]
+    ModuleVersionNotSet(String),
+
+    #[error("Namespace should not be set for deployment claim inside Stack: {0}")]
+    StackModuleNamespaceIsSet(String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -39,7 +39,7 @@ pub async fn publish_stack(
         info!("Using version: {}", version_arg.as_ref().unwrap());
         stack_manifest.spec.version = Some(version_arg.unwrap().to_string());
     }
-    let claims = get_claims_in_stack(manifest_path);
+    let claims = get_claims_in_stack(manifest_path)?;
     let claim_modules = get_modules_in_stack(handler, &claims).await;
 
     let (modules_str, variables_str, outputs_str) = generate_full_terraform_module(&claim_modules);
@@ -235,7 +235,7 @@ pub async fn get_stack_preview(
 ) -> anyhow::Result<String, anyhow::Error> {
     println!("Preview stack from {}", manifest_path);
 
-    let claims = get_claims_in_stack(manifest_path);
+    let claims = get_claims_in_stack(manifest_path)?;
     let claim_modules = get_modules_in_stack(handler, &claims).await;
 
     let (modules_str, variables_str, outputs_str) = generate_full_terraform_module(&claim_modules);
@@ -254,11 +254,10 @@ fn get_stack_manifest(manifest_path: &str) -> StackManifest {
     serde_yaml::from_str::<StackManifest>(&manifest).expect("Failed to parse stack manifest")
 }
 
-fn get_claims_in_stack(manifest_path: &str) -> Vec<DeploymentManifest> {
+fn get_claims_in_stack(manifest_path: &str) -> Result<Vec<DeploymentManifest>, anyhow::Error> {
     println!("Reading stack claim manifests in {}", manifest_path);
-    let claims =
-        read_stack_directory(Path::new(manifest_path)).expect("Failed to read stack directory");
-    claims
+    let claims = read_stack_directory(Path::new(manifest_path))?;
+    Ok(claims)
 }
 
 async fn get_modules_in_stack(

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -42,6 +42,8 @@ pub async fn publish_stack(
     let claims = get_claims_in_stack(manifest_path)?;
     let claim_modules = get_modules_in_stack(handler, &claims).await;
 
+    validate_claim_modules(&claim_modules)?;
+
     let (modules_str, variables_str, outputs_str) = generate_full_terraform_module(&claim_modules);
 
     let tf_variables = get_variables_from_tf_files(&variables_str).unwrap();
@@ -613,7 +615,7 @@ fn collect_module_outputs(
 
 // Create list of all variables from all modules
 fn collect_module_variables(
-    claim_modules: &Vec<(DeploymentManifest, ModuleResp)>,
+    claim_modules: &[(DeploymentManifest, ModuleResp)],
 ) -> HashMap<String, TfVariable> {
     let mut variables = HashMap::new();
 
@@ -640,6 +642,136 @@ fn collect_module_variables(
     }
 
     variables
+}
+
+pub fn validate_claim_modules(
+    claim_modules: &[(DeploymentManifest, ModuleResp)],
+) -> Result<bool, ModuleError> {
+    for (claim, module) in claim_modules {
+        let deployment_variables: serde_yaml::Mapping = claim.spec.variables.clone();
+        let variables: serde_json::Value = if deployment_variables.is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::to_value(&deployment_variables).unwrap()
+        };
+        let variables = env_utils::convert_first_level_keys_to_snake_case(&variables);
+
+        env_utils::verify_variable_existence_and_type(&module, &variables)?;
+
+        // Verify moduleVersion is set
+        // TODO: (may support Stacks in future but need more testing)
+        if claim.spec.module_version.is_none() {
+            return Err(ModuleError::ModuleVersionNotSet(
+                claim.metadata.name.clone(),
+            ));
+        }
+
+        // Verify namespace is not set as this is ignored
+        if claim.metadata.namespace.is_some() {
+            return Err(ModuleError::StackModuleNamespaceIsSet(
+                claim.metadata.name.clone(),
+            ));
+        }
+    }
+
+    if !validate_dependencies(claim_modules) {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+fn validate_dependencies(claim_modules: &[(DeploymentManifest, ModuleResp)]) -> bool {
+    let module_map = build_claim_module_map(claim_modules);
+
+    for (claim, _) in claim_modules {
+        let vars_json = convert_vars_to_snake_json(&claim.spec.variables);
+        for (ref_claim, ref_field) in extract_top_level_deps(&vars_json) {
+            if !claim_reference_exists(&module_map, &ref_claim, &ref_field) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn build_claim_module_map(
+    claim_modules: &[(DeploymentManifest, ModuleResp)],
+) -> HashMap<String, &ModuleResp> {
+    claim_modules
+        .iter()
+        .map(|(claim, module)| (claim.metadata.name.clone(), module))
+        .collect()
+}
+
+/// Turn a YAML Mapping into snake_case JSON for easy string scanning
+fn convert_vars_to_snake_json(vars: &serde_yaml::Mapping) -> serde_json::Value {
+    let json = if vars.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::to_value(vars).unwrap()
+    };
+    env_utils::convert_first_level_keys_to_snake_case(&json)
+}
+
+/// Find all “{{ Kind::Claim::Field }}” references in each top‑level string
+/// plus any nested string inside a top‑level map (one level deep only).
+fn extract_top_level_deps(vars: &serde_json::Value) -> Vec<(String, String)> {
+    let re = Regex::new(r"\{\{\s*\w+::(\w+)::(\w+)\s*\}\}").unwrap();
+    let mut deps = Vec::new();
+
+    if let Some(obj) = vars.as_object() {
+        for value in obj.values() {
+            match value {
+                serde_json::Value::String(s) => {
+                    for cap in re.captures_iter(s) {
+                        deps.push((cap[1].to_string(), to_snake_case(&cap[2])));
+                    }
+                }
+                serde_json::Value::Array(arr) => {
+                    for elem in arr {
+                        if let serde_json::Value::String(s) = elem {
+                            extract_from_str(s, &mut deps, &re);
+                        }
+                    }
+                }
+                serde_json::Value::Object(map) => {
+                    for nested in map.values() {
+                        if let serde_json::Value::String(s) = nested {
+                            for cap in re.captures_iter(s) {
+                                deps.push((cap[1].to_string(), to_snake_case(&cap[2])));
+                            }
+                        }
+                    }
+                }
+                _ => {} // Ignore non-referring types (booleans, numbers, null)
+            }
+        }
+    }
+
+    deps
+}
+
+fn extract_from_str(s: &str, deps: &mut Vec<(String, String)>, re: &Regex) {
+    for cap in re.captures_iter(s) {
+        deps.push((cap[1].to_string(), to_snake_case(&cap[2])));
+    }
+}
+
+/// Check that the named claim exists and exports the named output or variable
+fn claim_reference_exists(
+    module_map: &HashMap<String, &ModuleResp>,
+    claim_name: &str,
+    field_name: &str,
+) -> bool {
+    module_map
+        .get(claim_name)
+        .map(|m| {
+            m.tf_outputs.iter().any(|o| o.name == field_name)
+                || m.tf_variables.iter().any(|v| v.name == field_name)
+        })
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -977,6 +1109,582 @@ output "bucket2__bucket_arn" {
 }"#;
 
         assert_eq!(generated_terraform_module, expected_terraform_module);
+    }
+
+    #[test]
+    fn test_validate_claim_modules_valid() {
+        let yaml_manifest_bucket2 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+                tags:
+                    Name234: my-s3bucket-bucket2
+                    Environment: "dev"
+        "#;
+        let deployment_manifest_bucket2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket2).unwrap();
+
+        let claim_modules = [(
+            deployment_manifest_bucket2,
+            ModuleResp {
+                s3_key: "s3bucket/s3bucket-0.0.21.zip".to_string(),
+                track: "dev".to_string(),
+                track_version: "dev#000.000.021".to_string(),
+                version: "0.0.21".to_string(),
+                timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+                module_name: "S3Bucket".to_string(),
+                module_type: "module".to_string(),
+                module: "s3bucket".to_string(),
+                description: "Some description...".to_string(),
+                reference: "".to_string(),
+                manifest: ModuleManifest {
+                    metadata: Metadata {
+                        name: "metadata".to_string(),
+                    },
+                    api_version: "infraweave.io/v1".to_string(),
+                    kind: "Module".to_string(),
+                    spec: ModuleSpec {
+                        module_name: "S3Bucket".to_string(),
+                        version: Some("0.0.21".to_string()),
+                        description: "Some description...".to_string(),
+                        reference: "".to_string(),
+                        examples: None,
+                        cpu: None,
+                        memory: None,
+                    },
+                },
+                tf_outputs: vec![],
+                tf_variables: vec![
+                    TfVariable {
+                        name: "bucket_name".to_string(),
+                        default: None,
+                        description: Some("Name of the S3 bucket".to_string()),
+                        _type: Value::String("string".to_string()),
+                        nullable: Some(false),
+                        sensitive: Some(false),
+                    },
+                    TfVariable {
+                        _type: Value::String("map(string)".to_string()),
+                        name: "tags".to_string(),
+                        description: Some("Tags to apply to the S3 bucket".to_string()),
+                        default: serde_json::from_value(
+                            serde_json::json!({"Test": "hej", "AnotherTag": "something"}),
+                        )
+                        .unwrap(),
+                        nullable: Some(true),
+                        sensitive: Some(false),
+                    },
+                ],
+                stack_data: None,
+                version_diff: None,
+                cpu: get_default_cpu(),
+                memory: get_default_memory(),
+            },
+        )];
+
+        let valid = validate_claim_modules(&claim_modules).unwrap();
+        assert_eq!(valid, true);
+    }
+
+    #[test]
+    fn test_validate_claim_modules_namespace_should_not_be_set() {
+        let yaml_manifest_bucket2 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+            namespace: this-should-not-be-set-in-claim-for-stack
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+                tags:
+                    Name234: my-s3bucket-bucket2
+                    Environment: "dev"
+        "#;
+        let deployment_manifest_bucket2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket2).unwrap();
+
+        let claim_modules = [(
+            deployment_manifest_bucket2,
+            ModuleResp {
+                s3_key: "s3bucket/s3bucket-0.0.21.zip".to_string(),
+                track: "dev".to_string(),
+                track_version: "dev#000.000.021".to_string(),
+                version: "0.0.21".to_string(),
+                timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+                module_name: "S3Bucket".to_string(),
+                module_type: "module".to_string(),
+                module: "s3bucket".to_string(),
+                description: "Some description...".to_string(),
+                reference: "".to_string(),
+                manifest: ModuleManifest {
+                    metadata: Metadata {
+                        name: "metadata".to_string(),
+                    },
+                    api_version: "infraweave.io/v1".to_string(),
+                    kind: "Module".to_string(),
+                    spec: ModuleSpec {
+                        module_name: "S3Bucket".to_string(),
+                        version: Some("0.0.21".to_string()),
+                        description: "Some description...".to_string(),
+                        reference: "".to_string(),
+                        examples: None,
+                        cpu: None,
+                        memory: None,
+                    },
+                },
+                tf_outputs: vec![],
+                tf_variables: vec![
+                    TfVariable {
+                        name: "bucket_name".to_string(),
+                        default: None,
+                        description: Some("Name of the S3 bucket".to_string()),
+                        _type: Value::String("string".to_string()),
+                        nullable: Some(false),
+                        sensitive: Some(false),
+                    },
+                    TfVariable {
+                        _type: Value::String("map(string)".to_string()),
+                        name: "tags".to_string(),
+                        description: Some("Tags to apply to the S3 bucket".to_string()),
+                        default: serde_json::from_value(
+                            serde_json::json!({"Test": "hej", "AnotherTag": "something"}),
+                        )
+                        .unwrap(),
+                        nullable: Some(true),
+                        sensitive: Some(false),
+                    },
+                ],
+                stack_data: None,
+                version_diff: None,
+                cpu: get_default_cpu(),
+                memory: get_default_memory(),
+            },
+        )];
+
+        let result = validate_claim_modules(&claim_modules);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_validate_claim_modules_multiple_with_dependency_missing_output() {
+        let yaml_manifest_bucket1 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket1a
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+                tags:
+                    Name234: my-s3bucket-bucket1
+        "#;
+        let deployment_manifest_bucket1: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket1).unwrap();
+
+        let yaml_manifest_bucket2 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+                tags:
+                    Name234: my-s3bucket-bucket2
+                    dependentOn: "prefix-{{ S3Bucket::bucket1a::bucketArn }}-suffix"
+        "#;
+        let deployment_manifest_bucket2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket2).unwrap();
+
+        let module_bucket_0_0_21 = ModuleResp {
+            s3_key: "s3bucket/s3bucket-0.0.21.zip".to_string(),
+            track: "dev".to_string(),
+            track_version: "dev#000.000.021".to_string(),
+            version: "0.0.21".to_string(),
+            timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+            module_name: "S3Bucket".to_string(),
+            module_type: "module".to_string(),
+            module: "s3bucket".to_string(),
+            description: "Some description...".to_string(),
+            reference: "".to_string(),
+            manifest: ModuleManifest {
+                metadata: Metadata {
+                    name: "metadata".to_string(),
+                },
+                api_version: "infraweave.io/v1".to_string(),
+                kind: "Module".to_string(),
+                spec: ModuleSpec {
+                    module_name: "S3Bucket".to_string(),
+                    version: Some("0.0.21".to_string()),
+                    description: "Some description...".to_string(),
+                    reference: "".to_string(),
+                    examples: None,
+                    cpu: None,
+                    memory: None,
+                },
+            },
+            tf_outputs: vec![],
+            tf_variables: vec![
+                TfVariable {
+                    name: "bucket_name".to_string(),
+                    default: None,
+                    description: Some("Name of the S3 bucket".to_string()),
+                    _type: Value::String("string".to_string()),
+                    nullable: Some(false),
+                    sensitive: Some(false),
+                },
+                TfVariable {
+                    _type: Value::String("map(string)".to_string()),
+                    name: "tags".to_string(),
+                    description: Some("Tags to apply to the S3 bucket".to_string()),
+                    default: serde_json::from_value(
+                        serde_json::json!({"Test": "hej", "AnotherTag": "something"}),
+                    )
+                    .unwrap(),
+                    nullable: Some(true),
+                    sensitive: Some(false),
+                },
+            ],
+            stack_data: None,
+            version_diff: None,
+            cpu: get_default_cpu(),
+            memory: get_default_memory(),
+        };
+
+        let claim_modules = [
+            (deployment_manifest_bucket1, module_bucket_0_0_21.clone()),
+            (deployment_manifest_bucket2, module_bucket_0_0_21.clone()),
+        ];
+
+        let valid = validate_claim_modules(&claim_modules).unwrap();
+        assert_eq!(valid, false); // Should fail because bucketArn is not defined in the module_bucket_0_0_21 output
+    }
+
+    #[test]
+    fn test_validate_claim_modules_multiple_with_dependency_correct_output() {
+        let yaml_manifest_bucket1 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket1a
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+                tags:
+                    Name234: my-s3bucket-bucket1
+        "#;
+        let deployment_manifest_bucket1: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket1).unwrap();
+
+        let yaml_manifest_bucket2 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+                tags:
+                    Name234: my-s3bucket-bucket2
+                    dependentOn: "prefix-{{ S3Bucket::bucket1a::bucketArn }}-suffix"
+        "#;
+        let deployment_manifest_bucket2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket2).unwrap();
+
+        let module_bucket_0_0_21 = ModuleResp {
+            s3_key: "s3bucket/s3bucket-0.0.21.zip".to_string(),
+            track: "dev".to_string(),
+            track_version: "dev#000.000.021".to_string(),
+            version: "0.0.21".to_string(),
+            timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+            module_name: "S3Bucket".to_string(),
+            module_type: "module".to_string(),
+            module: "s3bucket".to_string(),
+            description: "Some description...".to_string(),
+            reference: "".to_string(),
+            manifest: ModuleManifest {
+                metadata: Metadata {
+                    name: "metadata".to_string(),
+                },
+                api_version: "infraweave.io/v1".to_string(),
+                kind: "Module".to_string(),
+                spec: ModuleSpec {
+                    module_name: "S3Bucket".to_string(),
+                    version: Some("0.0.21".to_string()),
+                    description: "Some description...".to_string(),
+                    reference: "".to_string(),
+                    examples: None,
+                    cpu: None,
+                    memory: None,
+                },
+            },
+            tf_outputs: vec![TfOutput {
+                name: "bucket_arn".to_string(),
+                value: "".to_string(),
+                description: "ARN of the bucket".to_string(),
+            }],
+            tf_variables: vec![
+                TfVariable {
+                    name: "bucket_name".to_string(),
+                    default: None,
+                    description: Some("Name of the S3 bucket".to_string()),
+                    _type: Value::String("string".to_string()),
+                    nullable: Some(false),
+                    sensitive: Some(false),
+                },
+                TfVariable {
+                    _type: Value::String("map(string)".to_string()),
+                    name: "tags".to_string(),
+                    description: Some("Tags to apply to the S3 bucket".to_string()),
+                    default: serde_json::from_value(
+                        serde_json::json!({"Test": "hej", "AnotherTag": "something"}),
+                    )
+                    .unwrap(),
+                    nullable: Some(true),
+                    sensitive: Some(false),
+                },
+            ],
+            stack_data: None,
+            version_diff: None,
+            cpu: get_default_cpu(),
+            memory: get_default_memory(),
+        };
+
+        let claim_modules = [
+            (deployment_manifest_bucket1, module_bucket_0_0_21.clone()),
+            (deployment_manifest_bucket2, module_bucket_0_0_21.clone()),
+        ];
+
+        let valid = validate_claim_modules(&claim_modules).unwrap();
+        assert_eq!(valid, true); // Should fail because bucketArn is not defined in the module_bucket_0_0_21 output
+    }
+
+    #[test]
+    fn test_validate_claim_modules_ec2_vpc_dependency_correct_output() {
+        // VPC deployment manifest YAML
+        let yaml_manifest_vpc = r#"
+    apiVersion: infraweave.io/v1
+    kind: VPC
+    metadata:
+      name: vpc1
+    spec:
+      region: us-east-1
+      moduleVersion: 0.0.1
+      variables:
+        cidr: "10.0.0.0/16"
+    "#;
+        let deployment_manifest_vpc: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_vpc).unwrap();
+
+        // EC2 deployment manifest YAML
+        let yaml_manifest_ec2 = r#"
+    apiVersion: infraweave.io/v1
+    kind: EC2
+    metadata:
+      name: ec2instance
+    spec:
+      region: us-east-1
+      moduleVersion: 0.0.1
+      variables:
+        instanceType: "t2.micro"
+        vpc_id: "{{ VPC::vpc1::vpcId }}"
+    "#;
+        let deployment_manifest_ec2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_ec2).unwrap();
+
+        // ModuleResp for the VPC.
+        // Note: It must include an output named "vpc_id" (i.e. vpcId becomes vpc_id)
+        let module_vpc = ModuleResp {
+            s3_key: "vpc/vpc-0.0.1.zip".to_string(),
+            track: "prod".to_string(),
+            track_version: "prod#000.000.001".to_string(),
+            version: "0.0.1".to_string(),
+            timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+            module_name: "VPC".to_string(),
+            module_type: "module".to_string(),
+            module: "vpc".to_string(),
+            description: "VPC Module".to_string(),
+            reference: "".to_string(),
+            manifest: ModuleManifest {
+                metadata: Metadata {
+                    name: "vpc-metadata".to_string(),
+                },
+                api_version: "infraweave.io/v1".to_string(),
+                kind: "Module".to_string(),
+                spec: ModuleSpec {
+                    module_name: "VPC".to_string(),
+                    version: Some("0.0.1".to_string()),
+                    description: "VPC module description".to_string(),
+                    reference: "".to_string(),
+                    examples: None,
+                    cpu: None,
+                    memory: None,
+                },
+            },
+            tf_outputs: vec![TfOutput {
+                name: "vpc_id".to_string(),
+                value: "".to_string(),
+                description: "VPC Identifier".to_string(),
+            }],
+            tf_variables: vec![TfVariable {
+                name: "cidr".to_string(),
+                default: Some(serde_json::json!("10.0.0.0/16")),
+                description: Some("CIDR block".to_string()),
+                _type: Value::String("string".to_string()),
+                nullable: Some(false),
+                sensitive: Some(false),
+            }],
+            stack_data: None,
+            version_diff: None,
+            cpu: get_default_cpu(),
+            memory: get_default_memory(),
+        };
+
+        // ModuleResp for the EC2 instance.
+        let module_ec2 = ModuleResp {
+            s3_key: "ec2/ec2-0.0.1.zip".to_string(),
+            track: "prod".to_string(),
+            track_version: "prod#000.000.001".to_string(),
+            version: "0.0.1".to_string(),
+            timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+            module_name: "EC2".to_string(),
+            module_type: "module".to_string(),
+            module: "ec2".to_string(),
+            description: "EC2 Module".to_string(),
+            reference: "".to_string(),
+            manifest: ModuleManifest {
+                metadata: Metadata {
+                    name: "ec2-metadata".to_string(),
+                },
+                api_version: "infraweave.io/v1".to_string(),
+                kind: "Module".to_string(),
+                spec: ModuleSpec {
+                    module_name: "EC2".to_string(),
+                    version: Some("0.0.1".to_string()),
+                    description: "EC2 module description".to_string(),
+                    reference: "".to_string(),
+                    examples: None,
+                    cpu: None,
+                    memory: None,
+                },
+            },
+            tf_outputs: vec![],
+            tf_variables: vec![
+                TfVariable {
+                    name: "instance_type".to_string(),
+                    default: Some(serde_json::json!("t2.micro")),
+                    description: Some("EC2 instance type".to_string()),
+                    _type: Value::String("string".to_string()),
+                    nullable: Some(false),
+                    sensitive: Some(false),
+                },
+                TfVariable {
+                    name: "vpc_id".to_string(),
+                    default: None,
+                    description: Some("VPC ID for the EC2 instance".to_string()),
+                    _type: Value::String("string".to_string()),
+                    nullable: Some(false),
+                    sensitive: Some(false),
+                },
+            ],
+            stack_data: None,
+            version_diff: None,
+            cpu: get_default_cpu(),
+            memory: get_default_memory(),
+        };
+
+        let claim_modules = [
+            (deployment_manifest_vpc, module_vpc),
+            (deployment_manifest_ec2, module_ec2),
+        ];
+
+        let valid = validate_claim_modules(&claim_modules).unwrap();
+        // Since the dependency in EC2 ("{{ VPC::vpc1::vpcId }}") is satisfied by VPC's output "vpc_id",
+        // the validation should pass.
+        assert_eq!(valid, true);
+    }
+
+    #[test]
+    fn test_validate_claim_modules_nonexisting_variable() {
+        let yaml_manifest_bucket2 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+                someVariableThatDoesNotExist: "some-value"
+        "#;
+        let deployment_manifest_bucket2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket2).unwrap();
+
+        let claim_modules = [(
+            deployment_manifest_bucket2,
+            ModuleResp {
+                s3_key: "s3bucket/s3bucket-0.0.21.zip".to_string(),
+                track: "dev".to_string(),
+                track_version: "dev#000.000.021".to_string(),
+                version: "0.0.21".to_string(),
+                timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+                module_name: "S3Bucket".to_string(),
+                module_type: "module".to_string(),
+                module: "s3bucket".to_string(),
+                description: "Some description...".to_string(),
+                reference: "".to_string(),
+                manifest: ModuleManifest {
+                    metadata: Metadata {
+                        name: "metadata".to_string(),
+                    },
+                    api_version: "infraweave.io/v1".to_string(),
+                    kind: "Module".to_string(),
+                    spec: ModuleSpec {
+                        module_name: "S3Bucket".to_string(),
+                        version: Some("0.0.21".to_string()),
+                        description: "Some description...".to_string(),
+                        reference: "".to_string(),
+                        examples: None,
+                        cpu: None,
+                        memory: None,
+                    },
+                },
+                tf_outputs: vec![],
+                tf_variables: vec![TfVariable {
+                    name: "bucket_name".to_string(),
+                    default: None,
+                    description: Some("Name of the S3 bucket".to_string()),
+                    _type: Value::String("string".to_string()),
+                    nullable: Some(false),
+                    sensitive: Some(false),
+                }],
+                stack_data: None,
+                version_diff: None,
+                cpu: get_default_cpu(),
+                memory: get_default_memory(),
+            },
+        )];
+
+        let result = validate_claim_modules(&claim_modules);
+        assert_eq!(result.is_err(), true);
     }
 
     fn get_example_claim_modules() -> Vec<(DeploymentManifest, ModuleResp)> {

--- a/integration-tests/stacks/bucketcollection-invalid-variable/bucket1a.yaml
+++ b/integration-tests/stacks/bucketcollection-invalid-variable/bucket1a.yaml
@@ -1,0 +1,13 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: bucket1a
+spec:
+  moduleVersion: 0.1.2-dev+test.10
+  region: N/A
+  variables:
+    # bucketName: my-temp-bucket1a // Missing this required variable
+    nonExistingVariable: this-variable-does-not-exist-in-the-module
+    tags:
+      Name234: my-s3bucket-bucket1a
+      Environment43: dev

--- a/integration-tests/stacks/bucketcollection-invalid-variable/bucket2.yaml
+++ b/integration-tests/stacks/bucketcollection-invalid-variable/bucket2.yaml
@@ -1,0 +1,14 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: bucket2
+spec:
+  moduleVersion: 0.1.3-dev+test.10
+  region: N/A
+  variables:
+    bucketName: "{{ S3Bucket::bucket1a::bucketName }}-after"
+    tags:
+      Name234: my-s3bucket
+      Tjoho: "This is cool"
+      Environment43: dev
+      PreviousBucket: "{{ S3Bucket::bucket1a::bucketArn }}"

--- a/integration-tests/stacks/bucketcollection-invalid-variable/stack.yaml
+++ b/integration-tests/stacks/bucketcollection-invalid-variable/stack.yaml
@@ -1,0 +1,40 @@
+apiVersion: infraweave.io/v1
+kind: Stack
+metadata:
+  name: bucketcollection
+spec:
+  stackName: BucketCollection
+  reference: https://github.com/infreweave-io/stacks/bucketcollection
+  description: |
+    This is a deployment stack consisting of a two S3-buckets and are for testing dependencies between modules.
+    
+    ## Details
+    The first bucket is called bucket1a, you can set the name of it in the variables.
+
+    The second S3 bucket has a name that depends on bucket1a, and will add '-after' appended at the end.
+    It will also add a tag with the ARN of the first bucket as a value.
+
+  examples:
+    - name: bucketcollection
+      description: |
+        # Minimal example
+
+        This is a deployment stack consisting of a two S3-buckets.
+
+        These are for testing dependencies between modules.
+        You will see that bucket2 will get its name based on the name of bucket1a, with appended '-after' at the end.
+
+        ### bucket1a
+        This module creates an S3 bucket.
+
+        ### bucket2
+        This module creates an S3 bucket that depends on bucket1a.
+        
+        It also shows how to use tags with dependencies.
+      variables:
+        bucket1a:
+          bucketName: bucket1a-name
+        bucket2:
+          tags:
+            SomeTag: SomeValue
+            AnotherTag: "ARN of dependency bucket {{ S3Bucket::bucket1a::bucketArn }}"

--- a/integration-tests/stacks/bucketcollection-missing-region/bucket1a.yaml
+++ b/integration-tests/stacks/bucketcollection-missing-region/bucket1a.yaml
@@ -1,0 +1,11 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: bucket1a
+spec:
+  moduleVersion: 0.1.2-dev+test.10
+  variables:
+    bucketName: my-temp-bucket1a
+    tags:
+      Name234: my-s3bucket-bucket1a
+      Environment43: dev

--- a/integration-tests/stacks/bucketcollection-missing-region/bucket2.yaml
+++ b/integration-tests/stacks/bucketcollection-missing-region/bucket2.yaml
@@ -1,0 +1,14 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: bucket2
+spec:
+  moduleVersion: 0.1.3-dev+test.10
+  region: N/A
+  variables:
+    bucketName: "{{ S3Bucket::bucket1a::bucketName }}-after"
+    tags:
+      Name234: my-s3bucket
+      Tjoho: "This is cool"
+      Environment43: dev
+      PreviousBucket: "{{ S3Bucket::bucket1a::bucketArn }}"

--- a/integration-tests/stacks/bucketcollection-missing-region/stack.yaml
+++ b/integration-tests/stacks/bucketcollection-missing-region/stack.yaml
@@ -1,0 +1,40 @@
+apiVersion: infraweave.io/v1
+kind: Stack
+metadata:
+  name: bucketcollection
+spec:
+  stackName: BucketCollection
+  reference: https://github.com/infreweave-io/stacks/bucketcollection
+  description: |
+    This is a deployment stack consisting of a two S3-buckets and are for testing dependencies between modules.
+    
+    ## Details
+    The first bucket is called bucket1a, you can set the name of it in the variables.
+
+    The second S3 bucket has a name that depends on bucket1a, and will add '-after' appended at the end.
+    It will also add a tag with the ARN of the first bucket as a value.
+
+  examples:
+    - name: bucketcollection
+      description: |
+        # Minimal example
+
+        This is a deployment stack consisting of a two S3-buckets.
+
+        These are for testing dependencies between modules.
+        You will see that bucket2 will get its name based on the name of bucket1a, with appended '-after' at the end.
+
+        ### bucket1a
+        This module creates an S3 bucket.
+
+        ### bucket2
+        This module creates an S3 bucket that depends on bucket1a.
+        
+        It also shows how to use tags with dependencies.
+      variables:
+        bucket1a:
+          bucketName: bucket1a-name
+        bucket2:
+          tags:
+            SomeTag: SomeValue
+            AnotherTag: "ARN of dependency bucket {{ S3Bucket::bucket1a::bucketArn }}"

--- a/integration-tests/tests/stack.rs
+++ b/integration-tests/tests/stack.rs
@@ -110,4 +110,105 @@ mod stack_tests {
         })
         .await;
     }
+
+    #[tokio::test]
+    async fn test_stack_publish_bucketcollection_missing_region() {
+        // should add variable checks as well
+        test_scaffold(|| async move {
+            let lambda_endpoint_url = "http://127.0.0.1:8080";
+            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let current_dir = env::current_dir().expect("Failed to get current directory");
+
+            env_common::publish_module(
+                &handler,
+                &current_dir
+                    .join("modules/s3bucket-dev/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                &"dev".to_string(),
+                Some("0.1.2-dev+test.10"),
+            )
+            .await
+            .unwrap();
+
+            env_common::publish_module(
+                &handler,
+                &current_dir
+                    .join("modules/s3bucket-dev/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                &"dev".to_string(),
+                Some("0.1.3-dev+test.10"),
+            )
+            .await
+            .unwrap();
+
+            let result = env_common::publish_stack(
+                &handler,
+                &current_dir
+                    .join("stacks/bucketcollection-missing-region/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                &"dev".to_string(),
+                Some("0.1.2-dev+test.10"),
+            )
+            .await;
+
+            assert_eq!(result.is_err(), true);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_stack_publish_bucketcollection_invalid_variables() {
+        test_scaffold(|| async move {
+            let lambda_endpoint_url = "http://127.0.0.1:8080";
+            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let current_dir = env::current_dir().expect("Failed to get current directory");
+
+            env_common::publish_module(
+                &handler,
+                &current_dir
+                    .join("modules/s3bucket-dev/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                &"dev".to_string(),
+                Some("0.1.2-dev+test.10"),
+            )
+            .await
+            .unwrap();
+
+            env_common::publish_module(
+                &handler,
+                &current_dir
+                    .join("modules/s3bucket-dev/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                &"dev".to_string(),
+                Some("0.1.3-dev+test.10"),
+            )
+            .await
+            .unwrap();
+
+            let result = env_common::publish_stack(
+                &handler,
+                &current_dir
+                    .join("stacks/bucketcollection-invalid-variable/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                &"dev".to_string(),
+                Some("0.1.2-dev+test.10"),
+            )
+            .await;
+
+            assert_eq!(result.is_err(), true);
+        })
+        .await;
+    }
 }

--- a/utils/src/stack.rs
+++ b/utils/src/stack.rs
@@ -23,12 +23,12 @@ pub fn read_stack_directory(directory: &Path) -> anyhow::Result<Vec<DeploymentMa
     {
         let content = fs::read_to_string(entry.path())?;
 
-        // push if it's a deployment, otherwise continue
+        // add if it's a deployment, otherwise return early with an error
         let deployment: DeploymentManifest = match serde_yaml::from_str(&content) {
             Ok(deployment) => deployment,
             Err(e) => {
                 println!("Failed to parse deployment {:?}: {}", entry.path(), e);
-                continue;
+                anyhow::bail!("Failed to parse deployment {:?}: {}", entry.path(), e);
             }
         };
         deployments.push(deployment);


### PR DESCRIPTION
This pull request modifies functions to return `Result` types for better error propagation to fail early if claims are invalid. It adds validation of claims in stacks, it also adds tests for stacks with missing regions and invalid variables updating stack configuration files with new test cases.

### Error Handling Improvements:
* [`env_common/src/logic/api_stack.rs`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L42-R42): Modified the `get_claims_in_stack` function to return a `Result` type and updated calls to this function to handle the potential error using the `?` operator.
* [`env_common/src/logic/api_stack.rs`]: Added function `validate_claim_modules` to ensure claims are valid for the specified module-version.
* [`utils/src/stack.rs`]: Updated the `read_stack_directory` function to return an error immediately if parsing a deployment fails, instead of continuing.

### New Unit Tests:
* [`env_common/src/logic/api_stack.rs`]: Added several tests for verifying the claims are valid at publish-time to ensure variables exists and are of right type. Also that namespace is not set as this instead will be set by the stack.

### New Integration Tests:
* [`integration-tests/tests/stack.rs`](diffhunk://#diff-3208c9c38c37f186e1c7b76b5b04f6509b0e9917ff1074a940bfc91729db7613R113-R213): Added new integration tests for publishing stacks with missing regions and invalid variables to ensure proper error handling and validation.
