### PR TITLE
docs: add lockfile and reference to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,18 @@ You need to set up:
 
 It all starts with you having a Terraform module available that you want to deploy.
 
-0. Have a terraform module ready.
+0. Have a terraform module ready (including the lockfile `.terraform.lock.hcl`).
 
 ```tf
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "example" {
   bucket = var.bucket_name
   tags   = var.tags
@@ -134,6 +143,8 @@ metadata:
 spec:
   moduleName: S3Bucket # metadata.name cannot have any uppercase, which is why we need this
   version: 0.0.11-dev # The released version to use
+  description: "This module deploys an S3 bucket in AWS" # Supports markdown
+  reference: https://github.com/your-org/s3bucket # The URL to the module's source code
 ```
 
 2. Publish it! *(to dev-track)*


### PR DESCRIPTION
This pull request updates the `README.md` file to align with the current functionality.

### Enhancements to Terraform module setup:

* Updated instructions to specify that the Terraform module must include the lockfile `.terraform.lock.hcl`. Added an example block defining required providers, specifically the AWS provider with version constraints. 

### Improvements to metadata section:

* Added a `description` field to provide a brief explanation of the module's purpose. 
* Included a `reference` field with a URL pointing to the source code of the module.