### PR TITLE
fix: skip version check if version starts with 0.0.0

### DIFF
--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -322,6 +322,11 @@ pub async fn compare_latest_version(
     track: &str,
     module_type: ModuleType,
 ) -> Result<Option<ModuleResp>, anyhow::Error> {
+    if version.starts_with("0.0.0") {
+        info!("Skipping version check for unreleased version {}", version);
+        return Ok(None); // Used for unreleased versions (for testing in pipeline)
+    }
+
     let fetch_module: Result<Option<ModuleResp>, anyhow::Error> = match module_type {
         ModuleType::Module => handler.get_latest_module_version(module, track).await,
         ModuleType::Stack => handler.get_latest_stack_version(module, track).await,


### PR DESCRIPTION
Add a check to skip version comparison for versions starting with "0.0.0" when publishing module or stack, and log a message indicating the skip. 

This is useful for handling unreleased versions, especially in testing pipelines.

Can further be utilized in queries to skip these build-versions to reduce noise when listing module/stack versions.
