### PR TITLE
fix: add python deployment outputs attribute

### DIFF
--- a/infraweave_py/test.py
+++ b/infraweave_py/test.py
@@ -27,6 +27,8 @@ bucket1 = Deployment(
     module=s3bucket,
 )
 
+print(bucket1.outputs)
+
 bucket1.set_variables(
     bucket_name="my-bucket12347ydfs3",
     enable_acl=False,
@@ -34,6 +36,7 @@ bucket1.set_variables(
 
 try:
     bucket1.apply()
+    print(bucket1.outputs)
     # Run some tests here
 except Exception as e:
     print(f"An error occurred: {e}")


### PR DESCRIPTION
This pull request includes several updates to the `infraweave_py` project, focusing on enhancing the `Deployment` struct and its methods, as well as updating the test file to reflect these changes. The most important changes include adding a new field to the `Deployment` struct, modifying methods to update this field, and adding a new getter method.

Enhancements to `Deployment` struct and methods:

* [`infraweave_py/src/deployment.rs`](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5R29): Added a new property `last_deployment` to the `Deployment` struct to store the last deployment response. Updated the `apply` and `destroy` methods to modify this field appropriately.
* [`infraweave_py/src/deployment.rs`](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5L105-R107): Changed the signature of the `apply` and `destroy` methods to take a mutable reference to `self`, allowing them to update the `last_deployment` field. 

* [`infraweave_py/src/deployment.rs`](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5R189-R210): Added a new getter method `outputs` to retrieve the outputs of the last deployment as a Python object. This method serializes the Rust data to JSON and then parses it in Python.
