### PR TITLE
fix: add track in stack_data for each module

### DIFF
--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -35,6 +35,8 @@ pub struct StackModule {
     pub module: String,
     pub version: String,
     pub s3_key: String,
+    #[serde(default)]
+    pub track: String,
 }
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -110,6 +110,7 @@ pub async fn publish_stack(
             .map(|(_d, m)| env_defs::StackModule {
                 module: m.module.clone(),
                 version: m.version.clone(),
+                track: m.track.clone(),
                 s3_key: m.s3_key.clone(),
             })
             .collect(),


### PR DESCRIPTION
This pull request introduces a new `track` field to the `StackModule` struct and updates the relevant logic to handle this new field. The changes ensure that the `track` field is serialized/deserialized with a default value and is properly propagated in the `publish_stack` function. 

This is used for e.g. links in backstage of the module constellation in a stack.

### Changes to `StackModule` struct:

* Added a new `track` field to the `StackModule` struct with a `#[serde(default)]` annotation to allow for default serialization/deserialization. (`defs/src/module.rs`, [defs/src/module.rsR38-R39](diffhunk://#diff-0501e3350bc6a9d308597a280a9c7c83e1c57d134d389b1780a3bcf522bb29a2R38-R39))

### Updates to `publish_stack` function:

* Updated the `publish_stack` function to include the new `track` field when mapping `StackModule` instances. (`env_common/src/logic/api_stack.rs`, [env_common/src/logic/api_stack.rsR113](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R113))