### PR TITLE
fix: only parse root level tf module blocks

### DIFF
--- a/utils/src/file.rs
+++ b/utils/src/file.rs
@@ -208,7 +208,7 @@ pub fn read_tf_directory(directory: &Path) -> io::Result<String> {
     let mut combined_contents = String::new();
 
     for entry in WalkDir::new(directory)
-        .max_depth(10)
+        .max_depth(1)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| {


### PR DESCRIPTION
This pull request includes a change to the `read_tf_directory` function in the `utils/src/file.rs` file to limit the directory traversal depth, which resolves a bug where submodules were included that resulted in incorrect variables.

* [`utils/src/file.rs`](diffhunk://#diff-7f5d2b7e915c9b4314806364c4159b29c1a6709e1af3931dc956e02d52d0b928L211-R211): Modified the `read_tf_directory` function to reduce the maximum directory traversal depth from 10 to 1.