### PR TITLE
feature: improve stack publish validation and error messages

### DIFF
--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -46,6 +46,9 @@ pub enum ModuleError {
     #[error("The source claim \"{0}\" has an invalid reference variable \"{3}\" in claim \"{2}\" with kind \"{1}\"")]
     StackClaimReferenceNotFound(String, String, String, String),
 
+    #[error("There is a duplicate claim name \"{0}\" in the stack")]
+    DuplicateClaimNames(String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -43,6 +43,9 @@ pub enum ModuleError {
     #[error("In the claim for \"{0}\", variable \"{1}\" is set to {2}, however no output/variable named \"{3}\" could be found for \"{4}\"")]
     OutputKeyNotFound(String, String, String, String, String),
 
+    #[error("The source claim \"{0}\" has an invalid reference variable \"{3}\" in claim \"{2}\" with kind \"{1}\"")]
+    StackClaimReferenceNotFound(String, String, String, String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -52,6 +52,9 @@ pub enum ModuleError {
     #[error("There is a circular dependency in the stack between: {0:?}")]
     CircularDependency(Vec<String>),
 
+    #[error("The stack claim \"{1}\" of kind \"{0}\" has an invalid reference \"{2}\" to itself")]
+    SelfReferencingClaim(String, String, String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -40,6 +40,9 @@ pub enum ModuleError {
     #[error("Namespace should not be set for deployment claim inside Stack: {0}")]
     StackModuleNamespaceIsSet(String),
 
+    #[error("In the claim for \"{0}\", variable \"{1}\" is set to {2}, however no output/variable named \"{3}\" could be found for \"{4}\"")]
+    OutputKeyNotFound(String, String, String, String, String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -49,6 +49,9 @@ pub enum ModuleError {
     #[error("There is a duplicate claim name \"{0}\" in the stack")]
     DuplicateClaimNames(String),
 
+    #[error("There is a circular dependency in the stack between: {0:?}")]
+    CircularDependency(Vec<String>),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -664,6 +664,19 @@ fn collect_module_variables(
 pub fn validate_claim_modules(
     claim_modules: &[(DeploymentManifest, ModuleResp)],
 ) -> Result<(), ModuleError> {
+    // Ensure unique claim names
+    let mut seen = std::collections::HashSet::new();
+    let duplicates: Vec<String> = claim_modules
+        .iter()
+        .map(|(claim, _)| claim.metadata.name.clone())
+        .filter(|name| !seen.insert(name.clone()))
+        .collect();
+    if !duplicates.is_empty() {
+        return Err(ModuleError::DuplicateClaimNames(
+            duplicates.first().unwrap().clone(),
+        ));
+    }
+
     for (claim, module) in claim_modules {
         let deployment_variables: serde_yaml::Mapping = claim.spec.variables.clone();
         let variables: serde_json::Value = if deployment_variables.is_empty() {
@@ -1311,6 +1324,121 @@ output "bucket2__bucket_arn" {
 
         let result = validate_claim_modules(&claim_modules);
         assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_validate_claim_modules_duplicate_claim_names() {
+        let yaml_manifest_bucket1 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket1
+        spec:
+            region: N/A
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name"
+        "#;
+        let deployment_manifest_bucket1: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket1).unwrap();
+
+        let yaml_manifest_bucket2 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+        spec:
+            region: N/A
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-other-name"
+        "#;
+        let deployment_manifest_bucket2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket2).unwrap();
+
+        let yaml_manifest_bucket3 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+        spec:
+            region: N/A
+            moduleVersion: 0.0.21
+            variables:
+                bucketName: "some-name-duplicate"
+        "#;
+        let deployment_manifest_bucket3: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket3).unwrap();
+
+        let module_bucket_0_0_21 = ModuleResp {
+            s3_key: "s3bucket/s3bucket-0.0.21.zip".to_string(),
+            track: "dev".to_string(),
+            track_version: "dev#000.000.021".to_string(),
+            version: "0.0.21".to_string(),
+            timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+            module_name: "S3Bucket".to_string(),
+            module_type: "module".to_string(),
+            module: "s3bucket".to_string(),
+            description: "Some description...".to_string(),
+            reference: "".to_string(),
+            manifest: ModuleManifest {
+                metadata: Metadata {
+                    name: "metadata".to_string(),
+                },
+                api_version: "infraweave.io/v1".to_string(),
+                kind: "Module".to_string(),
+                spec: ModuleSpec {
+                    module_name: "S3Bucket".to_string(),
+                    version: Some("0.0.21".to_string()),
+                    description: "Some description...".to_string(),
+                    reference: "".to_string(),
+                    examples: None,
+                    cpu: None,
+                    memory: None,
+                },
+            },
+            tf_outputs: vec![],
+            tf_variables: vec![
+                TfVariable {
+                    name: "bucket_name".to_string(),
+                    default: None,
+                    description: Some("Name of the S3 bucket".to_string()),
+                    _type: Value::String("string".to_string()),
+                    nullable: Some(false),
+                    sensitive: Some(false),
+                },
+                TfVariable {
+                    _type: Value::String("map(string)".to_string()),
+                    name: "tags".to_string(),
+                    description: Some("Tags to apply to the S3 bucket".to_string()),
+                    default: serde_json::from_value(
+                        serde_json::json!({"Test": "hej", "AnotherTag": "something"}),
+                    )
+                    .unwrap(),
+                    nullable: Some(true),
+                    sensitive: Some(false),
+                },
+            ],
+            stack_data: None,
+            version_diff: None,
+            cpu: get_default_cpu(),
+            memory: get_default_memory(),
+        };
+
+        let claim_modules = [
+            (deployment_manifest_bucket1, module_bucket_0_0_21.clone()),
+            (deployment_manifest_bucket2, module_bucket_0_0_21.clone()),
+            (deployment_manifest_bucket3, module_bucket_0_0_21.clone()),
+        ];
+
+        let result = validate_claim_modules(&claim_modules);
+        assert_eq!(result.is_ok(), false); // Should fail because the claim name bucket2 is defined twice
+        let error = result.unwrap_err();
+        if let ModuleError::DuplicateClaimNames(duplicate_name) = error {
+            assert_eq!(duplicate_name, "bucket2");
+        } else {
+            panic!("Unexpected error variant: {:?}", error);
+        }
     }
 
     #[test]

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -733,7 +733,7 @@ fn validate_dependencies(
                     claim.metadata.name.clone(),
                     ref_kind.clone(),
                     ref_claim.clone(),
-                    ref_field.clone(),
+                    to_camel_case(&ref_field),
                 ));
             }
         }
@@ -1639,7 +1639,7 @@ output "bucket2__bucket_arn" {
             assert_eq!(source_claim, "bucket2");
             assert_eq!(kind_ref, "S3Bucket");
             assert_eq!(claim_ref, "bucket1a");
-            assert_eq!(variable_ref, "bucket_arn".to_string());
+            assert_eq!(variable_ref, "bucketArn".to_string());
         } else {
             panic!("Unexpected error variant: {:?}", error);
         }
@@ -1753,7 +1753,7 @@ output "bucket2__bucket_arn" {
             assert_eq!(source_claim, "bucket2");
             assert_eq!(kind_ref, "UnknownKind");
             assert_eq!(claim_ref, "bucket1a");
-            assert_eq!(variable_ref, "bucket_name".to_string());
+            assert_eq!(variable_ref, "bucketName".to_string());
         } else {
             panic!("Unexpected error variant: {:?}", error);
         }


### PR DESCRIPTION
This pull request introduces several new error variants to the `ModuleError` enum in the `env_common/src/errors.rs` file and adding logic and unit-tests in `env_common/src/logic/api_stack.rs`. These changes are aimed at providing more specific error messages for various issues that can occur within the stack module.

New error variants added to `ModuleError` enum along with adding validation logic for each error:

* [`OutputKeyNotFound`](diffhunk://#diff-c6d872fdae44796737bb215d4a4711cbc0ecc171a501c67c73a410b6174823daR43-R57): Added to handle cases where a specified output or variable cannot be found.
* [`StackClaimReferenceNotFound`](diffhunk://#diff-c6d872fdae44796737bb215d4a4711cbc0ecc171a501c67c73a410b6174823daR43-R57): Added to manage scenarios where a reference variable in a claim is invalid.
* [`DuplicateClaimNames`](diffhunk://#diff-c6d872fdae44796737bb215d4a4711cbc0ecc171a501c67c73a410b6174823daR43-R57): Added to identify and report duplicate claim names within the stack.
* [`CircularDependency`](diffhunk://#diff-c6d872fdae44796737bb215d4a4711cbc0ecc171a501c67c73a410b6174823daR43-R57): Added to detect and report circular dependencies between claims in the stack.
* [`SelfReferencingClaim`](diffhunk://#diff-c6d872fdae44796737bb215d4a4711cbc0ecc171a501c67c73a410b6174823daR43-R57): Added to handle cases where a claim references itself, which is invalid.