### PR TITLE
fix: make TfVariable properties non-null

### DIFF
--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -6,15 +6,15 @@ pub fn get_module_identifier(module: &str, track: &str) -> String {
 }
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct TfVariable {
     pub name: String,
     #[serde(rename = "type")]
     pub _type: serde_json::Value,
-    pub default: Option<serde_json::Value>,
-    pub description: Option<String>,
-    pub nullable: Option<bool>,
-    pub sensitive: Option<bool>,
+    pub default: serde_json::Value,
+    pub description: String,
+    pub nullable: bool,
+    pub sensitive: bool,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -484,16 +484,16 @@ fn is_all_module_example_variables_valid(
             return (false, error); // Example-variable does not exist
         }
         let tf_variable = tf_variable.unwrap();
-        let is_nullable = tf_variable.nullable.unwrap_or(false);
-        if tf_variable.default.is_none() && !is_nullable && value.is_null() {
+        let is_nullable = tf_variable.nullable;
+        if tf_variable.default == serde_json::Value::Null && !is_nullable && value.is_null() {
             let error = format!("Required variable {} is null but mandatory", key_str);
             return (false, error); // Required variable is null
         }
     }
     // Check that all required variables are present in example_variables
     for tf_variable in tf_variables.iter() {
-        let is_nullable = tf_variable.nullable.unwrap_or(false);
-        if tf_variable.default.is_none() && !is_nullable {
+        let is_nullable = tf_variable.nullable;
+        if tf_variable.default == serde_json::Value::Null && !is_nullable {
             // This is a required variable
             let variable_exists = example_variables
                 .contains_key(&serde_yaml::Value::String(tf_variable.name.clone()));
@@ -562,26 +562,26 @@ portMapping:
         let tf_variables = vec![
             TfVariable {
                 name: "bucket_name".to_string(),
-                description: Some("The name of the bucket".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "The name of the bucket".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
             },
             TfVariable {
                 name: "tags".to_string(),
-                description: Some("The tags to apply to the bucket".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "The tags to apply to the bucket".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("map".to_string()),
             },
             TfVariable {
                 name: "port_mapping".to_string(),
-                description: Some("The port mapping".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "The port mapping".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("list".to_string()),
             },
         ];
@@ -607,18 +607,18 @@ port_mapping:
         let tf_variables = vec![
             TfVariable {
                 name: "instance_name".to_string(),
-                description: Some("Instance name".to_string()),
-                default: Some(serde_json::Value::String("my-instance".to_string())),
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "Instance name".to_string(),
+                default: serde_json::Value::String("my-instance".to_string()),
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
             },
             TfVariable {
                 name: "bucket_name".to_string(),
-                description: Some("Bucket name".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "Bucket name".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
             },
         ];
@@ -638,18 +638,18 @@ bucket_name: some-bucket-name
         let tf_variables = vec![
             TfVariable {
                 name: "instance_name".to_string(),
-                description: Some("Instance name".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "Instance name".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
             },
             TfVariable {
                 name: "bucket_name".to_string(),
-                description: Some("Bucket name".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "Bucket name".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
             },
         ];
@@ -669,18 +669,18 @@ bucket_name: some-bucket-name
         let tf_variables = vec![
             TfVariable {
                 name: "instance_name".to_string(),
-                description: Some("Instance name".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(true),
+                description: "Instance name".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: true,
                 _type: serde_json::Value::String("string".to_string()),
             },
             TfVariable {
                 name: "bucket_name".to_string(),
-                description: Some("Bucket name".to_string()),
-                default: None,
-                sensitive: Some(false),
-                nullable: Some(false),
+                description: "Bucket name".to_string(),
+                default: serde_json::Value::Null,
+                sensitive: false,
+                nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
             },
         ];
@@ -699,10 +699,10 @@ bucket_name: some-bucket-name
     fn test_is_example_variables_valid_false_required_missing() {
         let tf_variables = vec![TfVariable {
             name: "bucket_name".to_string(),
-            description: Some("The name of the bucket".to_string()),
-            default: None,
-            sensitive: Some(false),
-            nullable: Some(false),
+            description: "The name of the bucket".to_string(),
+            default: serde_json::Value::Null,
+            sensitive: false,
+            nullable: false,
             _type: serde_json::Value::String("string".to_string()),
         }];
         let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
@@ -725,10 +725,10 @@ port_mapping:
     fn test_is_example_variables_snake_case_false() {
         let tf_variables = vec![TfVariable {
             name: "bucketName".to_string(),
-            description: Some("Bucket name".to_string()),
-            default: None,
-            sensitive: Some(false),
-            nullable: Some(false),
+            description: "Bucket name".to_string(),
+            default: serde_json::Value::Null,
+            sensitive: false,
+            nullable: false,
             _type: serde_json::Value::String("string".to_string()),
         }];
         let example_variables = serde_yaml::from_str::<serde_yaml::Value>(

--- a/integration-tests/tests/stack.rs
+++ b/integration-tests/tests/stack.rs
@@ -282,37 +282,38 @@ mod stack_tests {
             assert_eq!(stacks[0].tf_variables[0]._type, "list(string)");
             assert_eq!(
                 stacks[0].tf_variables[0].default,
-                Some(serde_json::json!(["dev1.example.com", "dev2.example.com"]))
+                serde_json::json!(["dev1.example.com", "dev2.example.com"])
             );
 
             assert_eq!(stacks[0].tf_variables[1].name, "route1__tags");
             assert_eq!(stacks[0].tf_variables[1]._type, "map(string)");
             assert_eq!(
                 stacks[0].tf_variables[1].default,
-                Some(serde_json::json!({"Name": "example.com", "Environment": "dev"}))
+                serde_json::json!({"Name": "example.com", "Environment": "dev"})
             );
 
             assert_eq!(stacks[0].tf_variables[2].name, "route1__ttl");
             assert_eq!(stacks[0].tf_variables[2]._type, "number");
-            assert_eq!(stacks[0].tf_variables[2].default, Some(300.into())); // Default value in variables.tf is null, but 300 is set in claim
+            assert_eq!(stacks[0].tf_variables[2].default, serde_json::json!(300)); // Default value in variables.tf is null, but 300 is set in claim
 
             assert_eq!(stacks[0].tf_variables[3].name, "route2__records");
             assert_eq!(stacks[0].tf_variables[3]._type, "list(string)");
             assert_eq!(
                 stacks[0].tf_variables[3].default,
-                Some(serde_json::json!(["uat1.example.com", "uat2.example.com"]))
+                serde_json::json!(["uat1.example.com", "uat2.example.com"])
             ); // Default value in variables.tf is set, but overriding in claim
 
             assert_eq!(stacks[0].tf_variables[4].name, "route2__tags");
             assert_eq!(stacks[0].tf_variables[4]._type, "map(string)");
             assert_eq!(
                 stacks[0].tf_variables[4].default,
-                Some(serde_json::json!({"override": true}))
+                serde_json::json!({"override": true})
             ); // Default value in variables.tf is set, but overriding in claim
 
             assert_eq!(stacks[0].tf_variables[5].name, "route2__ttl");
             assert_eq!(stacks[0].tf_variables[5]._type, "number");
-            assert_eq!(stacks[0].tf_variables[5].default, None); // No default value in variables.tf and nothing is set in claim
+            assert_eq!(stacks[0].tf_variables[5].default, serde_json::Value::Null);
+            // No default value in variables.tf and nothing is set in claim
         })
         .await;
     }

--- a/utils/src/variables.rs
+++ b/utils/src/variables.rs
@@ -100,7 +100,10 @@ pub fn verify_required_variables_are_set(
     let module_variables = &module.tf_variables;
     let variables_map = variables.as_object().unwrap();
     for variable in module_variables {
-        if variable.default.is_none() && !variables_map.contains_key(variable.name.as_str()) {
+        if variable.default == serde_json::Value::Null
+            && variable.nullable == false
+            && !variables_map.contains_key(variable.name.as_str())
+        {
             missing_variables.push(variable.name.clone());
         }
     }
@@ -283,20 +286,20 @@ mod tests {
             ],
             tf_variables: vec![
                 TfVariable {
-                    default: None,
+                    default: serde_json::Value::Null,
                     name: "bucket_name".to_string(),
-                    description: Some("Name of the S3 bucket".to_string()),
+                    description: "Name of the S3 bucket".to_string(),
                     _type: Value::String("string".to_string()),
-                    nullable: Some(false),
-                    sensitive: Some(false),
+                    nullable: false,
+                    sensitive: false,
                 },
                 TfVariable {
-                    default: None,
+                    default: serde_json::Value::Null,
                     name: "enable_acl".to_string(),
-                    description: Some("Enable ACL for the S3 bucket".to_string()),
+                    description: "Enable ACL for the S3 bucket".to_string(),
                     _type: Value::Bool(false),
-                    nullable: Some(false),
-                    sensitive: Some(false),
+                    nullable: false,
+                    sensitive: false,
                 },
                 TfVariable {
                     default: serde_json::from_value(
@@ -304,10 +307,10 @@ mod tests {
                     )
                     .unwrap(),
                     name: "tags".to_string(),
-                    description: Some("Tags to apply to the S3 bucket".to_string()),
+                    description: "Tags to apply to the S3 bucket".to_string(),
                     _type: Value::String("map(string)".to_string()),
-                    nullable: Some(true),
-                    sensitive: Some(false),
+                    nullable: true,
+                    sensitive: false,
                 },
             ],
             stack_data: None,


### PR DESCRIPTION
This pull request includes several changes to the `TfVariable` struct and its usage across various files to improve consistency and simplify the codebase. The most important changes include modifying the `TfVariable` struct to make certain fields non-optional (since it did not provide any function) and updating the related logic to handle these changes. This simplifies logic and reduces error prone checks since e.g. `default` could be both `None` or `Some(serde_json::Value::Null)`.

Changes to `TfVariable` struct:

* [`defs/src/module.rs`](diffhunk://#diff-0501e3350bc6a9d308597a280a9c7c83e1c57d134d389b1780a3bcf522bb29a2L9-R17): Added `PartialEq` derive to `TfVariable` and made `default`, `description`, `nullable`, and `sensitive` fields non-optional.

Updates to logic handling `TfVariable`:

* [`env_common/src/logic/api_module.rs`](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9L487-R496): Updated the logic in `is_all_module_example_variables_valid` function to handle non-optional `default` and `nullable` fields.
* [`env_common/src/logic/api_stack.rs`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L515-R519): Removed checks for `None` values and updated logic to handle non-optional `default` and `description` fields across multiple functions, including `generate_terraform_variable_single`, `generate_dependency_map`, and `collect_module_variables`. 

Updates to test cases:

* [`env_common/src/logic/api_stack.rs`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L948-R998): Updated test cases to reflect changes in `TfVariable` struct, ensuring `default`, `description`, `nullable`, and `sensitive` fields are non-optional. 