### PR TITLE
fix: require "required_providers" to be set for all providers existing in lock file

### DIFF
--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -34,8 +34,8 @@ pub use log::LogData;
 pub use module::{
     deserialize_module_manifest, get_module_identifier, Metadata, ModuleDiffAddition,
     ModuleDiffChange, ModuleDiffRemoval, ModuleExample, ModuleManifest, ModuleResp, ModuleSpec,
-    ModuleStackData, ModuleVersionDiff, StackModule, TfOutput, TfRequiredProvider, TfValidation,
-    TfVariable,
+    ModuleStackData, ModuleVersionDiff, StackModule, TfLockProvider, TfOutput, TfRequiredProvider,
+    TfValidation, TfVariable,
 };
 pub use notification::NotificationData;
 pub use policy::{

--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -55,6 +55,13 @@ pub struct TfRequiredProvider {
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct TfLockProvider {
+    pub source: String,
+    pub version: String,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct ModuleDiffAddition {
     pub path: String,
     pub value: serde_json::Value,
@@ -103,6 +110,8 @@ pub struct ModuleResp {
     pub tf_outputs: Vec<TfOutput>, // Added to capture the outputs array
     #[serde(default)]
     pub tf_required_providers: Vec<TfRequiredProvider>,
+    #[serde(default)]
+    pub tf_lock_providers: Vec<TfLockProvider>,
     pub s3_key: String,
     pub stack_data: Option<ModuleStackData>,
     pub version_diff: Option<ModuleVersionDiff>,

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -19,8 +19,11 @@ pub enum ModuleError {
     #[error("Invalid module schema: {0}")]
     InvalidModuleSchema(String),
 
-    #[error(".terraform.lock.hcl file does not exist in the specified directory. To guarantee consistent behaviour by always using the same dependency versions, please run `terraform init` in the directory before proceeding.")]
-    TerraformLockfileMissing,
+    #[error("{0}. To guarantee consistent behaviour by always using the same dependency versions, please run `terraform init` in the directory before proceeding.")]
+    TerraformLockfileMissing(String),
+
+    #[error(".terraform.lock.hcl file exists but is empty.")]
+    TerraformLockfileEmpty,
 
     #[error("Failed to upload module: {0}")]
     UploadModuleError(String),

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -85,9 +85,9 @@ pub async fn publish_module(
     let tf_variables = get_variables_from_tf_files(&tf_content).unwrap();
     let tf_outputs = get_outputs_from_tf_files(&tf_content).unwrap();
     let tf_required_providers = get_tf_required_providers_from_tf_files(&tf_content).unwrap();
+    let tf_lock_providers = get_providers_from_lockfile(&tf_lock_file_content)?;
 
-    let expected_providers = get_providers_from_lockfile(&tf_lock_file_content)?;
-    validate_tf_required_providers_is_set(&tf_required_providers, &expected_providers)?;
+    validate_tf_required_providers_is_set(&tf_required_providers, &tf_lock_providers)?;
 
     let module = module_yaml.metadata.name.clone();
     let version = match module_yaml.spec.version.clone() {
@@ -190,6 +190,7 @@ pub async fn publish_module(
         tf_variables,
         tf_outputs,
         tf_required_providers,
+        tf_lock_providers,
         s3_key: format!(
             "{}/{}-{}.zip",
             &module_yaml.metadata.name, &module_yaml.metadata.name, &version

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -4,9 +4,10 @@ use env_defs::{
 };
 use env_utils::{
     contains_terraform_lockfile, generate_module_example_deployment, get_outputs_from_tf_files,
-    get_tf_required_providers_from_tf_files, get_timestamp, get_variables_from_tf_files,
-    merge_json_dicts, read_tf_directory, semver_parse, validate_module_schema,
-    validate_tf_backend_not_set, zero_pad_semver,
+    get_providers_from_lockfile, get_tf_required_providers_from_tf_files, get_timestamp,
+    get_variables_from_tf_files, merge_json_dicts, read_tf_directory, semver_parse,
+    validate_module_schema, validate_tf_backend_not_set, validate_tf_required_providers_is_set,
+    zero_pad_semver,
 };
 use log::{debug, info, warn};
 use std::path::Path;
@@ -62,16 +63,17 @@ pub async fn publish_module(
         }
     }
 
-    match contains_terraform_lockfile(&zip_file) {
-        std::result::Result::Ok(exists) => {
-            if !exists {
-                return Err(ModuleError::TerraformLockfileMissing);
+    let tf_lock_file_content = match contains_terraform_lockfile(&zip_file) {
+        std::result::Result::Ok(contents) => {
+            if contents.is_empty() {
+                return Err(ModuleError::TerraformLockfileEmpty);
             }
+            contents
         }
         Err(error) => {
-            return Err(ModuleError::ZipError(error.to_string()));
+            return Err(ModuleError::TerraformLockfileMissing(error.to_string()));
         }
-    }
+    };
 
     match validate_module_schema(&manifest) {
         std::result::Result::Ok(_) => (),
@@ -83,6 +85,9 @@ pub async fn publish_module(
     let tf_variables = get_variables_from_tf_files(&tf_content).unwrap();
     let tf_outputs = get_outputs_from_tf_files(&tf_content).unwrap();
     let tf_required_providers = get_tf_required_providers_from_tf_files(&tf_content).unwrap();
+
+    let expected_providers = get_providers_from_lockfile(&tf_lock_file_content)?;
+    validate_tf_required_providers_is_set(&tf_required_providers, &expected_providers)?;
 
     let module = module_yaml.metadata.name.clone();
     let version = match module_yaml.spec.version.clone() {

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -1,11 +1,11 @@
 use env_defs::{
     CloudProvider, DeploymentManifest, ModuleExample, ModuleManifest, ModuleResp,
-    ModuleVersionDiff, StackManifest, TfOutput, TfVariable,
+    ModuleVersionDiff, StackManifest, TfLockProvider, TfOutput, TfVariable,
 };
 use env_utils::{
     get_outputs_from_tf_files, get_timestamp, get_variables_from_tf_files, get_version_track,
-    get_zip_file_from_str, merge_zips, read_stack_directory, to_camel_case, to_snake_case,
-    zero_pad_semver,
+    get_zip_file_from_str, indent, merge_zips, read_stack_directory, semver_parse, to_camel_case,
+    to_snake_case, zero_pad_semver,
 };
 use hcl::Value as HclValue;
 use log::info;
@@ -54,6 +54,7 @@ pub async fn publish_stack(
     let tf_variables = get_variables_from_tf_files(&variables_str).unwrap();
     let tf_outputs = get_outputs_from_tf_files(&outputs_str).unwrap();
     let tf_required_providers = vec![]; // TODO: pick latest version of providers from modules
+    let tf_lock_providers = vec![]; // TODO: pick latest version of providers from modules
 
     let module = stack_manifest.metadata.name.clone();
     let version = match stack_manifest.spec.version.clone() {
@@ -187,6 +188,7 @@ pub async fn publish_stack(
         tf_variables,
         tf_outputs,
         tf_required_providers,
+        tf_lock_providers,
         s3_key: format!(
             "{}/{}-{}.zip",
             &stack_manifest.metadata.name, &stack_manifest.metadata.name, &version
@@ -361,6 +363,54 @@ pub fn generate_full_terraform_module(
         terraform_output_code,
     ))
 }
+fn generate_terraform_block(modules: &HashMap<String, ModuleResp>) -> String {
+    // Pick the latest-version lock for each source
+    let latest_locks = modules
+        .values()
+        .flat_map(|m| m.tf_lock_providers.iter().cloned())
+        .fold(HashMap::new(), |mut acc, p| {
+            acc.entry(p.source.clone())
+                .and_modify(|existing: &mut TfLockProvider| {
+                    if semver_parse(&p.version).unwrap() > semver_parse(&existing.version).unwrap()
+                    {
+                        *existing = p.clone();
+                    }
+                })
+                .or_insert(p);
+            acc
+        });
+
+    let name_map = modules
+        .values()
+        .flat_map(|m| {
+            m.tf_required_providers
+                .iter()
+                .map(|rp| (rp.source.clone(), rp.name.clone()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    let providers_str = latest_locks
+        .into_values()
+        .map(|p| {
+            format!(
+                "\n  {} = {{\n    source = \"{}\"\n    version = \"{}\"\n  }}",
+                name_map.get(&p.source).expect("missing provider name"),
+                p.source,
+                p.version
+            )
+        })
+        .collect::<String>();
+
+    format!(
+        r#"
+terraform {{
+  required_providers {{{}
+  }}
+}}
+"#,
+        indent(&providers_str, 2)
+    )
+}
 
 fn generate_terraform_modules(
     module_collection: &HashMap<String, ModuleResp>,
@@ -368,6 +418,8 @@ fn generate_terraform_modules(
     dependency_map: &HashMap<String, String>,
 ) -> String {
     let mut terraform_modules = vec![];
+
+    let terraform_block_str = generate_terraform_block(&module_collection);
 
     for (claim_name, module) in module_collection {
         let module_str = generate_terraform_module_single(
@@ -380,7 +432,7 @@ fn generate_terraform_modules(
     }
 
     terraform_modules.sort(); // Sort for consistent ordering
-    terraform_modules.join("\n")
+    format!("{}{}", terraform_block_str, terraform_modules.join("\n"))
 }
 
 fn generate_terraform_module_single(
@@ -1044,7 +1096,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use env_defs::{Metadata, ModuleSpec};
+    use env_defs::{Metadata, ModuleSpec, TfLockProvider, TfRequiredProvider};
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
 
@@ -1462,7 +1514,17 @@ output "bucket2__list_of_strings" {
             &generated_dependency_map,
         );
 
+        // Two versions exist (5.81.0 and 5.95.0), ensure the latest is used
         let expected_terraform_outputs_string = r#"
+terraform {
+  required_providers {    
+      aws = {
+        source = "hashicorp/aws"
+        version = "5.95.0"
+      }
+  }
+}
+
 module "bucket1a" {
   source = "./s3bucket-0.0.21"
 
@@ -1472,7 +1534,7 @@ module "bucket1a" {
 }
 
 module "bucket2" {
-  source = "./s3bucket-0.0.21"
+  source = "./s3bucket-0.0.22"
 
   bucket_name = "${var.bucket1a__bucket_name}-after"
   input_list = module.bucket1a.list_of_strings
@@ -1498,7 +1560,17 @@ module "bucket2" {
         let generated_terraform_module =
             format!("{}\n{}\n{}", modules_str, variables_str, outputs_str);
 
+        // Two versions exist (5.81.0 and 5.95.0), ensure the latest is used
         let expected_terraform_module = r#"
+terraform {
+  required_providers {    
+      aws = {
+        source = "hashicorp/aws"
+        version = "5.95.0"
+      }
+  }
+}
+
 module "bucket1a" {
   source = "./s3bucket-0.0.21"
 
@@ -1508,7 +1580,7 @@ module "bucket1a" {
 }
 
 module "bucket2" {
-  source = "./s3bucket-0.0.21"
+  source = "./s3bucket-0.0.22"
 
   bucket_name = "${var.bucket1a__bucket_name}-after"
   input_list = module.bucket1a.list_of_strings
@@ -1614,6 +1686,7 @@ output "bucket2__list_of_strings" {
                 },
                 tf_outputs: vec![],
                 tf_required_providers: vec![],
+                tf_lock_providers: vec![],
                 tf_variables: vec![
                     TfVariable {
                         name: "bucket_name".to_string(),
@@ -1697,6 +1770,7 @@ output "bucket2__list_of_strings" {
                 },
                 tf_outputs: vec![],
                 tf_required_providers: vec![],
+                tf_lock_providers: vec![],
                 tf_variables: vec![
                     TfVariable {
                         name: "bucket_name".to_string(),
@@ -1802,6 +1876,7 @@ output "bucket2__list_of_strings" {
             },
             tf_outputs: vec![],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -1909,6 +1984,7 @@ output "bucket2__list_of_strings" {
             },
             tf_outputs: vec![],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2024,6 +2100,7 @@ output "bucket2__list_of_strings" {
             },
             tf_outputs: vec![],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2143,6 +2220,7 @@ output "bucket2__list_of_strings" {
                 description: "ARN of the bucket".to_string(),
             }],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2247,6 +2325,7 @@ output "bucket2__list_of_strings" {
                 description: "ARN of the bucket".to_string(),
             }],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2394,6 +2473,7 @@ output "bucket2__list_of_strings" {
                 description: "ARN of the bucket".to_string(),
             }],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "bucket_name".to_string(),
@@ -2509,6 +2589,7 @@ output "bucket2__list_of_strings" {
                 description: "VPC Identifier".to_string(),
             }],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![TfVariable {
                 name: "cidr".to_string(),
                 default: serde_json::json!("10.0.0.0/16"),
@@ -2553,6 +2634,7 @@ output "bucket2__list_of_strings" {
             },
             tf_outputs: vec![],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             tf_variables: vec![
                 TfVariable {
                     name: "instance_type".to_string(),
@@ -2636,6 +2718,7 @@ output "bucket2__list_of_strings" {
                 },
                 tf_outputs: vec![],
                 tf_required_providers: vec![],
+                tf_lock_providers: vec![],
                 tf_variables: vec![TfVariable {
                     name: "bucket_name".to_string(),
                     default: serde_json::Value::Null,
@@ -2702,6 +2785,7 @@ output "bucket2__list_of_strings" {
                 },
                 tf_outputs: vec![],
                 tf_required_providers: vec![],
+                tf_lock_providers: vec![],
                 tf_variables: vec![TfVariable {
                     name: "bucket_name".to_string(),
                     default: serde_json::Value::Null,
@@ -2740,7 +2824,7 @@ output "bucket2__list_of_strings" {
         name: bucket2
     spec:
         region: eu-west-1
-        moduleVersion: 0.0.21
+        moduleVersion: 0.0.22
         variables:
             bucketName: "{{ S3Bucket::bucket1a::bucketName }}-after"
             inputList: "{{ S3Bucket::bucket1a::listOfStrings }}"
@@ -2760,11 +2844,11 @@ output "bucket2__list_of_strings" {
 
         // Create a vector of (DeploymentManifest, ModuleResp) tuples
         let claim_modules = vec![
+            (deployment_manifest_bucket1a.clone(), s3bucket_module),
             (
-                deployment_manifest_bucket1a.clone(),
-                s3bucket_module.clone(),
+                deployment_manifest_bucket2.clone(),
+                s3bucket_module_upgraded(),
             ),
-            (deployment_manifest_bucket2.clone(), s3bucket_module.clone()),
         ];
         claim_modules
     }
@@ -2811,7 +2895,15 @@ output "bucket2__list_of_strings" {
                 // TfOutput { name: "region".to_string(), description: "".to_string(), value: "".to_string() },
                 // TfOutput { name: "sse_algorithm".to_string(), description: "".to_string(), value: "".to_string() },
             ],
-            tf_required_providers: vec![],
+            tf_required_providers: vec![TfRequiredProvider {
+                name: "aws".to_string(),
+                source: "hashicorp/aws".to_string(),
+                version: "~> 5.0".to_string(),
+            }],
+            tf_lock_providers: vec![TfLockProvider {
+                source: "hashicorp/aws".to_string(),
+                version: "5.81.0".to_string(),
+            }],
             tf_variables: vec![
                 TfVariable {
                     default: serde_json::Value::Null,
@@ -2847,5 +2939,22 @@ output "bucket2__list_of_strings" {
             cpu: get_default_cpu(),
             memory: get_default_memory(),
         }
+    }
+
+    fn s3bucket_module_upgraded() -> ModuleResp {
+        let mut module = s3bucket_module();
+        module.version = "0.0.22".to_string();
+        module.s3_key = "s3bucket/s3bucket-0.0.22.zip".to_string();
+        module.manifest.spec.version = Some("0.0.22".to_string());
+        module.tf_required_providers = vec![TfRequiredProvider {
+            name: "aws".to_string(),
+            source: "hashicorp/aws".to_string(),
+            version: "~> 5.0".to_string(),
+        }];
+        module.tf_lock_providers = vec![TfLockProvider {
+            source: "hashicorp/aws".to_string(),
+            version: "5.95.0".to_string(),
+        }];
+        module
     }
 }

--- a/integration-tests/modules/nginx-helm/.terraform.lock.hcl
+++ b/integration-tests/modules/nginx-helm/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.0.0-pre2"
+  constraints = "3.0.0-pre2"
+  hashes = [
+    "h1:GuJGHn2rEFZ0AmYYokVDphkU79M4MJzqb6mOHu/5CPM=",
+    "zh:232b6eac97603aa8edc9f0edaca5aec0a54baf0b81aceb048609a6ffece47940",
+    "zh:470db00c284e7d70d509281f4b78185d5709235e979fe8da0c6a326ada43ec65",
+    "zh:524b9a73f04e50107bd2b8f4d7f83ba666aec6fd679f41dfa1de0e3208ff3b7e",
+    "zh:66c1d4cc7a2b42ce191da0a7f7fe9d56833cf37ffa8a9b15351efa84eb636292",
+    "zh:6757866a63aa20823ab7bb6be1c991083390ced87e7c4f31c7095b8d9d47cc39",
+    "zh:709b746e201cd2f6c5a7c4a28e8193b15371a592b5bbd698c1502f5d67d3fa8f",
+    "zh:7f9cff32ca92db80afc87e0e7e02e77e48751dda3ed833a8660ef6d09d69dc04",
+    "zh:8d704b9fea770c59b1b98b8310da7eb67dd3fcc206e417310cfbabf40365b7a9",
+    "zh:cd4e4bb4b259d0012ba30d02480e92be314c33691b7e5c21fc42411145166f07",
+    "zh:d6fb4fe960eaabf8ccbf382c0c977e7266c2865a97ecb5f404eaa76f98f58d31",
+    "zh:e7ab6a5772bc93e9e2d896eec40723453a9ac76351d9f0c5653fa377bec3d026",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/integration-tests/modules/nginx-helm/main.tf
+++ b/integration-tests/modules/nginx-helm/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+      version = "3.0.0-pre2"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path = "~/.kube/config"
+  }
+}
+
+resource "helm_release" "nginx_ingress" {
+  name       = "nginx-ingress-controller"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "nginx-ingress-controller"
+
+  set = [
+    {
+      name  = "service.type"
+      value = var.service_type
+    }
+  ]
+}

--- a/integration-tests/modules/nginx-helm/module.yaml
+++ b/integration-tests/modules/nginx-helm/module.yaml
@@ -1,0 +1,13 @@
+apiVersion: infraweave.io/v1
+kind: Module
+metadata:
+  # group: infraweave.io    # The group of the module
+  name: nginxhelm # The name of the module you define
+spec:
+  moduleName: NginxHelm # metadata.name cannot have any uppercase, which is why we need this
+  # version: 0.0.36-dev+test.11 # The released version to use
+  reference: https://github.com/infreweave-io/modules/nginxhelm # The URL to the module's source code
+  cpu: "1024"
+  memory: "4096"
+  description: |
+    Helm chart for Nginx ingress controller.

--- a/integration-tests/modules/nginx-helm/outputs.tf
+++ b/integration-tests/modules/nginx-helm/outputs.tf
@@ -1,0 +1,3 @@
+output "tags" {
+  value = helm_release.nginx_ingress.tags
+}

--- a/integration-tests/modules/nginx-helm/variables.tf
+++ b/integration-tests/modules/nginx-helm/variables.tf
@@ -1,0 +1,13 @@
+
+variable "service_type" {
+  type    = string
+  description = "Choose between LoadBalancer, NodePort, or ClusterIP for the service type."
+  default = "ClusterIP"
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+    Test = "override-me"
+  }
+}

--- a/integration-tests/modules/route53record/main.tf
+++ b/integration-tests/modules/route53record/main.tf
@@ -1,7 +1,9 @@
-locals {
-  tags = {
-    Name        = "example.com"
-    Environment = "dev"
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
   }
 }
 
@@ -10,6 +12,13 @@ provider "aws" {
 
   default_tags {
     tags = local.tags
+  }
+}
+
+locals {
+  tags = {
+    Name        = "example.com"
+    Environment = "dev"
   }
 }
 

--- a/integration-tests/modules/s3bucket-dev/main.tf
+++ b/integration-tests/modules/s3bucket-dev/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "example" {
   bucket = var.bucket_name
 

--- a/integration-tests/modules/s3bucket-missing-lockfile/main.tf
+++ b/integration-tests/modules/s3bucket-missing-lockfile/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "example" {
   bucket = var.bucket_name
 

--- a/integration-tests/modules/s3bucket-stable/main.tf
+++ b/integration-tests/modules/s3bucket-stable/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "example" {
   bucket = var.bucket_name
 

--- a/integration-tests/stacks/providermix/bucket1a.yaml
+++ b/integration-tests/stacks/providermix/bucket1a.yaml
@@ -1,0 +1,11 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: bucket1a
+spec:
+  moduleVersion: 0.1.2-dev+test.10
+  region: N/A
+  variables:
+    tags:
+      Name234: my-s3bucket-bucket1a
+      Environment43: dev

--- a/integration-tests/stacks/providermix/nginxhelm.yaml
+++ b/integration-tests/stacks/providermix/nginxhelm.yaml
@@ -1,0 +1,8 @@
+apiVersion: infraweave.io/v1
+kind: NginxHelm
+metadata:
+  name: nginxhelm
+spec:
+  moduleVersion: 0.5.5-dev+test.1
+  region: N/A
+  variables: {}

--- a/integration-tests/stacks/providermix/stack.yaml
+++ b/integration-tests/stacks/providermix/stack.yaml
@@ -1,0 +1,9 @@
+apiVersion: infraweave.io/v1
+kind: Stack
+metadata:
+  name: providermix
+spec:
+  stackName: ProviderMix
+  reference: https://github.com/infreweave-io/stacks/providermix
+  description: |
+    This is a deployment stack consisting of an S3-bucket and a Helm chart just for testing different providers.

--- a/integration-tests/tests/module.rs
+++ b/integration-tests/tests/module.rs
@@ -65,8 +65,8 @@ mod module_tests {
             };
 
             let module_vec: Vec<u8> = download_module_to_vec(&handler, &modules[0].s3_key).await;
-            let contains_lockfile = contains_terraform_lockfile(&module_vec).unwrap();
-            assert_eq!(contains_lockfile, true);
+            let lockfile_contents_result = contains_terraform_lockfile(&module_vec);
+            assert_eq!(lockfile_contents_result.is_ok(), true);
 
             assert_eq!(modules.len(), 1);
             assert_eq!(modules[0].module, "s3bucket");

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -829,6 +829,7 @@ mod tests {
                 tf_variables: vec![],
                 tf_outputs: vec![],
                 tf_required_providers: vec![],
+                tf_lock_providers: vec![],
                 s3_key: "test-module-1.0.0-beta".to_string(),
                 stack_data: None,
                 version_diff: None,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -26,8 +26,9 @@ pub use json::{
 pub use log::sanitize_payload_for_logging;
 pub use logging::setup_logging;
 pub use module::{
-    get_outputs_from_tf_files, get_tf_required_providers_from_tf_files,
-    get_variables_from_tf_files, indent, validate_tf_backend_not_set,
+    get_outputs_from_tf_files, get_providers_from_lockfile,
+    get_tf_required_providers_from_tf_files, get_variables_from_tf_files, indent,
+    validate_tf_backend_not_set, validate_tf_required_providers_is_set,
 };
 pub use module_diff::diff_modules;
 pub use provider_util::{

--- a/utils/src/variables.rs
+++ b/utils/src/variables.rs
@@ -337,6 +337,7 @@ mod tests {
                 },
             ],
             tf_required_providers: vec![],
+            tf_lock_providers: vec![],
             stack_data: None,
             version_diff: None,
             cpu: "1024".to_string(),


### PR DESCRIPTION
This pull request introduces several enhancements to improve Terraform module validation, error handling, and integration testing. The most significant changes includes:

* requiring modules to set required providers in the terraform block to match the providers from the lock-file. 
* uses these to constrain the provider version when creating a stack, meaning that for a set of versioned modules, it will be fully reproducible and only use the versions specified.  (it does not pick the latest available provider for stacks - you need to bump the lockfile for modules first. If two or more modules are using same provider but different versions in their lockfile, the latest of those will be picked)

### Enhancements to Terraform Lock File Handling:

* Added a new `TfLockProvider` struct to represent provider source and version, and updated the `ModuleResp` struct to include a `tf_lock_providers` field. (`defs/src/module.rs`, [[1]](diffhunk://#diff-0501e3350bc6a9d308597a280a9c7c83e1c57d134d389b1780a3bcf522bb29a2R56-R62) [[2]](diffhunk://#diff-0501e3350bc6a9d308597a280a9c7c83e1c57d134d389b1780a3bcf522bb29a2R113-R114)
* Improved error handling for Terraform lock files by introducing a new `TerraformLockfileEmpty` error and modifying `TerraformLockfileMissing` to include a dynamic error message. (`env_common/src/errors.rs`, [env_common/src/errors.rsL22-R26](diffhunk://#diff-c6d872fdae44796737bb215d4a4711cbc0ecc171a501c67c73a410b6174823daL22-R26))
* Updated the `publish_module` function to validate the presence and contents of the `.terraform.lock.hcl` file and ensure consistency between required and lock providers. (`env_common/src/logic/api_module.rs`, [[1]](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9L65-R76) [[2]](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9R88-R90) [[3]](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9R193)

### Provider Versioning in Terraform Modules:

* Enhanced the `generate_full_terraform_module` function to include provider versioning by generating a `required_providers` block with the latest versions of providers from the lock file. (`env_common/src/logic/api_stack.rs`, [[1]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L350-R360) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R372-R448)
* Added a helper function, `generate_terraform_block`, to create the `required_providers` block and determine the latest provider versions. (`env_common/src/logic/api_stack.rs`, F602563bL369R457)

### Updates to Stack Publishing and Testing:

* Updated the `publish_stack` function to incorporate `TfLockProvider` data and ensure provider versioning is included in the generated Terraform configuration. (`env_common/src/logic/api_stack.rs`, [[1]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L52-R64) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R198)
* Enhanced test cases to validate the inclusion of the `required_providers` block and ensure the latest provider versions are used. (`env_common/src/logic/api_stack.rs`, [[1]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L1459-R1554) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L1475-R1564) [[3]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L1511-R1610)

These changes improve the consistency and reliability of Terraform module and stack deployments by ensuring provider versions are explicitly defined and validated.
