### PR TITLE
feature: publish stacks to all regions

### DIFF
--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -219,14 +219,22 @@ pub async fn publish_stack(
         }
     }
 
-    println!("Uploading stack as module {}", &module.module);
-    match upload_module(handler, &module, &zip_base64).await {
-        Ok(_) => {
-            info!("Stack published successfully");
-            Ok(())
+    let all_regions = handler.get_all_regions().await.unwrap();
+    info!("Publishing stack in all regions: {:?}", all_regions);
+    for region in all_regions {
+        let region_handler = handler.copy_with_region(&region).await;
+        match upload_module(&region_handler, &module, &zip_base64).await {
+            Ok(_) => {
+                info!("Stack published successfully in region {}", region);
+            }
+            Err(error) => {
+                return Err(ModuleError::UploadModuleError(error.to_string()));
+            }
         }
-        Err(error) => Err(ModuleError::UploadModuleError(error.to_string())),
     }
+
+    info!("Stack published successfully in all regions!");
+    Ok(())
 }
 
 pub async fn get_stack_preview(


### PR DESCRIPTION
This pull request includes changes to the `publish_stack` function in `env_common/src/logic/api_stack.rs` to enhance the stack publishing process by supporting multiple regions. 

This is an extension to https://github.com/infraweave-io/infraweave/pull/9

Enhancements to stack publishing:

* [`env_common/src/logic/api_stack.rs`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L222-R239): Modified `publish_stack` to retrieve all regions and publish the stack in each region individually, with improved logging to indicate success or failure for each region. Added a final log statement to confirm successful publication in all regions.