### PR TITLE
fix: prevent default null value for non-nullable variable

### DIFF
--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -609,16 +609,22 @@ fn generate_terraform_variable_single(
     let description = variable.description.clone();
     let nullable = variable.nullable;
     let sensitive = variable.sensitive;
+
+    let default_line = if default_value == "null" && !nullable {
+        println!("Default value is null and nullable is false for variable {}. This should be added as an example value", var_name);
+        "".to_string()
+    } else {
+        format!("\n{}", indent(&format!("default = {}", &default_value), 1))
+    };
     format!(
         r#"
 variable "{}" {{
-  type = {}
-  default = {}
+  type = {}{}
   description = "{}"
   nullable = {}
   sensitive = {}
 }}"#,
-        var_name, _type, &default_value, &description, nullable, sensitive
+        var_name, _type, &default_line, &description, nullable, sensitive
     )
 }
 
@@ -1450,7 +1456,6 @@ mod tests {
         let expected_terraform_variables_string = r#"
 variable "bucket1a__bucket_name" {
   type = string
-  default = null
   description = "Name of the S3 bucket"
   nullable = false
   sensitive = false
@@ -1467,9 +1472,9 @@ variable "bucket1a__input_list" {
 variable "bucket1a__tags" {
   type = map(string)
   default = {
-  "AnotherTag" = "something"
-  "Test" = "hej"
-}
+    "AnotherTag" = "something"
+    "Test" = "hej"
+  }
   description = "Tags to apply to the S3 bucket"
   nullable = true
   sensitive = false
@@ -1619,7 +1624,6 @@ module "bucket2" {
 
 variable "bucket1a__bucket_name" {
   type = string
-  default = null
   description = "Name of the S3 bucket"
   nullable = false
   sensitive = false
@@ -1636,9 +1640,9 @@ variable "bucket1a__input_list" {
 variable "bucket1a__tags" {
   type = map(string)
   default = {
-  "AnotherTag" = "something"
-  "Test" = "hej"
-}
+    "AnotherTag" = "something"
+    "Test" = "hej"
+  }
   description = "Tags to apply to the S3 bucket"
   nullable = true
   sensitive = false


### PR DESCRIPTION
This pull request modifies the `generate_terraform_variable_single` function in `env_common/src/logic/api_stack.rs` to handle cases where the default value is `null` and the variable is not nullable. The changes ensure better handling of such cases and update the corresponding test cases and examples.

### Enhancements to Terraform Variable Generation:

* [`env_common/src/logic/api_stack.rs`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R612-R627): Updated the `generate_terraform_variable_single` function to add a check for cases where the default value is `null` and the variable is not nullable. A warning message is printed, and an empty string is used as the default line in such cases.

### Updates to Test Cases and Examples:

* [`env_common/src/logic/api_stack.rs`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L1453): Updated test cases to remove the `default = null` line for variables with `nullable = false`. This aligns with the new behavior of the `generate_terraform_variable_single` function. [[1]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L1453) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L1622)