### PR TITLE
fix: cleaner error message for missing region or credentials

### DIFF
--- a/env_aws/src/utils.rs
+++ b/env_aws/src/utils.rs
@@ -3,10 +3,13 @@ use aws_config::meta::region::RegionProviderChain;
 #[allow(dead_code)]
 pub async fn get_region() -> String {
     let region_provider = RegionProviderChain::default_provider().or_default_provider();
-    let region = region_provider
-        .region()
-        .await
-        .expect("Failed to load region");
+    let region = match region_provider.region().await {
+        Some(region) => region,
+        None => {
+            println!("No region found, did you forget to set AWS_REGION?");
+            std::process::exit(1);
+        }
+    };
     region.to_string()
 }
 


### PR DESCRIPTION
This pull request improves error handling for region and project ID retrieval in the AWS and Azure cloud providers, ensuring that the application exits gracefully with meaningful error messages when critical configuration values are missing or cannot be retrieved.

### Error Handling Improvements:

* **AWS Region Retrieval**: Updated the `get_region` function in `env_aws/src/utils.rs` to handle cases where no region is found. If the region is missing, a clear error message is printed, and the application exits with a non-zero status.

* **AWS Project ID Retrieval**: Modified the `GenericCloudHandler` implementation in `env_common/src/interface/cloud_handlers.rs` to handle errors during AWS project ID retrieval. If the project ID cannot be fetched, an error message is logged, and the application exits.

* **Azure Project ID Retrieval**: Similarly, updated the `GenericCloudHandler` implementation to handle errors during Azure project ID retrieval. If the project ID retrieval fails, the application logs the error and exits.

### Dependency Changes:

* **Added `process::exit` Import**: Included the `process::exit` function in `env_common/src/interface/cloud_handlers.rs` to support the new error handling logic.