### PR TITLE
fix: restrict stack module claim to lowercase alphanumeric

### DIFF
--- a/utils/src/string_utils.rs
+++ b/utils/src/string_utils.rs
@@ -22,6 +22,14 @@ mod tests {
     }
 
     #[test]
+    fn test_convert_camel_case_single_number_no_underscore() {
+        let input = "test5something";
+        let expected = "test5something";
+        let actual = to_camel_case(input);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_convert_camel_case_double_underscore() {
         let input = "test__abc";
         let expected = "testAbc";


### PR DESCRIPTION
This pull request introduces a validation function for stack module claim names, adds corresponding tests, and includes a minor addition to the string utility tests. The most significant changes involve ensuring claim names conform to specific naming rules and improving test coverage.

### Validation Enhancements:
* Added a new function `validate_stack_module_claim_name` in `env_common/src/logic/api_stack.rs` to enforce that claim names must consist of lowercase letters and numbers only. The function uses a regular expression for validation and returns a `ValidationError` if the name does not comply.
* Integrated the `validate_stack_module_claim_name` function into the `validate_claim_modules` function to ensure claim name validation is part of the module validation process.

### Test Coverage:
* Added two new tests in `env_common/src/logic/api_stack.rs`:
  - [`test_validate_stack_module_claim_valid`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R1762-R1801): Verifies that valid claim names pass validation.
  - [`test_validate_stack_module_claim_name_should_be_lowercase_alphanumeric`](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R1762-R1801): Ensures invalid claim names (e.g., containing non-alphanumeric characters) fail validation.
* Added a test in `utils/src/string_utils.rs` to validate the behavior of the `to_camel_case` function when the input contains a single number without underscores.