### PR TITLE
feature: migrate project configuration to terraform

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -256,25 +256,6 @@ async fn main() {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("set-project")
-                .arg(
-                    Arg::with_name("project_id")
-                        .help("Project id to insert/update")
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name("name")
-                        .help("Name of the project")
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name("description")
-                        .help("Description about the project")
-                        .required(true),
-                )
-                .about("Insert or update an existing project")
-        )
-        .subcommand(
             SubCommand::with_name("get-current-project")
                 .about("Get current project")
         )
@@ -537,43 +518,6 @@ async fn main() {
                 "Invalid subcommand for policy, must be one of 'publish', 'test', or 'version'"
             ),
         },
-        Some(("set-project", run_matches)) => {
-            let project_id = run_matches.value_of("project_id").unwrap();
-            let name = run_matches.value_of("name").unwrap();
-            let description = run_matches.value_of("description").unwrap();
-            let project = ProjectData {
-                project_id: project_id.to_string(),
-                name: name.to_string(),
-                description: description.to_string(),
-                regions: vec![ // TODO: Take this as input
-                    "eu-central-1".to_string(),
-                    "us-west-2".to_string(),
-                    "us-east-1".to_string(),
-                ],
-                region_map: serde_json::json!({
-                    "eu-central-1": {
-                        "git_provider": "gitlab",
-                        "project_id": "123456",
-                    },
-                    "us-west-2": {
-                        "git_provider": "gitlab",
-                        "project_id": "12345699",
-                    },
-                    "us-east-1": {
-                        "git_provider": "gitlab",
-                        "project_id": "12345600",
-                    }
-                }),
-            };
-            match current_region_handler().await.set_project(&project).await {
-                Ok(_) => {
-                    info!("Project inserted");
-                }
-                Err(e) => {
-                    error!("Failed to insert project: {}", e);
-                }
-            }
-        }
         Some(("get-current-project", _run_matches)) => {
             match current_region_handler().await.get_current_project().await {
                 Ok(project) => {

--- a/defs/src/deployment.rs
+++ b/defs/src/deployment.rs
@@ -115,7 +115,6 @@ pub struct ProjectData {
     pub name: String,
     pub description: String,
     pub regions: Vec<String>,
-    pub region_map: Value,
 }
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/defs/src/provider.rs
+++ b/defs/src/provider.rs
@@ -15,7 +15,6 @@ pub trait CloudProviderCommon: Send + Sync {
         deployment: &DeploymentResp,
         is_plan: bool,
     ) -> Result<(), anyhow::Error>;
-    async fn set_project(&self, project: &ProjectData) -> Result<(), anyhow::Error>;
     async fn insert_event(&self, event: EventData) -> Result<String, anyhow::Error>;
     async fn publish_notification(
         &self,

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 
 use crate::logic::{
     insert_event, insert_infra_change_record, publish_notification, publish_policy, read_logs,
-    set_deployment, set_project, PROJECT_ID, REGION,
+    set_deployment, PROJECT_ID, REGION,
 };
 
 #[derive(Clone)]
@@ -106,9 +106,6 @@ impl CloudProviderCommon for GenericCloudHandler {
         is_plan: bool,
     ) -> Result<(), anyhow::Error> {
         set_deployment(self, deployment, is_plan).await
-    }
-    async fn set_project(&self, project: &ProjectData) -> Result<(), anyhow::Error> {
-        set_project(self, project).await
     }
     async fn insert_infra_change_record(
         &self,

--- a/env_common/src/logic/api_deployment.rs
+++ b/env_common/src/logic/api_deployment.rs
@@ -61,52 +61,6 @@ fn get_payload(deployment: &DeploymentResp, is_plan: bool) -> serde_json::Value 
     deployment_payload
 }
 
-pub async fn set_project(
-    handler: &GenericCloudHandler,
-    project: &ProjectData,
-) -> Result<(), anyhow::Error> {
-    // TODO: dont use transaction for single item
-    let deployment_table_placeholder = "deployments";
-
-    let mut transaction_items = vec![];
-
-    let pks = vec![
-        "PROJECTS".to_string(),
-        // format!("PROJECT#{}", project.project_id),
-    ];
-
-    for pk in pks {
-        let mut project_payload = serde_json::to_value(serde_json::json!({
-            "PK": pk,
-            "SK": format!("PROJECT#{}", project.project_id),
-        }))
-        .unwrap();
-
-        let project_value = serde_json::to_value(project).unwrap();
-        merge_json_dicts(&mut project_payload, &project_value);
-
-        transaction_items.push(serde_json::json!({
-            "Put": {
-                "TableName": deployment_table_placeholder,
-                "Item": project_payload
-            }
-        }));
-    }
-
-    // -------------------------
-    // Execute the Transaction
-    // -------------------------
-    let payload = serde_json::json!({
-        "event": "transact_write",
-        "items": transaction_items,
-    });
-
-    match handler.run_function(&payload).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(anyhow::anyhow!("Failed to set project: {}", e)),
-    }
-}
-
 pub async fn set_deployment(
     handler: &GenericCloudHandler,
     deployment: &DeploymentResp,

--- a/env_common/src/logic/mod.rs
+++ b/env_common/src/logic/mod.rs
@@ -16,7 +16,7 @@ pub use api_module::{
 
 pub use api_stack::{get_stack_preview, publish_stack};
 
-pub use api_deployment::{set_deployment, set_project};
+pub use api_deployment::set_deployment;
 
 pub use api_event::insert_event;
 


### PR DESCRIPTION
This pull request primarily focuses on removing the functionality related to setting projects in the codebase. The changes involve deleting the `set-project` subcommand, removing related methods, and cleaning up unused imports and structures.

Key changes include:

### Removal of `set-project` functionality:

* [`cli/src/main.rs`](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL258-L276): Removed the `set-project` subcommand and its associated logic for handling project data. [[1]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL258-L276) [[2]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL540-L576)
* [`defs/src/deployment.rs`](diffhunk://#diff-4a4b233e5d4dcc00b749ac904746e8f09fe6aceaa6b660aabf9ff3034880fda6L118): Removed the `region_map` field from the `ProjectData` struct.
* [`defs/src/provider.rs`](diffhunk://#diff-89b7226cf04a3e2503474c49a8ea3a0dedd488c89f29a81bcaf25c0e14faf423L18): Removed the `set_project` method from the `CloudProviderCommon` trait.
* [`env_common/src/interface/cloud_handlers.rs`](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7L16-R16): Removed the `set_project` method implementation and the related import. [[1]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7L16-R16) [[2]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7L110-L112)
* [`env_common/src/logic/api_deployment.rs`](diffhunk://#diff-424aae68793ef7c4d7cfbf58f7d7193746f4a8a0c9140f5f1944e213745a33e3L64-L109): Deleted the `set_project` function.
* [`env_common/src/logic/mod.rs`](diffhunk://#diff-a0eea96a63345b5c7765c2ebdd9a0aede0aefbcf0ac3433b72026f6dc084f998L19-R19): Removed the `set_project` import.