### PR TITLE
ci: add release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - skip-release
+    authors:
+      - bot-user
+  categories:
+    - title: "🚨 Breaking Changes"
+      labels:
+        - breaking-change
+    - title: "✨ New Features"
+      labels:
+        - enhancement
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+    - title: "⚙️ Maintenance & Refactoring"
+      labels:
+        - chore
+        - refactor
+    - title: "🚧 CI & Pipeline"
+      labels:
+        - ci
+        - pipeline
+    - title: "📝 Documentation Updates"
+      labels:
+        - documentation
+    - title: "📦 Dependencies"
+      labels:
+        - dependencies
+    - title: "🔀 Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
This pull request includes changes to the `.github/release.yml` file to improve the release notes management

Changelog improvements:

* Added exclusion of labels `ignore-for-release` and `skip-release` and author `bot-user` to the changelog.
* Defined multiple categories with corresponding labels for the changelog, including 
  * "🚨 Breaking Changes"
  * "✨ New Features"
  * "🐛 Bug Fixes"
  * "⚙️ Maintenance & Refactoring"
  * "🚧 CI & Pipeline"
  * "📝 Documentation Updates"
  * "📦 Dependencies"
  * "🔀 Other Changes".