### PR TITLE
fix: enable python builds

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,7 +1,9 @@
 name: Build Python Wheels
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   build-and-publish:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -79,6 +79,13 @@ jobs:
           sed -i 's#path = "../defs"#path = "defs"#' Cargo.toml
           sed -i 's#path = "../utils"#path = "utils"#' Cargo.toml
 
+      - name: Update version in pyproject.toml from tag
+        run: |
+          TAG_VERSION="${{ github.ref_name }}"
+          # Remove a leading "v" if present, e.g., v0.0.49 becomes 0.0.49
+          TAG_VERSION=${TAG_VERSION#v}
+          sed -i "s/^version = .*/version = \"$TAG_VERSION\"/" infraweave_py/pyproject.toml
+
       - name: Build Wheels
         working-directory: infraweave_py
         env:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -82,9 +82,12 @@ jobs:
       - name: Update version in pyproject.toml from tag
         run: |
           TAG_VERSION="${{ github.ref_name }}"
-          # Remove a leading "v" if present, e.g., v0.0.49 becomes 0.0.49
-          TAG_VERSION=${TAG_VERSION#v}
-          sed -i "s/^version = .*/version = \"$TAG_VERSION\"/" infraweave_py/pyproject.toml
+          TAG_VERSION=${TAG_VERSION#v} # Remove a leading "v" if present, e.g., v0.0.49 becomes 0.0.49
+          if [[ "$(uname)" == "Darwin" ]]; then
+            sed -i '' "s/^version = .*/version = \"$TAG_VERSION\"/" infraweave_py/pyproject.toml
+          else
+            sed -i "s/^version = .*/version = \"$TAG_VERSION\"/" infraweave_py/pyproject.toml
+          fi
 
       - name: Build Wheels
         working-directory: infraweave_py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,3 +82,92 @@ jobs:
 
       - name: Build ${{ matrix.package }} package using ${{ matrix.dockerfile }}
         run: docker build -f ${{ matrix.dockerfile }} .
+
+  python-builds:
+    name: Build python ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            arch: x86_64
+            python-arch: x64
+            cibw-build: cp311-manylinux_x86_64
+          - name: macos-arm64
+            os: macos-latest
+            arch: arm64
+            python-arch: arm64
+            cibw-build: cp311-macosx_arm64
+          # - name: linux-aarch64
+          #   os: ubuntu-latest
+          #   arch: aarch64
+          #   python-arch: arm64
+          #   cibw-build: cp311-manylinux_aarch64
+          # - os: macos-latest
+          #   arch: x86_64
+          #   python-arch: x64
+          # - os: ubuntu-latest
+          #   arch: arm64
+          #   python-arch: arm64
+          # - os: macos-latest
+          #   arch: x86_64
+          #   python-arch: x64
+          #   - os: windows-latest
+          #     arch: x86_64  # Only x86_64 is supported for Windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+          architecture: ${{ matrix.python-arch }}
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install maturin==1.7.5 cibuildwheel
+
+      - name: Check Maturin Version
+        run: maturin --version
+
+      - name: Prepare Dependencies for dockerized build
+        if: runner.os == 'Linux'
+        run: |
+          cp -r env_common infraweave_py/env_common
+          cp -r defs infraweave_py/defs
+          cp -r utils infraweave_py/utils
+          cp -r env_aws infraweave_py/env_aws
+          cp -r env_azure infraweave_py/env_azure
+
+      - name: Adjust Cargo.toml paths for dockerized build
+        if: runner.os == 'Linux'
+        working-directory: infraweave_py
+        run: |
+          sed -i 's#path = "../env_common"#path = "env_common"#' Cargo.toml
+          sed -i 's#path = "../defs"#path = "defs"#' Cargo.toml
+          sed -i 's#path = "../utils"#path = "utils"#' Cargo.toml
+
+      - name: Build Wheels
+        working-directory: infraweave_py
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.cibw-build }}
+          CIBW_ENVIRONMENT: |
+            PATH=$HOME/.cargo/bin:$PATH
+            RUSTFLAGS=""
+          CIBW_BEFORE_BUILD_LINUX: |
+            yum install -y perl-core
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            source $HOME/.cargo/env
+          CIBW_BEFORE_BUILD_MACOS: |
+            brew install openssl
+        run: |
+          cibuildwheel --output-dir dist
+      

--- a/infraweave_py/pyproject.toml
+++ b/infraweave_py/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "infraweave"
-version = "0.0.49"
-description = "Implement InfraWeave in Python"
+version = "0.0.0+to-be-overriden"
+description = "Interact with InfraWeave using Python"
 readme = "README.md"
 authors = [
     {name = "InfraWeave Team", email = "opensource@infraweave.com"}

--- a/infraweave_py/src/python.rs
+++ b/infraweave_py/src/python.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use crate::deployment::Deployment;
 pub use crate::module::Module;
 pub use crate::stack::Stack;
-use env_common::interface::{initialize_project_id_and_region, CloudHandler};
-use env_common::logic::handler;
+use env_common::interface::{initialize_project_id_and_region, GenericCloudHandler};
+use env_defs::CloudProvider;
 use env_utils::setup_logging;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict};
@@ -55,7 +55,7 @@ fn create_dynamic_wrapper(py: Python, class_name: &str, wrapped_class: &str) -> 
 #[allow(dead_code)]
 async fn get_available_modules_stacks() -> (Vec<String>, Vec<String>) {
     initialize_project_id_and_region().await;
-    let handler = handler();
+    let handler = GenericCloudHandler::default().await;
     let (modules, stacks) = tokio::join!(
         handler.get_all_latest_module(""),
         handler.get_all_latest_stack("")


### PR DESCRIPTION
This pull request includes 
* triggers the python build and deploy workflow by tags
* adding a new test job for building Python wheels
* Update the Rust code to use a more generic cloud handler.

Workflow configuration updates:

* [`.github/workflows/pypi.yml`](diffhunk://#diff-1baea138c19b06c7531655c5e977dbbcca5bd9147709625e2ee40984905502c5L4-R6): Changed the trigger for the build workflow from `workflow_dispatch` to `push` with specific tag patterns.
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R85-R173): Added a new job `python-builds` to build Python wheels for different OS and architecture combinations, including steps for setting up Python, installing Rust, and building the wheels.

Rust code updates:

* [`infraweave_py/src/python.rs`](diffhunk://#diff-acc7cfc5c72d0060d1f171f676d688d0b573bce746ba677d282fb4a3bb60319eL6-R7): Replaced `CloudHandler` with `GenericCloudHandler` and added the `CloudProvider` import.
* [`infraweave_py/src/python.rs`](diffhunk://#diff-acc7cfc5c72d0060d1f171f676d688d0b573bce746ba677d282fb4a3bb60319eL58-R58): Updated the `get_available_modules_stacks` function to use `GenericCloudHandler::default().await` instead of `handler()`.