### PR TITLE
fix: bump zip to v2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6047,7 +6047,7 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
- "zip 2.2.1",
+ "zip 2.3.0",
 ]
 
 [[package]]
@@ -6661,9 +6661,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d52293fc86ea7cf13971b3bb81eb21683636e7ae24c729cdaf1b7c4157a352"
+checksum = "84e9a772a54b54236b9b744aaaf8d7be01b4d6e99725523cb82cb32d1c81b1d7"
 dependencies = [
  "arbitrary",
  "crc32fast",


### PR DESCRIPTION
To patch a vulnerability https://security.snyk.io/vuln/SNYK-RUST-ZIP-9460813