### PR TITLE
fix: add python error output

### DIFF
--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -185,8 +185,14 @@ async fn run_job(
                 &status
             };
             println!(
-                "Finished {} with status {}! (job_id: {})",
-                command, status, job_id
+                "Finished {} with status {}! (job_id: {})\n{}",
+                command,
+                status,
+                job_id,
+                deployment_job_result
+                    .as_ref()
+                    .map(|d| d.error_text.clone())
+                    .unwrap_or_else(|| "No error_text".to_string())
             );
             final_status = status.to_string();
             deployment_result = deployment_job_result;


### PR DESCRIPTION
This pull request includes changes to the `infraweave_py/src/deployment.rs` file to improve error handling and provide more detailed information in deployment operations. The most important changes include updating the `run_job` function to return additional deployment details and modifying the `apply`, `plan`, and `destroy` methods to handle these details.

Enhancements to error handling and deployment information:

* Updated imports to include `DeploymentResp` in `infraweave_py/src/deployment.rs` to handle additional deployment details.
* Modified the `apply`, `plan`, and `destroy` methods to handle the additional deployment details returned by `run_job` and provide more specific error messages. [[1]](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5L101-R111) [[2]](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5L114-R128) [[3]](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5L130-R158)
* Updated the `run_job` function to return a tuple that includes `DeploymentResp` for more detailed deployment information. [[1]](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5L130-R158) [[2]](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5R175-R178) [[3]](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5R192-R198)