### PR TITLE
fix: use config table for get_projects

### DIFF
--- a/utils/src/provider_util.rs
+++ b/utils/src/provider_util.rs
@@ -10,7 +10,7 @@ pub async fn get_projects(
     provider: &dyn CloudProvider,
     query: Value,
 ) -> Result<Vec<ProjectData>, anyhow::Error> {
-    match provider.read_db_generic("deployments", &query).await {
+    match provider.read_db_generic("config", &query).await {
         Ok(items) => {
             let mut projects_vec: Vec<ProjectData> = vec![];
             for project in items {


### PR DESCRIPTION
This pull request includes a change to the `get_projects` function in the `utils/src/provider_util.rs` file. The change modifies the database collection being queried from "deployments" to "config", aligning with the new terraform structure.

* [`utils/src/provider_util.rs`](diffhunk://#diff-8527c4e2ff2034d60edcca767b3d738a50383c22f05285d30309a9c68d433bd0L13-R13): Changed the collection name in the `read_db_generic` method call from "deployments" to "config".