### PR TITLE
fix: improve github check run formatting

### DIFF
--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -456,7 +456,8 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                     };
                     if let ExtraData::GitHub(ref mut github_check_run) = extra_data {
                         github_check_run.job_details.file_path = active.path.clone();
-                        github_check_run.job_details.manifest_yaml = canonical.clone();
+                        github_check_run.job_details.manifest_yaml =
+                            canonical.clone().trim_start_matches("---").to_string();
                         let region = if let Some(region) = yaml["spec"]["region"].as_str() {
                             region.to_string()
                         } else {
@@ -479,7 +480,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
 ```yaml
 {}
 ```"#,
-                                canonical
+                                canonical.trim_start_matches("---").to_string()
                             )),
                             annotations: None,
                         });
@@ -578,7 +579,8 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                     };
                     if let ExtraData::GitHub(ref mut github_check_run) = extra_data {
                         github_check_run.job_details.file_path = deleted.path.clone();
-                        github_check_run.job_details.manifest_yaml = canonical.clone();
+                        github_check_run.job_details.manifest_yaml =
+                            canonical.clone().trim_start_matches("---").to_string();
                         let region = if let Some(region) = yaml["spec"]["region"].as_str() {
                             region.to_string()
                         } else {
@@ -601,7 +603,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
 ```yaml
 {}
 ```"#,
-                                canonical
+                                canonical.trim_start_matches("---").to_string()
                             )),
                             annotations: None,
                         });

--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -184,13 +184,13 @@ File: **{}**
 Deployment ID: **{}**
 Environment: **{}**
 
-# Claim
+## Claim
 
 ```yaml
 {}
 ```
 
-# Information
+## Information
 
 ```diff
 {}


### PR DESCRIPTION
This pull request includes changes to the `gitops/src/github.rs` and `gitops/src/main.rs` files to improve the handling of YAML data and update documentation formatting.

Improvements to YAML data handling:

* [`gitops/src/github.rs`](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L459-R460): Modified the `handle_process_push_event` function to trim the leading "---" from the `canonical` string before using it in `manifest_yaml` and other instances. [[1]](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L459-R460) [[2]](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L482-R483) [[3]](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L581-R583) [[4]](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L604-R606)

Documentation formatting updates:

* [`gitops/src/main.rs`](diffhunk://#diff-dc5453bb76c985775aedb0cff6bd802776b1a286c35ee865822c0cd8a107a90cL187-R193): Changed the headers from `#` to `##` for better structure and readability in the deployment and environment documentation sections.