### PR TITLE
fix: add required_providers to module

### DIFF
--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -34,7 +34,8 @@ pub use log::LogData;
 pub use module::{
     deserialize_module_manifest, get_module_identifier, Metadata, ModuleDiffAddition,
     ModuleDiffChange, ModuleDiffRemoval, ModuleExample, ModuleManifest, ModuleResp, ModuleSpec,
-    ModuleStackData, ModuleVersionDiff, StackModule, TfOutput, TfValidation, TfVariable,
+    ModuleStackData, ModuleVersionDiff, StackModule, TfOutput, TfRequiredProvider, TfValidation,
+    TfVariable,
 };
 pub use notification::NotificationData;
 pub use policy::{

--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -47,6 +47,14 @@ pub struct TfOutput {
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct TfRequiredProvider {
+    pub name: String,
+    pub version: String,
+    pub source: String,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct ModuleDiffAddition {
     pub path: String,
     pub value: serde_json::Value,
@@ -93,6 +101,8 @@ pub struct ModuleResp {
     pub manifest: ModuleManifest,
     pub tf_variables: Vec<TfVariable>,
     pub tf_outputs: Vec<TfOutput>, // Added to capture the outputs array
+    #[serde(default)]
+    pub tf_required_providers: Vec<TfRequiredProvider>,
     pub s3_key: String,
     pub stack_data: Option<ModuleStackData>,
     pub version_diff: Option<ModuleVersionDiff>,

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -4,8 +4,9 @@ use env_defs::{
 };
 use env_utils::{
     contains_terraform_lockfile, generate_module_example_deployment, get_outputs_from_tf_files,
-    get_timestamp, get_variables_from_tf_files, merge_json_dicts, read_tf_directory, semver_parse,
-    validate_module_schema, validate_tf_backend_not_set, zero_pad_semver,
+    get_tf_required_providers_from_tf_files, get_timestamp, get_variables_from_tf_files,
+    merge_json_dicts, read_tf_directory, semver_parse, validate_module_schema,
+    validate_tf_backend_not_set, zero_pad_semver,
 };
 use log::{debug, info, warn};
 use std::path::Path;
@@ -81,6 +82,7 @@ pub async fn publish_module(
 
     let tf_variables = get_variables_from_tf_files(&tf_content).unwrap();
     let tf_outputs = get_outputs_from_tf_files(&tf_content).unwrap();
+    let tf_required_providers = get_tf_required_providers_from_tf_files(&tf_content).unwrap();
 
     let module = module_yaml.metadata.name.clone();
     let version = match module_yaml.spec.version.clone() {
@@ -182,6 +184,7 @@ pub async fn publish_module(
         manifest: module_yaml.clone(),
         tf_variables,
         tf_outputs,
+        tf_required_providers,
         s3_key: format!(
             "{}/{}-{}.zip",
             &module_yaml.metadata.name, &module_yaml.metadata.name, &version

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -53,6 +53,7 @@ pub async fn publish_stack(
 
     let tf_variables = get_variables_from_tf_files(&variables_str).unwrap();
     let tf_outputs = get_outputs_from_tf_files(&outputs_str).unwrap();
+    let tf_required_providers = vec![]; // TODO: pick latest version of providers from modules
 
     let module = stack_manifest.metadata.name.clone();
     let version = match stack_manifest.spec.version.clone() {
@@ -185,6 +186,7 @@ pub async fn publish_stack(
         manifest: module_manifest,
         tf_variables,
         tf_outputs,
+        tf_required_providers,
         s3_key: format!(
             "{}/{}-{}.zip",
             &stack_manifest.metadata.name, &stack_manifest.metadata.name, &version
@@ -1611,6 +1613,7 @@ output "bucket2__list_of_strings" {
                     },
                 },
                 tf_outputs: vec![],
+                tf_required_providers: vec![],
                 tf_variables: vec![
                     TfVariable {
                         name: "bucket_name".to_string(),
@@ -1693,6 +1696,7 @@ output "bucket2__list_of_strings" {
                     },
                 },
                 tf_outputs: vec![],
+                tf_required_providers: vec![],
                 tf_variables: vec![
                     TfVariable {
                         name: "bucket_name".to_string(),
@@ -1797,6 +1801,7 @@ output "bucket2__list_of_strings" {
                 },
             },
             tf_outputs: vec![],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -1903,6 +1908,7 @@ output "bucket2__list_of_strings" {
                 },
             },
             tf_outputs: vec![],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2017,6 +2023,7 @@ output "bucket2__list_of_strings" {
                 },
             },
             tf_outputs: vec![],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2135,6 +2142,7 @@ output "bucket2__list_of_strings" {
                 value: "".to_string(),
                 description: "ARN of the bucket".to_string(),
             }],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2238,6 +2246,7 @@ output "bucket2__list_of_strings" {
                 value: "".to_string(),
                 description: "ARN of the bucket".to_string(),
             }],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2384,6 +2393,7 @@ output "bucket2__list_of_strings" {
                 value: "".to_string(),
                 description: "ARN of the bucket".to_string(),
             }],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2498,6 +2508,7 @@ output "bucket2__list_of_strings" {
                 value: "".to_string(),
                 description: "VPC Identifier".to_string(),
             }],
+            tf_required_providers: vec![],
             tf_variables: vec![TfVariable {
                 name: "cidr".to_string(),
                 default: serde_json::json!("10.0.0.0/16"),
@@ -2541,6 +2552,7 @@ output "bucket2__list_of_strings" {
                 },
             },
             tf_outputs: vec![],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "instance_type".to_string(),
@@ -2623,6 +2635,7 @@ output "bucket2__list_of_strings" {
                     },
                 },
                 tf_outputs: vec![],
+                tf_required_providers: vec![],
                 tf_variables: vec![TfVariable {
                     name: "bucket_name".to_string(),
                     default: serde_json::Value::Null,
@@ -2688,6 +2701,7 @@ output "bucket2__list_of_strings" {
                     },
                 },
                 tf_outputs: vec![],
+                tf_required_providers: vec![],
                 tf_variables: vec![TfVariable {
                     name: "bucket_name".to_string(),
                     default: serde_json::Value::Null,
@@ -2797,6 +2811,7 @@ output "bucket2__list_of_strings" {
                 // TfOutput { name: "region".to_string(), description: "".to_string(), value: "".to_string() },
                 // TfOutput { name: "sse_algorithm".to_string(), description: "".to_string(), value: "".to_string() },
             ],
+            tf_required_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     default: serde_json::Value::Null,

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -828,6 +828,7 @@ mod tests {
                 reference: "https://github.com/project".to_string(),
                 tf_variables: vec![],
                 tf_outputs: vec![],
+                tf_required_providers: vec![],
                 s3_key: "test-module-1.0.0-beta".to_string(),
                 stack_data: None,
                 version_diff: None,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -26,7 +26,8 @@ pub use json::{
 pub use log::sanitize_payload_for_logging;
 pub use logging::setup_logging;
 pub use module::{
-    get_outputs_from_tf_files, get_variables_from_tf_files, indent, validate_tf_backend_not_set,
+    get_outputs_from_tf_files, get_tf_required_providers_from_tf_files,
+    get_variables_from_tf_files, indent, validate_tf_backend_not_set,
 };
 pub use module_diff::diff_modules;
 pub use provider_util::{

--- a/utils/src/variables.rs
+++ b/utils/src/variables.rs
@@ -336,6 +336,7 @@ mod tests {
                     sensitive: false,
                 },
             ],
+            tf_required_providers: vec![],
             stack_data: None,
             version_diff: None,
             cpu: "1024".to_string(),


### PR DESCRIPTION
This pull request introduces support for handling Terraform required providers by adding a new `TfRequiredProvider` struct, updating relevant logic to parse and process required providers, and ensuring compatibility across the codebase. The most important changes include defining the new struct, updating module and stack publishing logic, and adding parsing functionality for required providers. The new data field is not yet used anywhere, it is intended to be used for stacks later on.

### New Feature: Terraform Required Providers

* **Added `TfRequiredProvider` struct**: A new struct was introduced in `defs/src/module.rs` to represent Terraform required providers, including fields for `name`, `version`, and `source`. This struct is used throughout the codebase to handle required provider data.
* **Updated module response**: The `ModuleResp` struct in `defs/src/module.rs` was updated to include a new field `tf_required_providers` with a default value, enabling the storage of required provider information.

### Logic Updates for Handling Required Providers

* **Parsing required providers**: A new function `get_tf_required_providers_from_tf_files` was added in `utils/src/module.rs` to parse and extract required provider information from Terraform files. This includes logic for handling HCL expressions and attributes.
* **Module publishing logic**: The `publish_module` function in `env_common/src/logic/api_module.rs` was updated to extract required providers using the new parsing function and include them in the module response. [[1]](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9R85) [[2]](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9R187)
* **Stack publishing logic**: The `publish_stack` function in `env_common/src/logic/api_stack.rs` was updated to include a placeholder for required providers, with plans to implement provider version selection in the future. [[1]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R56) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R189)

### Codebase Integration and Refactoring

* **Exported new functionality**: The `TfRequiredProvider` struct and `get_tf_required_providers_from_tf_files` function were added to the relevant module exports in `defs/src/lib.rs` and `utils/src/lib.rs`. [[1]](diffhunk://#diff-dce60921cb288dcb0912a027091cc4fb5fd26c31685984760735db157e08ef08L37-R38) [[2]](diffhunk://#diff-2a68e14bf95d2e3c7c7c72b92741c10dc2ea9027388a899a65a9a73b4152b80fL29-R30)
* **Test updates**: Various test cases in `operator/src/operator.rs` and `env_common/src/logic/api_stack.rs` were updated to include the new `tf_required_providers` field, ensuring compatibility with the changes. [[1]](diffhunk://#diff-46cf44a083bd5f031887f93d91d7577de42bf49b6bc7bc08c0bd70b1597f1bb6R831) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R1616)