### PR TITLE
fix: remove unwraps in api_module and api_stack

### DIFF
--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -55,6 +55,9 @@ pub enum ModuleError {
     #[error("The stack claim \"{1}\" of kind \"{0}\" has an invalid reference \"{2}\" to itself")]
     SelfReferencingClaim(String, String, String),
 
+    #[error("The manifest \"{0}\" is missing the \"version\" field")]
+    ModuleVersionMissing(String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
This pull request improves error handling and validation in the module and stack publishing workflows by replacing `unwrap` calls with proper error propagation, introducing a new error variant, and adding checks for missing fields. These changes enhance robustness and maintainability.

### Error Handling Improvements:

* Added a new `ModuleError::ModuleVersionMissing` variant to handle cases where the "version" field is missing in the manifest. This is now used in `publish_module` and `publish_stack` functions to return a clear error when the field is absent. (`env_common/src/errors.rs`, `env_common/src/logic/api_module.rs`, `env_common/src/logic/api_stack.rs`) 

* Replaced all `unwrap` calls with proper error propagation using `?` or `map_err` in functions such as `publish_module`, `publish_stack`, `insert_module`, and `compare_latest_version`. This ensures that errors are handled gracefully instead of causing panics. (`env_common/src/logic/api_module.rs`, `env_common/src/logic/api_stack.rs`) 

### Validation Enhancements:

* Added checks for the presence of the "version" field in both `publish_module` and `publish_stack` functions, returning a descriptive error if the field is missing. This prevents downstream errors caused by invalid manifests. (`env_common/src/logic/api_module.rs`, `env_common/src/logic/api_stack.rs`) 