### PR TITLE
fix: add debug logs for module variable/output hcl parsing

### DIFF
--- a/utils/src/module.rs
+++ b/utils/src/module.rs
@@ -1,6 +1,7 @@
 use env_defs::TfOutput;
 use env_defs::TfVariable;
 use hcl::de;
+use log::debug;
 use std::collections::HashMap;
 use std::io::{self, ErrorKind};
 
@@ -106,6 +107,7 @@ pub fn get_variables_from_tf_files(contents: &str) -> Result<Vec<TfVariable>, St
                     sensitive: Some(sensitive),
                 };
 
+                debug!("Parsing variable block {:?} as {:?}", var_attrs, variable);
                 variables.push(variable);
             }
         }
@@ -144,6 +146,7 @@ pub fn get_outputs_from_tf_files(contents: &str) -> Result<Vec<env_defs::TfOutpu
                 value: attrs.get("value").unwrap_or(&"".to_string()).to_string(),
             };
 
+            debug!("Parsing output block {:?} as {:?}", block, output);
             outputs.push(output);
         }
     }


### PR DESCRIPTION
This pull request includes changes to the `utils/src/module.rs` file to add debug logging for better traceability.

Logging enhancements:

* [`utils/src/module.rs`](diffhunk://#diff-5811a3176b70706d138dd7d0267d3e2000a04da5c568c9cb49430e477de53e54R110): Added debug logging to the `get_variables_from_tf_files` function to log variable parsing details.
* [`utils/src/module.rs`](diffhunk://#diff-5811a3176b70706d138dd7d0267d3e2000a04da5c568c9cb49430e477de53e54R149): Added debug logging to the `get_outputs_from_tf_files` function to log output parsing details.