### PR TITLE
fix: improve module claim validation for stacks

### DIFF
--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -55,6 +55,9 @@ pub enum ModuleError {
     #[error("The stack claim \"{1}\" of kind \"{0}\" has an invalid reference \"{2}\" to itself")]
     SelfReferencingClaim(String, String, String),
 
+    #[error("Variable name casing mismatch in claim '{0}': Provided '{1}', expected '{2}'")]
+    VariableNameCasingMismatch(String, String, String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -55,9 +55,6 @@ pub enum ModuleError {
     #[error("The stack claim \"{1}\" of kind \"{0}\" has an invalid reference \"{2}\" to itself")]
     SelfReferencingClaim(String, String, String),
 
-    #[error("Variable name casing mismatch in claim '{0}': Provided '{1}', expected '{2}'")]
-    VariableNameCasingMismatch(String, String, String),
-
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -688,21 +688,7 @@ pub fn validate_claim_modules(
         };
         let variables = env_utils::convert_first_level_keys_to_snake_case(&provided_variables);
 
-        // Check that provided variable names match the original casing exactly
-        if let Some(provided_vars) = provided_variables.as_object() {
-            for provided_name in provided_vars.keys() {
-                // Convert the provided key to camelCase
-                let camel_case = env_utils::to_camel_case(provided_name);
-                // If the conversion changes the key, it indicates snake_case formatting.
-                if provided_name != &camel_case {
-                    return Err(ModuleError::VariableNameCasingMismatch(
-                        claim.metadata.name.clone(),
-                        provided_name.clone(),
-                        camel_case,
-                    ));
-                }
-            }
-        }
+        env_utils::verify_variable_claim_casing(&claim, &provided_variables)?;
 
         env_utils::verify_variable_existence_and_type(&module, &variables)?;
 

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -681,12 +681,28 @@ pub fn validate_claim_modules(
 
     for (claim, module) in claim_modules {
         let deployment_variables: serde_yaml::Mapping = claim.spec.variables.clone();
-        let variables: serde_json::Value = if deployment_variables.is_empty() {
+        let provided_variables: serde_json::Value = if deployment_variables.is_empty() {
             serde_json::json!({})
         } else {
             serde_json::to_value(&deployment_variables).unwrap()
         };
-        let variables = env_utils::convert_first_level_keys_to_snake_case(&variables);
+        let variables = env_utils::convert_first_level_keys_to_snake_case(&provided_variables);
+
+        // Check that provided variable names match the original casing exactly
+        if let Some(provided_vars) = provided_variables.as_object() {
+            for provided_name in provided_vars.keys() {
+                // Convert the provided key to camelCase
+                let camel_case = env_utils::to_camel_case(provided_name);
+                // If the conversion changes the key, it indicates snake_case formatting.
+                if provided_name != &camel_case {
+                    return Err(ModuleError::VariableNameCasingMismatch(
+                        claim.metadata.name.clone(),
+                        provided_name.clone(),
+                        camel_case,
+                    ));
+                }
+            }
+        }
 
         env_utils::verify_variable_existence_and_type(&module, &variables)?;
 
@@ -2149,7 +2165,7 @@ output "bucket2__bucket_arn" {
       moduleVersion: 0.0.1
       variables:
         instanceType: "t2.micro"
-        vpc_id: "{{ VPC::vpc1::vpcId }}"
+        vpcId: "{{ VPC::vpc1::vpcId }}"
     "#;
         let deployment_manifest_ec2: DeploymentManifest =
             serde_yaml::from_str(yaml_manifest_ec2).unwrap();
@@ -2330,6 +2346,71 @@ output "bucket2__bucket_arn" {
 
         let result = validate_claim_modules(&claim_modules);
         assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_validate_claim_modules_nonexisting_variable_wrongcase() {
+        let yaml_manifest_bucket2 = r#"
+        apiVersion: infraweave.io/v1
+        kind: S3Bucket
+        metadata:
+            name: bucket2
+        spec:
+            region: eu-west-1
+            moduleVersion: 0.0.21
+            variables:
+                bucket_name: "some-name"
+        "#;
+        let deployment_manifest_bucket2: DeploymentManifest =
+            serde_yaml::from_str(yaml_manifest_bucket2).unwrap();
+
+        let claim_modules = [(
+            deployment_manifest_bucket2,
+            ModuleResp {
+                s3_key: "s3bucket/s3bucket-0.0.21.zip".to_string(),
+                track: "dev".to_string(),
+                track_version: "dev#000.000.021".to_string(),
+                version: "0.0.21".to_string(),
+                timestamp: "2024-10-10T22:23:14.368+02:00".to_string(),
+                module_name: "S3Bucket".to_string(),
+                module_type: "module".to_string(),
+                module: "s3bucket".to_string(),
+                description: "Some description...".to_string(),
+                reference: "".to_string(),
+                manifest: ModuleManifest {
+                    metadata: Metadata {
+                        name: "metadata".to_string(),
+                    },
+                    api_version: "infraweave.io/v1".to_string(),
+                    kind: "Module".to_string(),
+                    spec: ModuleSpec {
+                        module_name: "S3Bucket".to_string(),
+                        version: Some("0.0.21".to_string()),
+                        description: "Some description...".to_string(),
+                        reference: "".to_string(),
+                        examples: None,
+                        cpu: None,
+                        memory: None,
+                    },
+                },
+                tf_outputs: vec![],
+                tf_variables: vec![TfVariable {
+                    name: "bucket_name".to_string(),
+                    default: None,
+                    description: Some("Name of the S3 bucket".to_string()),
+                    _type: Value::String("string".to_string()),
+                    nullable: Some(false),
+                    sensitive: Some(false),
+                }],
+                stack_data: None,
+                version_diff: None,
+                cpu: get_default_cpu(),
+                memory: get_default_memory(),
+            },
+        )];
+
+        let result = validate_claim_modules(&claim_modules);
+        assert_eq!(result.is_err(), true); // it is expecting camelCase, however it is entered as snake_case
     }
 
     fn get_example_claim_modules() -> Vec<(DeploymentManifest, ModuleResp)> {

--- a/integration-tests/claims/s3bucket-dev-claim-snake_case.yaml
+++ b/integration-tests/claims/s3bucket-dev-claim-snake_case.yaml
@@ -1,0 +1,13 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: my-s3bucket2
+spec:
+  region: us-west-2
+  moduleVersion: 0.1.2-dev+test.10
+  reference: https://github.com/some-repo/some-path/claim.yaml
+  variables:
+    bucket_name: dev-my-unique-bucket-name-1234-playground
+    tags:
+      Name234: my-s3bucket2
+      Environment43: testtest3

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -38,7 +38,10 @@ pub use schema_validation::{validate_module_schema, validate_policy_schema};
 pub use stack::read_stack_directory;
 pub use string_utils::{to_camel_case, to_snake_case};
 pub use time::{epoch_to_timestamp, get_epoch, get_timestamp};
-pub use variables::{verify_required_variables_are_set, verify_variable_existence_and_type};
+pub use variables::{
+    verify_required_variables_are_set, verify_variable_claim_casing,
+    verify_variable_existence_and_type,
+};
 pub use versioning::{
     get_version_track, semver_parse, semver_parse_without_build, zero_pad_semver,
 };

--- a/utils/src/variables.rs
+++ b/utils/src/variables.rs
@@ -1,4 +1,27 @@
-use env_defs::ModuleResp;
+use env_defs::{DeploymentManifest, ModuleResp};
+
+pub fn verify_variable_claim_casing(
+    claim: &DeploymentManifest,
+    provided_variables: &serde_json::Value,
+) -> Result<(), anyhow::Error> {
+    // Check that provided variable names match the original casing exactly
+    if let Some(provided_vars) = provided_variables.as_object() {
+        for provided_name in provided_vars.keys() {
+            // Convert the provided key to camelCase
+            let camel_case = crate::to_camel_case(provided_name);
+            // If the conversion changes the key, it indicates snake_case formatting.
+            if provided_name != &camel_case {
+                return Err(anyhow::anyhow!(
+                    "Variable name casing mismatch in claim '{}': Provided '{}', expected '{}'",
+                    claim.metadata.name.clone(),
+                    provided_name.clone(),
+                    camel_case,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
 
 pub fn verify_variable_existence_and_type(
     module: &ModuleResp,


### PR DESCRIPTION
This pull request introduces several changes to enforce camelCase formatting for variable names and includes new tests to verify this behavior. The most important changes include adding a new function to check variable name casing, updating existing functions to use this new check, and adding tests to ensure the correct functionality.

### Enforcing camelCase formatting for variable names:

* [`env_common/src/logic/api_infra.rs`](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L7-R8): Added `verify_variable_claim_casing` to the list of imports and included a call to this function in `run_claim` to ensure provided claim variables are in camelCase. [[1]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L7-R8) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R199-R201)
* [`env_common/src/logic/api_stack.rs`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L684-R691): Updated `validate_claim_modules` to use `verify_variable_claim_casing` and changed variable names to camelCase in the example manifest. [[1]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L684-R691) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L2152-R2154)

### Updating variable handling:

* [`env_common/src/logic/api_infra.rs`](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L91-R94): Renamed variables to `provided_variables` to clarify their purpose and updated functions to use this new name. [[1]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L91-R94) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L116-R121)
* [`utils/src/variables.rs`](diffhunk://#diff-aaaf7db89574cb181aa0efdcd097092cd0c091792c2f7b19062a48bb65c22539L1-R24): Added `verify_variable_claim_casing` function to check that provided variable names match the expected camelCase format.

### Adding tests:

* [`integration-tests/tests/infra.rs`](diffhunk://#diff-3c1b043c8b2109fa53325fba609bb184b48620608b1365aed188b16344edde3fR89-R134): Added a new test `test_infra_apply_s3bucket_dev_snake_case` to verify that claims using snake_case variable names fail as expected.
* [`integration-tests/claims/s3bucket-dev-claim-snake_case.yaml`](diffhunk://#diff-13d2ce2ef39204e11d515828d3e327662b5b2fbbd54a53823185e24d7e17f2ddR1-R13): Added a new test claim file with snake_case variable names to test the new validation.

### Updating utilities:

* [`utils/src/lib.rs`](diffhunk://#diff-2a68e14bf95d2e3c7c7c72b92741c10dc2ea9027388a899a65a9a73b4152b80fL41-R44): Exported the new `verify_variable_claim_casing` function.