### PR TITLE
fix: add regional provider storage (terraform)

### DIFF
--- a/defs/src/provider.rs
+++ b/defs/src/provider.rs
@@ -69,7 +69,11 @@ pub trait CloudProvider: Send + Sync {
         stack: &str,
         track: &str,
     ) -> Result<Option<ModuleResp>, anyhow::Error>;
-    async fn generate_presigned_url(&self, key: &str) -> Result<String, anyhow::Error>;
+    async fn generate_presigned_url(
+        &self,
+        key: &str,
+        bucket: &str,
+    ) -> Result<String, anyhow::Error>;
     async fn get_all_latest_module(&self, track: &str) -> Result<Vec<ModuleResp>, anyhow::Error>;
     async fn get_all_latest_stack(&self, track: &str) -> Result<Vec<ModuleResp>, anyhow::Error>;
     async fn get_all_module_versions(

--- a/env_aws/src/provider.rs
+++ b/env_aws/src/provider.rs
@@ -138,10 +138,14 @@ impl CloudProvider for AwsCloudProvider {
     ) -> Result<Option<ModuleResp>, anyhow::Error> {
         _get_module_optional(self, crate::get_latest_stack_version_query(stack, track)).await
     }
-    async fn generate_presigned_url(&self, key: &str) -> Result<String, anyhow::Error> {
+    async fn generate_presigned_url(
+        &self,
+        key: &str,
+        bucket: &str,
+    ) -> Result<String, anyhow::Error> {
         match crate::run_function(
             &self.function_endpoint,
-            &crate::get_generate_presigned_url_query(key, "modules"),
+            &crate::get_generate_presigned_url_query(key, bucket),
             &self.project_id,
             &self.region,
         )

--- a/env_azure/src/provider.rs
+++ b/env_azure/src/provider.rs
@@ -114,10 +114,14 @@ impl CloudProvider for AzureCloudProvider {
     ) -> Result<Option<ModuleResp>, anyhow::Error> {
         _get_module_optional(self, crate::get_latest_stack_version_query(stack, track)).await
     }
-    async fn generate_presigned_url(&self, key: &str) -> Result<String, anyhow::Error> {
+    async fn generate_presigned_url(
+        &self,
+        key: &str,
+        bucket: &str,
+    ) -> Result<String, anyhow::Error> {
         match crate::run_function(
             &self.function_endpoint,
-            &crate::get_generate_presigned_url_query(key, "modules"),
+            &crate::get_generate_presigned_url_query(key, bucket),
             &self.project_id,
             &self.region,
         )

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -200,8 +200,12 @@ impl CloudProvider for GenericCloudHandler {
     ) -> Result<Option<ModuleResp>, anyhow::Error> {
         self.provider.get_latest_stack_version(stack, track).await
     }
-    async fn generate_presigned_url(&self, key: &str) -> Result<String, anyhow::Error> {
-        self.provider.generate_presigned_url(key).await
+    async fn generate_presigned_url(
+        &self,
+        key: &str,
+        bucket: &str,
+    ) -> Result<String, anyhow::Error> {
+        self.provider.generate_presigned_url(key, bucket).await
     }
     async fn get_all_latest_module(&self, track: &str) -> Result<Vec<ModuleResp>, anyhow::Error> {
         self.provider.get_all_latest_module(track).await

--- a/terraform_runner/src/lib.rs
+++ b/terraform_runner/src/lib.rs
@@ -13,8 +13,9 @@ pub use opa::{
 };
 pub use read::read_module_from_file;
 pub use terraform::{
-    run_terraform_command, store_backend_file, store_tf_vars_json, terraform_apply_destroy,
-    terraform_init, terraform_output, terraform_plan, terraform_show, terraform_validate,
+    run_terraform_command, set_up_provider_mirror, store_backend_file, store_tf_vars_json,
+    terraform_apply_destroy, terraform_init, terraform_output, terraform_plan, terraform_show,
+    terraform_validate,
 };
 pub use utils::get_env_var;
 pub use webhook::post_webhook;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -10,6 +10,7 @@ mod provider_util;
 mod schema_validation;
 mod stack;
 mod string_utils;
+mod terraform;
 mod time;
 mod variables;
 mod versioning;
@@ -39,6 +40,7 @@ pub use provider_util::{
 pub use schema_validation::{validate_module_schema, validate_policy_schema};
 pub use stack::read_stack_directory;
 pub use string_utils::{to_camel_case, to_snake_case};
+pub use terraform::get_provider_url_key;
 pub use time::{epoch_to_timestamp, get_epoch, get_timestamp};
 pub use variables::{
     verify_required_variables_are_set, verify_variable_claim_casing,

--- a/utils/src/terraform.rs
+++ b/utils/src/terraform.rs
@@ -1,0 +1,32 @@
+use env_defs::TfLockProvider;
+
+pub fn get_provider_url_key(
+    tf_lock_provider: &TfLockProvider,
+    target: &str,
+    category: &str,
+) -> (String, String) {
+    let parts: Vec<&str> = tf_lock_provider.source.split('/').collect();
+    // parts: ["registry.terraform.io", "hashicorp", "aws"]
+    let namespace = parts[1];
+    let provider = parts[2];
+
+    let prefix = format!(
+        "terraform-provider-{provider}_{version}",
+        provider = provider,
+        version = tf_lock_provider.version
+    );
+    let file = match category {
+        // "index_json" => format!("index.json"),
+        "provider_binary" => format!("{prefix}_{target}.zip"),
+        "shasum" => format!("{prefix}_SHA256SUMS"),
+        "signature" => format!("{prefix}_SHA256SUMS.72D7468F.sig"), // New Hashicorp signature after incident HCSEC-2021-12 (v0.15.1 and later)
+        _ => panic!("Invalid category"),
+    };
+
+    let download_url = format!(
+        "https://releases.hashicorp.com/terraform-provider-{provider}/{version}/{file}",
+        version = tf_lock_provider.version,
+    );
+    let key = format!("registry.terraform.io/{namespace}/{provider}/{file}",);
+    (download_url, key)
+}


### PR DESCRIPTION
This pull request introduces significant updates to the handling of Terraform providers, including support for provider mirroring, enhanced error handling, and updates to the `generate_presigned_url` method across multiple cloud providers. These changes improve Terraform workflows by enabling pre-downloading of providers, streamlining API interactions, and enhancing logging and error management.

### Enhancements to Terraform Provider Handling:
* Added the `set_up_provider_mirror` function to create a local provider mirror and pre-download Terraform providers for improved offline support. This includes dynamically generating `.terraformrc` files and downloading provider binaries, checksums, and signatures. (`terraform_runner/src/terraform.rs`, [terraform_runner/src/terraform.rsR546-R634](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07R546-R634))
* Introduced the `get_provider_url_key` utility function to construct download URLs and S3 keys for Terraform providers. (`utils/src/terraform.rs`, [utils/src/terraform.rsR1-R32](diffhunk://#diff-acc94ee3ce15ed8afc6b88fbf73fe33a2d813b7213717cdf3f06ef026e50b1e2R1-R32))

### Updates to `generate_presigned_url`:
* Modified the `generate_presigned_url` method in the `CloudProvider` trait to accept a `bucket` parameter, updating all implementations (`AwsCloudProvider`, `AzureCloudProvider`, `GenericCloudHandler`) accordingly. (`defs/src/provider.rs`, [[1]](diffhunk://#diff-89b7226cf04a3e2503474c49a8ea3a0dedd488c89f29a81bcaf25c0e14faf423L72-R76); `env_aws/src/provider.rs`, [[2]](diffhunk://#diff-b3a53a302ae9534b38dbf2b6144fce8af1ff0c6a709391ac41749f7876507dd0L141-R148); `env_azure/src/provider.rs`, [[3]](diffhunk://#diff-e353cace0e989e1dc552e6d01e1b66dc2c20e66822d8fc401e6c03f4b1a0183bL117-R124); `env_common/src/interface/cloud_handlers.rs`, [[4]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7L203-R208)

### Improvements to Module Publishing:
* Enhanced the `publish_module` function to upload and cache Terraform providers in all regions during module publishing. (`env_common/src/logic/api_module.rs`, [env_common/src/logic/api_module.rsL213-R235](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9L213-R235))
* Added the `upload_provider` function to handle the provider upload logic, ensuring providers are cached in cloud storage. (`env_common/src/logic/api_module.rs`, [env_common/src/logic/api_module.rsR299-R341](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9R299-R341))

### Error Handling and Logging:
* Improved error handling in `download_zip` with detailed context for failures and checks for 404 errors. (`utils/src/file.rs`, [utils/src/file.rsL170-R189](diffhunk://#diff-7f5d2b7e915c9b4314806364c4159b29c1a6709e1af3931dc956e02d52d0b928L170-R189))
* Replaced `info!` logs with `println!` for more consistent output during module publishing. (`env_common/src/logic/api_module.rs`, [env_common/src/logic/api_module.rsL213-R235](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9L213-R235))

### Terraform Workflow Updates:
* Updated the `terraform_flow` function to pre-download Terraform providers before initializing Terraform. (`terraform_runner/src/main.rs`, [terraform_runner/src/main.rsR133-R144](diffhunk://#diff-e9e0fc901305920f7cc58ed668c4ce89104dfcafe05a7d4da1b9b73105d012e0R133-R144))
* Added the `TF_CLI_CONFIG_FILE` environment variable to Terraform commands for custom provider mirror configurations. (`terraform_runner/src/terraform.rs`, [terraform_runner/src/terraform.rsR41](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07R41))