### PR TITLE
Feat/add python context manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,18 +220,14 @@ bucket1 = Deployment(
     region="us-west-2"
 )
 
-bucket1.set_variables(
-    bucket_name="my-bucket12347ydfs3"
-)
-
-try:
+with bucket1:
+    bucket1.set_variables(
+        bucket_name="my-bucket12347ydfs3"
+    )
     bucket1.apply()
     # Run some tests here
-except Exception as e:
-    print(f"An error occurred: {e}")
-    # Handle the error as needed
-finally:
-    bucket1.destroy()
+
+# bucket1.destroy() is automatically called when finished (or on error)
 ```
 
 > *This can also be used to create integration tests with multiple modules or stacks*

--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -208,6 +208,26 @@ impl Deployment {
             None => Ok(py.None()),
         }
     }
+
+    // Called at the start of a `with Deployment(...) as d:` block.
+    fn __enter__<'p>(slf: PyRefMut<'p, Self>) -> PyResult<PyRefMut<'p, Self>> {
+        Ok(slf)
+    }
+
+    // Called when exiting the `with` block.
+    fn __exit__(
+        mut slf: PyRefMut<Self>,
+        _exc_type: Option<PyObject>,
+        _exc_value: Option<PyObject>,
+        _traceback: Option<PyObject>,
+    ) -> PyResult<bool> {
+        if slf.last_deployment.is_some() {
+            if let Err(e) = slf.destroy() {
+                eprintln!("Automatic {}.destroy() failed: {}", slf.name, e);
+            }
+        }
+        Ok(false)
+    }
 }
 
 pub fn get_namespace(namespace_arg: &str) -> String {

--- a/infraweave_py/test.py
+++ b/infraweave_py/test.py
@@ -27,19 +27,12 @@ bucket1 = Deployment(
     module=s3bucket,
 )
 
-print(bucket1.outputs)
+with bucket1:
 
-bucket1.set_variables(
-    bucket_name="my-bucket12347ydfs3",
-    enable_acl=False,
-)
-
-try:
-    bucket1.apply()
     print(bucket1.outputs)
-    # Run some tests here
-except Exception as e:
-    print(f"An error occurred: {e}")
-    # Handle the error as needed
-finally:
-    bucket1.destroy()
+
+    bucket1.set_variables(
+        bucket_name="my-bucket12347ydfs3",
+        enable_acl=False,
+    )
+    bucket1.apply()


### PR DESCRIPTION
This pull request introduces a new context manager (`with` block) for the `Deployment` class, simplifying resource lifecycle management by automatically handling cleanup operations. The most important changes include adding `__enter__` and `__exit__` methods to the `Deployment` class and updating examples and tests to use the new context manager.

### Enhancements to `Deployment` lifecycle management:
* [`infraweave_py/src/deployment.rs`](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5R211-R230): Added `__enter__` and `__exit__` methods to the `Deployment` class, enabling its use as a context manager. The `__exit__` method ensures that `destroy()` is automatically called when exiting the `with` block, even in case of errors.

### Updates to documentation and examples:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R223-R230): Updated the example to use the new `with` block for `Deployment`, removing the need for explicit `try-finally` blocks for cleanup.

### Updates to tests:
* [`infraweave_py/test.py`](diffhunk://#diff-4888891347e4d32bccd8c1f326adb05530bb3f3519fe6e20e5b9998745dbea46R30-L45): Modified test code to use the `with` block for `Deployment`, simplifying the code and ensuring automatic cleanup.