### PR TITLE
fix: set cli version from tag build

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   PROJECT_NAME: cli
+  VERSION: ${{ github.ref_name }}
 
 jobs:
   build:
@@ -29,12 +30,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4
         with:
           targets: "${{ matrix.target }}"
 
       - name: Setup Cache for Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 
       - name: Build Binary
         run: cargo build -p ${PROJECT_NAME} --verbose --locked --release --target ${{ matrix.target }}
@@ -78,7 +79,7 @@ jobs:
           path: ./cli-releases
 
       - name: Create GitHub Release and Upload Assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         with:
           files: ./cli-releases/** # Upload all binaries as release assets
         env:

--- a/.github/workflows/docker-cli.yml
+++ b/.github/workflows/docker-cli.yml
@@ -12,6 +12,8 @@ jobs:
       version: ${{ github.ref_name }}
       image_name: cli
       folder: cli
+    env:
+      VERSION: ${{ github.ref_name }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -131,6 +131,6 @@ jobs:
           find dist/ -name '*.whl' -exec cp {} dist_collected/ \;
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           packages-dir: dist_collected/

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "cli"
 version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
+build = "build.rs"
 
 [dependencies]
 clap = "3.0"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,8 @@
 FROM rust:1.82-alpine AS builder
 
+ARG VERSION
+ENV VERSION=${VERSION}
+
 RUN apk add --no-cache \
     build-base \
     musl-dev \

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let ver = std::env::var("VERSION").unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+    println!("cargo:rustc-env=APP_VERSION={}", ver);
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,11 +15,8 @@ use log::{error, info};
 
 #[tokio::main]
 async fn main() {
-    setup_logging().unwrap();
-    initialize_project_id_and_region().await;
-
     let matches = App::new("CLI App")
-        .version("0.1.0")
+        .version(env!("APP_VERSION"))
         .author("InfraWeave <opensource@infraweave.com>")
         .about("Handles all InfraWeave CLI operations")
         .subcommand(
@@ -361,6 +358,9 @@ async fn main() {
                 ),
         )
         .get_matches();
+
+    setup_logging().unwrap();
+    initialize_project_id_and_region().await;
 
     match matches.subcommand() {
         Some(("module", module_matches)) => match module_matches.subcommand() {


### PR DESCRIPTION
This pull request introduces dynamic versioning support, updating GitHub Actions workflows with to set the build-version for the --version flag.

### Versioning and Build System Updates:
* Added a `build.rs` file to dynamically set the `APP_VERSION` environment variable based on the `VERSION` environment variable or the package version from `Cargo.toml`. 
* Updated `Cargo.toml` to include a `build = "build.rs"` directive for the custom build script. 
* Modified the `Dockerfile` to accept a `VERSION` argument and set it as an environment variable during the build process. 

### GitHub Actions Workflow Updates:
* Added a `VERSION` environment variable to the `docker-cli.yml` workflow for consistent versioning. 
* Updated the actions to use a specific commit reference.

### Code Refactoring:
* Updated the CLI's `main.rs` to use the dynamically set `APP_VERSION` for the application's version, replacing the hardcoded version string. 
* Rearranged the initialization flow in the `main` function to ensure logging and project setup occur before handling subcommands. 