### PR TITLE
fix: remove pre-commit integration-tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,3 @@ repos:
         entry: make unit-tests
         language: system
         pass_filenames: false
-
-      - id: make-integration-tests
-        name: check integration tests
-        entry: make integration-tests
-        language: system
-        pass_filenames: false
-        env:
-          INFRAWEAVE_API_FUNCTION: "function"
-          TEST_MODE: "true"


### PR DESCRIPTION
Due to slow workflow, it is anyway tested in the pull-request. Make it up to the user if considered necessary.

This pull request includes a small change to the `.pre-commit-config.yaml` file. The change removes the `make-integration-tests` pre-commit hook, which was used to check integration tests.

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L23-L31): Removed the `make-integration-tests` hook