### PR TITLE
fix: add RepositoryData in ProjectData

### DIFF
--- a/defs/src/deployment.rs
+++ b/defs/src/deployment.rs
@@ -110,11 +110,22 @@ pub struct Dependent {
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RepositoryData {
+    pub git_provider: String,
+    pub git_url: String,
+    pub repository_path: String,
+    #[serde(rename = "type")]
+    pub _type: String,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ProjectData {
     pub project_id: String,
     pub name: String,
     pub description: String,
     pub regions: Vec<String>,
+    pub repositories: Vec<RepositoryData>,
 }
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]


### PR DESCRIPTION
This pull request includes the addition of the `RepositoryData` struct and the modification of the `ProjectData` struct to include a list of repositories. This is used for configuring one or more repositories to a project.

Changes to `defs/src/deployment.rs`:

* Added `RepositoryData` struct with fields `git_provider`, `git_url`, `repository_path`, and `type`.
* Modified `ProjectData` struct to include a new field `repositories` which is a list of `RepositoryData`.