### PR TITLE
fix: remove runner ExtraData warning

### DIFF
--- a/terraform_runner/src/main.rs
+++ b/terraform_runner/src/main.rs
@@ -97,9 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 status: result.to_string(),
             };
         }
-        _ => {
-            println!("Unknown type of ExtraData found");
-        }
+        ExtraData::None => {}
     }
 
     let notification = NotificationData {


### PR DESCRIPTION
This pull request makes a minor change to the `terraform_runner/src/main.rs` file by simplifying the handling of the `ExtraData::None` case in the `main` function. The change removes an unnecessary branch that printed a message for unknown `ExtraData` types in the runner and replaces it with an empty match arm for `ExtraData::None`.