### PR TITLE
fix: update reference on rename-only in gitops

### DIFF
--- a/env_common/src/logic/mod.rs
+++ b/env_common/src/logic/mod.rs
@@ -23,8 +23,8 @@ pub use api_event::insert_event;
 pub use api_notification::publish_notification;
 
 pub use api_infra::{
-    destroy_infra, driftcheck_infra, is_deployment_in_progress, is_deployment_plan_in_progress,
-    mutate_infra, run_claim, submit_claim_job,
+    destroy_infra, driftcheck_infra, get_deployment_details, is_deployment_in_progress,
+    is_deployment_plan_in_progress, mutate_infra, run_claim, submit_claim_job,
 };
 
 pub use api_change_record::insert_infra_change_record;

--- a/gitops/src/defs.rs
+++ b/gitops/src/defs.rs
@@ -30,6 +30,8 @@ pub struct GroupedFile {
     pub active: Option<(FileChange, String)>,
     // The deleted file and its YAML document (if applicable)
     pub deleted: Option<(FileChange, String)>,
+    // The renamed file and its YAML document (if applicable)
+    pub renamed: Option<(FileChange, String)>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This pull request resolves https://github.com/infraweave-io/infraweave/issues/31 by updating the reference of deployments if a file is only renamed, which previously did not trigger anything.

### Support for Renamed Files:
* Enhanced the `GroupedFile` struct in `gitops/src/defs.rs` to include a `renamed` field for tracking renamed files. 
* Updated `group_files_by_manifest` in `gitops/src/gitops.rs` to detect and handle renamed files, distinguishing them from new or deleted files.
* Added test cases in `gitops/src/gitops.rs` to validate handling of renamed files, including multi-document YAML scenarios. 

### Refactoring for Code Reuse:
* Added a new utility function `get_deployment_details` in `env_common/src/logic/api_infra.rs` to centralize logic for extracting deployment details, reducing duplication in related functions. 
* Updated `mod.rs` and other files to include the new `get_deployment_details` function.

### Namespace Handling in GitHub Check Runs:
* Modified `get_check_run_name` in `gitops/src/github.rs` to include the namespace in the check run name. 
* Updated `handle_process_push_event` to handle namespaces more robustly, defaulting to "default" when not specified.