### PR TITLE
fix: remove warnings

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use clap::{App, Arg, SubCommand};
 use cli::{current_region_handler, get_environment, run_claim_file};
 use env_common::{
@@ -10,7 +8,7 @@ use env_common::{
         publish_policy, publish_stack,
     },
 };
-use env_defs::{CloudProvider, CloudProviderCommon, ExtraData, ProjectData};
+use env_defs::{CloudProvider, ExtraData};
 use env_utils::setup_logging;
 
 use log::{error, info};

--- a/env_common/src/logic/api_deployment.rs
+++ b/env_common/src/logic/api_deployment.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use env_defs::{get_deployment_identifier, CloudProvider, DeploymentResp, ProjectData};
+use env_defs::{get_deployment_identifier, CloudProvider, DeploymentResp};
 use env_utils::merge_json_dicts;
 
 use crate::interface::GenericCloudHandler;

--- a/terraform_runner/src/module.rs
+++ b/terraform_runner/src/module.rs
@@ -1,6 +1,6 @@
 use env_common::DeploymentStatusHandler;
 use env_defs::{ApiInfraPayload, CloudProvider};
-use std::{path::Path, process::exit};
+use std::path::Path;
 
 use env_common::{get_module_download_url, interface::GenericCloudHandler};
 


### PR DESCRIPTION
This pull request includes several changes to the import statements across multiple files to remove unused imports and streamline the code.

Optimization of import statements:

* [`cli/src/main.rs`](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL1-L2): Removed the unused import of `std::vec` and `CloudProviderCommon`, `ProjectData` from `env_defs`. [[1]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL1-L2) [[2]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL13-R11)
* [`env_common/src/logic/api_deployment.rs`](diffhunk://#diff-424aae68793ef7c4d7cfbf58f7d7193746f4a8a0c9140f5f1944e213745a33e3L3-R3): Removed the unused import of `ProjectData` from `env_defs`.
* [`terraform_runner/src/module.rs`](diffhunk://#diff-e5e1ccfb2bda608fb74f3ad98d11c61357bd0123976b29ef6ca6fb49e9dbdfcbL3-R3): Removed the unused import of `process::exit` from `std`.