### PR TITLE
fix: restrict name and namespace to follow dns label naming convention

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -2,7 +2,7 @@ use env_common::interface::GenericCloudHandler;
 
 pub fn get_environment(environment_arg: &str) -> String {
     if !environment_arg.contains('/') {
-        format!("{}/infraweave_cli", environment_arg)
+        format!("cli/{}", environment_arg)
     } else {
         environment_arg.to_string()
     }

--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -493,10 +493,16 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                                 "{}/blob/{}/{}",
                                 repository_url, default_branch, active.path
                             );
+                            let namespace = deployment_claim
+                                .metadata
+                                .namespace
+                                .unwrap_or("default".to_string());
+                            // Prevent collision between repos by using repo_full_name
+                            let repo_full_name_dash = repo_full_name.replace("/", "-");
                             match run_claim(
                                 &handler,
                                 &yaml,
-                                &format!("git/{}", repo_full_name),
+                                &format!("github-{}/{}", repo_full_name_dash, namespace),
                                 command,
                                 flags,
                                 extra_data.clone(),
@@ -613,10 +619,16 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                                 "{}/blob/{}/{}",
                                 repository_url, default_branch, deleted.path
                             );
+                            let namespace = deployment_claim
+                                .metadata
+                                .namespace
+                                .unwrap_or("default".to_string());
+                            // Prevent collision between repos by using repo_full_name
+                            let repo_full_name_dash = repo_full_name.replace("/", "-");
                             match run_claim(
                                 &handler,
                                 &yaml,
-                                &format!("git/{}", repo_full_name),
+                                &format!("github-{}/{}", repo_full_name_dash, namespace),
                                 command,
                                 flags,
                                 extra_data.clone(),

--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -35,7 +35,7 @@ impl Deployment {
         stack: Option<&PyAny>,
     ) -> PyResult<Self> {
         let deployment_id = name.clone();
-        let reference = "python-script".to_string();
+        let reference = "python".to_string();
 
         match (module, stack) {
             (None, None) => Err(PyException::new_err(
@@ -217,6 +217,7 @@ async fn plan_or_apply_deployment(command: &str, deployment: &Deployment) -> Str
         extra_data: ExtraData::None,
     };
 
+    // TODO: Use run_claim() in api_infra.rs instead! (which has more verification)
     let job_id = submit_claim_job(&handler, &payload).await.unwrap(); // TODO: Handle with python error
 
     info!("Job ID: {}", job_id);

--- a/integration-tests/tests/infra.rs
+++ b/integration-tests/tests/infra.rs
@@ -37,7 +37,7 @@ mod infra_tests {
                     .map(|doc| serde_yaml::Value::deserialize(doc).unwrap_or("".into()))
                     .collect();
 
-            let environment = "playground".to_string();
+            let environment = "k8s-cluster-1/playground".to_string();
             let command = "apply".to_string();
             let flags = vec![];
             let (job_id, deployment_id) = match run_claim(
@@ -77,7 +77,7 @@ mod infra_tests {
             let deployment = deployment.unwrap();
             assert_eq!(deployment.deployment_id, "s3bucket/my-s3bucket2");
             assert_eq!(deployment.module, "s3bucket");
-            assert_eq!(deployment.environment, "playground");
+            assert_eq!(deployment.environment, "k8s-cluster-1/playground");
             assert_eq!(
                 deployment.reference,
                 "https://github.com/some-repo/some-path/claim.yaml"
@@ -113,7 +113,7 @@ mod infra_tests {
                     .map(|doc| serde_yaml::Value::deserialize(doc).unwrap_or("".into()))
                     .collect();
 
-            let environment = "playground".to_string();
+            let environment = "k8s-cluster-1/playground".to_string();
             let command = "apply".to_string();
             let flags = vec![];
             let (job_id, deployment_id) = match run_claim(
@@ -153,7 +153,7 @@ mod infra_tests {
             let deployment = deployment.unwrap();
             assert_eq!(deployment.deployment_id, "s3bucket/my-s3bucket2");
             assert_eq!(deployment.module, "s3bucket");
-            assert_eq!(deployment.environment, "playground");
+            assert_eq!(deployment.environment, "k8s-cluster-1/playground");
             assert_eq!(deployment.reference, "reference-fallback");
         })
         .await;

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -83,7 +83,7 @@ mod operator_tests {
 
             let deployment_id = "test-bucket123";
             let namespace = "default";
-            let environment = format!("my-k8s-cluster-1/{}", namespace);
+            let environment = format!("k8s-cluster-id/{}", namespace);
 
             let yaml_claim = format!(
                 r#"


### PR DESCRIPTION
This pull request improves deployment separation using validation for a stricter definition of namespaces.

### Environment Handling and Formatting:

* Changed the format depending on what initiated the job:
  * cli => `cli/{namespace}`
  * python => `python/{namespace}`
  * kubernetes => `k8s-{cluster-id}/{namespace}` (to not collide between clusters)
  * github => `github-{full-repo-name}/{namespace}` (to not collide between repos)

### Validation:

* [`env_common/src/logic/api_infra.rs`](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R46-R53): Added `validate_name` function to ensure deployment names and namespaces meet specific criteria and integrated it into the `run_claim` function. [[1]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R46-R53) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R235-R248)
* Criterias:
  * Only a-z, 0-9, and -
  * Starts/ends with alphanumeric
  * Length between 1 and 63 characters
