### PR TITLE
fix: swap deployment_id and environment

### DIFF
--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -197,8 +197,8 @@ Environment: **{}**
 ```
                 "#,
                     github_event.job_details.file_path,
-                    github_event.job_details.environment,
                     github_event.job_details.deployment_id,
+                    github_event.job_details.environment,
                     github_event.job_details.manifest_yaml,
                     information
                 )),


### PR DESCRIPTION
This pull request includes a minor change to the `gitops/src/main.rs` file. The change reorders the parameters in a string formatting function call to ensure that `github_event.job_details.environment` is placed correctly.

* [`gitops/src/main.rs`](diffhunk://#diff-dc5453bb76c985775aedb0cff6bd802776b1a286c35ee865822c0cd8a107a90cL200-R201): Reordered the parameters in the string formatting function call to ensure `github_event.job_details.environment` is correctly positioned.