### PR TITLE
fix: replace infraweave_py deployment environment with namespace

### DIFF
--- a/infraweave_py/test.py
+++ b/infraweave_py/test.py
@@ -22,7 +22,7 @@ print(s3bucket.get_name())
 
 bucket1 = Deployment(
     name="bucket1",
-    environment="dev",
+    namespace="dev",
     region="us-west-2",
     module=s3bucket,
 )


### PR DESCRIPTION
This pull request makes a significant change to the `Deployment` struct and its related methods by replacing the term `environment` with `namespace`. This is to align with the Kubernetes-compatible claims that are used with other deployment methods. Below is a summary of the most important changes:

### Refactor from `environment` to `namespace` in `Deployment` struct:

* The `environment` field in the `Deployment` struct has been renamed to `namespace`, and all references to `environment` throughout the code have been updated accordingly.

### Updates to method logic and logging:

* The `get_environment` function has been renamed to `get_namespace`, with its logic updated to reflect the terminology change. 
* Logging messages in methods like `apply`, `plan`, and `destroy` have been updated to use `namespace` instead of `environment`. (`infraweave_py/src/deployment.rs`,

### Updates to async functions:

* All async functions, such as `run_job` and `plan_or_apply_deployment`, now reference `namespace` instead of `environment` in their parameters and logic. 