### PR TITLE
fix: remove region from project-map

### DIFF
--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -361,16 +361,12 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
     let repo_full_name = payload["repository"]["full_name"].as_str().unwrap();
     let repository_url = payload["repository"]["html_url"].as_str().unwrap();
 
-    let (project_id, _region, project_id_found) =
+    let (project_id, project_id_found) =
         match get_project_id_for_repository_path(repo_full_name).await {
-            Ok((project_id, _region)) => (project_id, _region, true),
+            Ok(project_id) => (project_id, true),
             Err(e) => {
                 println!("Error getting project id: {:?}", e);
-                (
-                    "NOT_FOUND_FOR_REPO".to_string(),
-                    "NOT_FOUND_FOR_REPO".to_string(),
-                    false,
-                )
+                ("NOT_FOUND_FOR_REPO".to_string(), false)
             }
         };
 

--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -121,7 +121,7 @@ async fn process_runner_event(payload: Value) -> Result<Value, Error> {
         ExtraData::GitHub(mut github_event) => {
             println!("GitHub Event: {:?}", github_event);
 
-            let (project_id, _region) =
+            let project_id =
                 get_project_id_for_repository_path(&github_event.repository.full_name).await?;
             let region = &github_event.job_details.region;
             println!(

--- a/gitops/src/project.rs
+++ b/gitops/src/project.rs
@@ -16,7 +16,7 @@ async fn get_project_map() -> Map<String, serde_json::Value> {
 
 pub async fn get_project_id_for_repository_path(
     full_repository_path: &str,
-) -> Result<(String, String), anyhow::Error> {
+) -> Result<String, anyhow::Error> {
     let project_map: Map<String, serde_json::Value> = match env::var("PROJECT_MAP") {
         Ok(project_map_str) => serde_json::from_str(&project_map_str).unwrap(),
         Err(_) => get_project_map().await,
@@ -32,11 +32,7 @@ pub async fn get_project_id_for_repository_path(
                 full_repository_path, value
             );
             let project_id = value.get("project_id").unwrap();
-            let region = value.get("region").unwrap();
-            return Ok((
-                project_id.as_str().unwrap().to_string(),
-                region.as_str().unwrap().to_string(),
-            ));
+            return Ok(project_id.as_str().unwrap().to_string());
         }
     }
 
@@ -56,20 +52,16 @@ mod tests {
             "PROJECT_MAP",
             r#"{
             "SomeGroup/path123/*": {
-                "project_id": "111111111",
-                "region": "us-west-1"
+                "project_id": "111111111"
             },
             "SomeGroup/path987/*": {
-                "project_id": "222222222",
-                "region": "us-west-2"
+                "project_id": "222222222"
             },
             "SomeGroup/strictpath987/project987": {
-                "project_id": "333333333",
-                "region": "us-west-3"
+                "project_id": "333333333"
             },
             "SomeGroup/path567/proj*": {
-                "project_id": "444444444",
-                "region": "us-west-4"
+                "project_id": "444444444"
             }
         }"#,
         );
@@ -78,7 +70,7 @@ mod tests {
             get_project_id_for_repository_path("SomeGroup/path123/project123")
                 .await
                 .unwrap(),
-            ("111111111".to_string(), "us-west-1".to_string())
+            "111111111".to_string()
         );
 
         assert_eq!(
@@ -93,7 +85,7 @@ mod tests {
             get_project_id_for_repository_path("SomeGroup/path987/project987")
                 .await
                 .unwrap(),
-            ("222222222".to_string(), "us-west-2".to_string())
+            "222222222".to_string()
         );
         assert_eq!(
             get_project_id_for_repository_path("SomeGroup/strictpath987")
@@ -107,21 +99,21 @@ mod tests {
             get_project_id_for_repository_path("SomeGroup/strictpath987/project987")
                 .await
                 .unwrap(),
-            ("333333333".to_string(), "us-west-3".to_string())
+            "333333333".to_string()
         );
 
         assert_eq!(
             get_project_id_for_repository_path("SomeGroup/path567/proj")
                 .await
                 .unwrap(),
-            ("444444444".to_string(), "us-west-4".to_string())
+            "444444444".to_string()
         );
 
         assert_eq!(
             get_project_id_for_repository_path("SomeGroup/path567/project123")
                 .await
                 .unwrap(),
-            ("444444444".to_string(), "us-west-4".to_string())
+            "444444444".to_string()
         );
     }
 }


### PR DESCRIPTION
This pull request simplifies the handling of project IDs by removing the region information from the `get_project_id_for_repository_path` function and its associated calls and tests. The changes streamline the code and reduce the complexity of the returned values.

Key changes include:

### Function modifications:

* [`gitops/src/github.rs`](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L364-R369): Updated `handle_process_push_event` to remove the region from the `get_project_id_for_repository_path` function call and its returned values.
* [`gitops/src/main.rs`](diffhunk://#diff-dc5453bb76c985775aedb0cff6bd802776b1a286c35ee865822c0cd8a107a90cL124-R124): Modified `process_runner_event` to only retrieve the project ID without the region.
* [`gitops/src/project.rs`](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L19-R19): Simplified `get_project_id_for_repository_path` to return only the project ID, removing the region from the returned tuple. [[1]](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L19-R19) [[2]](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L35-R35)

### Test updates:

* [`gitops/src/project.rs`](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L59-R64): Updated tests to reflect the changes in `get_project_id_for_repository_path`, removing the region from expected results. [[1]](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L59-R64) [[2]](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L81-R73) [[3]](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L96-R88) [[4]](diffhunk://#diff-e8aad1307474c89fac0b0fd7773e15e443530dd49d68e25bbb5d793ac151edf8L110-R116)