### PR TITLE
docs: update CONTRIBUTING.md with colima tip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,9 @@ Thank you for your interest in contributing to Infraweave! We value your contrib
      ```bash
      make test
      ```
+     Note that the integration-tests requires docker.
+
+     > If you are on a mac with apple silicon you can use `colima start --cpu 5 --memory 10 --arch aarch64 --vm-type=vz --vz-rosetta --mount-type virtiofs`
 
 4. **Explore the Code**:
    - Familiarize yourself with the project structure and documentation.


### PR DESCRIPTION
This pull request includes an update to the `CONTRIBUTING.md` file to provide additional information for running integration tests. The most important change is the addition of instructions for macOS users with Apple Silicon on how to start Colima with specific parameters.

Documentation update:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R26-R28): Added a note that integration tests require Docker and provided specific instructions for starting Colima on macOS with Apple Silicon.