### PR TITLE
fix: add stack example validation on publish

### DIFF
--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -475,7 +475,10 @@ fn is_all_module_example_variables_valid(
         let key_str = key.as_str().unwrap();
         // Check if variable is snake_case
         if key_str != env_utils::to_snake_case(key_str) {
-            let error = format!("Example variable {} is not snake_case", key_str);
+            let error = format!(
+                "Example variable {} is not snake_case like the terraform variable",
+                key_str
+            );
             return (false, error); // Example-variable is not snake_case
         }
         let tf_variable = tf_variables.iter().find(|&x| x.name == key_str);

--- a/integration-tests/stacks/bucketcollection-dev/bucket1a.yaml
+++ b/integration-tests/stacks/bucketcollection-dev/bucket1a.yaml
@@ -6,7 +6,6 @@ spec:
   moduleVersion: 0.1.2-dev+test.10
   region: N/A
   variables:
-    bucketName: my-temp-bucket1a
     tags:
       Name234: my-s3bucket-bucket1a
       Environment43: dev

--- a/integration-tests/stacks/bucketcollection-dev/bucket2.yaml
+++ b/integration-tests/stacks/bucketcollection-dev/bucket2.yaml
@@ -7,8 +7,3 @@ spec:
   region: N/A
   variables:
     bucketName: "{{ S3Bucket::bucket1a::bucketName }}-after"
-    tags:
-      Name234: my-s3bucket
-      Tjoho: "This is cool"
-      Environment43: dev
-      PreviousBucket: "{{ S3Bucket::bucket1a::bucketArn }}"


### PR DESCRIPTION
This pull request introduces several significant changes to the `env_common/src/logic/api_stack.rs` file, focusing on improving the validation and handling of module example variables. 
### Validation Enhancements:

* Added `validate_examples` function to validate example variables against Terraform variables.
* Introduced `is_all_module_example_variables_valid` function to check the validity of all module example variables.

### Function Modifications:

* Updated `publish_stack` function to include a call to `validate_examples`.
* Modified `generate_terraform_variable_single` function to include `nullable` and `sensitive` attributes in the generated Terraform variable string.

### Test Enhancements:

* Added new test cases to validate the functionality of `is_all_module_example_variables_valid`.

### Error Message Improvement:

* Improved error message in `is_all_module_example_variables_valid` to provide more context when an example variable is not snake_case.

### Integration Test Adjustments:
* [`integration-tests/stacks/bucketcollection-dev/bucket1a.yaml`](diffhunk://#diff-1ad298686d79a4be8d767f072a9b75ff32e0196673bd60418df94e44954aa1cbL9): Removed the `bucketName` variable from the example to align with the new validation logic.
* [`integration-tests/stacks/bucketcollection-dev/bucket2.yaml`](diffhunk://#diff-c99c9dc1906c7fb4783c3f20f95aa23af4a576672f97490f47768bb7b5ddd3e2L10-L14): Removed the `tags` from the example to align with the new validation logic.