### PR TITLE
feat: add infraweave context as tf-vars for use in module

### DIFF
--- a/defs/src/gitprovider.rs
+++ b/defs/src/gitprovider.rs
@@ -68,12 +68,21 @@ pub struct JobDetails {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct User {
+    pub email: String,
+    pub name: String,
+    pub username: String,
+    pub profile_url: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GitHubCheckRun {
     pub installation: Installation,
     pub app_id: String,
     pub repository: Repository,
     pub check_run: CheckRun,
     pub job_details: JobDetails,
+    pub user: User,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -26,7 +26,7 @@ pub use errors::CloudHandlerError;
 pub use event::{get_event_identifier, EventData};
 pub use gitprovider::{
     CheckRun, CheckRunOutput, ExtraData, GitHubCheckRun, Installation, JobDetails, Owner,
-    Repository,
+    Repository, User,
 };
 pub use infra::ApiInfraPayload;
 pub use infra_change_record::{get_change_record_identifier, InfraChangeRecord};

--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -109,11 +109,13 @@ pub struct ModuleResp {
     #[serde(deserialize_with = "deserialize_module_manifest")]
     pub manifest: ModuleManifest,
     pub tf_variables: Vec<TfVariable>,
-    pub tf_outputs: Vec<TfOutput>, // Added to capture the outputs array
+    pub tf_outputs: Vec<TfOutput>,
     #[serde(default)]
     pub tf_required_providers: Vec<TfRequiredProvider>,
     #[serde(default)]
     pub tf_lock_providers: Vec<TfLockProvider>,
+    #[serde(default)]
+    pub tf_extra_environment_variables: Vec<String>,
     pub s3_key: String,
     pub stack_data: Option<ModuleStackData>,
     pub version_diff: Option<ModuleVersionDiff>,

--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -211,8 +211,8 @@ Environment: **{}**
             let private_key_pem = get_securestring_aws(&private_key_pem_ssm_key).await?; // Read here to avoid multiple reads of the same secret
                                                                                          // https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#update-a-check-run
             match post_check_run_from_payload(github_event, &private_key_pem).await {
-                Ok(_) => {
-                    info!("Check run posted");
+                Ok(resp) => {
+                    info!("Check run posted: {}", resp);
                 }
                 Err(e) => {
                     info!("Error posting check run: {}", e);

--- a/integration-tests/modules/s3bucket-dev/main.tf
+++ b/integration-tests/modules/s3bucket-dev/main.tf
@@ -7,8 +7,17 @@ terraform {
   }
 }
 
+provider "aws" {
+  default_tags {
+    tags = merge(
+      var.tags,
+      {
+        INFRAWEAVE_REFERENCE = var.INFRAWEAVE_REFERENCE
+      }
+    )
+  }
+}
+
 resource "aws_s3_bucket" "example" {
   bucket = var.bucket_name
-
-  tags = var.tags
 }

--- a/integration-tests/modules/s3bucket-dev/variables.tf
+++ b/integration-tests/modules/s3bucket-dev/variables.tf
@@ -17,3 +17,9 @@ variable "tags" {
     Test = "override-me"
   }
 }
+
+variable "INFRAWEAVE_REFERENCE" {
+  type = string
+  description = "This is to be set automatically during runtime"
+  default = ""
+}

--- a/integration-tests/tests/module.rs
+++ b/integration-tests/tests/module.rs
@@ -72,6 +72,12 @@ mod module_tests {
             assert_eq!(modules[0].module, "s3bucket");
             assert_eq!(modules[0].version, "0.1.2-dev+test.10");
             assert_eq!(modules[0].track, "dev");
+            assert_eq!(modules[0].tf_extra_environment_variables.len(), 1);
+            assert_eq!(
+                modules[0].tf_extra_environment_variables[0],
+                "INFRAWEAVE_REFERENCE"
+            );
+            assert_eq!(modules[0].tf_variables.len(), 3);
 
             let examples = modules[0].clone().manifest.spec.examples.unwrap();
             assert_eq!(examples[0].name, "simple-bucket");

--- a/integration-tests/tests/stack.rs
+++ b/integration-tests/tests/stack.rs
@@ -104,9 +104,28 @@ mod stack_tests {
                 "ARN of dependency bucket {{ S3Bucket::bucket1a::bucketArn }}",
             );
 
-            assert_eq!(stacks[0].tf_variables[0].name, "bucket1a__bucket_name",);
+            assert_eq!(stacks[0].tf_extra_environment_variables.len(), 1);
+            assert_eq!(
+                stacks[0].tf_extra_environment_variables[0],
+                "INFRAWEAVE_REFERENCE"
+            );
 
+            assert_eq!(stacks[0].tf_variables.len(), 5);
+            assert_eq!(stacks[0].tf_variables[0].name, "bucket1a__bucket_name",);
+            assert_eq!(stacks[0].tf_variables[1].name, "bucket1a__enable_acl",);
+            assert_eq!(stacks[0].tf_variables[2].name, "bucket1a__tags",);
+            assert_eq!(stacks[0].tf_variables[3].name, "bucket2__enable_acl",);
+            assert_eq!(stacks[0].tf_variables[4].name, "bucket2__tags",);
+
+            assert_eq!(stacks[0].tf_outputs.len(), 8);
             assert_eq!(stacks[0].tf_outputs[0].name, "bucket1a__bucket_arn",);
+            assert_eq!(stacks[0].tf_outputs[1].name, "bucket1a__region",);
+            assert_eq!(stacks[0].tf_outputs[2].name, "bucket1a__sse_algorithm",);
+            assert_eq!(stacks[0].tf_outputs[3].name, "bucket1a__tags",);
+            assert_eq!(stacks[0].tf_outputs[4].name, "bucket2__bucket_arn",);
+            assert_eq!(stacks[0].tf_outputs[5].name, "bucket2__region",);
+            assert_eq!(stacks[0].tf_outputs[6].name, "bucket2__sse_algorithm",);
+            assert_eq!(stacks[0].tf_outputs[7].name, "bucket2__tags",);
         })
         .await;
     }

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -830,6 +830,7 @@ mod tests {
                 tf_outputs: vec![],
                 tf_required_providers: vec![],
                 tf_lock_providers: vec![],
+                tf_extra_environment_variables: vec![],
                 s3_key: "test-module-1.0.0-beta".to_string(),
                 stack_data: None,
                 version_diff: None,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -29,7 +29,8 @@ pub use logging::setup_logging;
 pub use module::{
     get_outputs_from_tf_files, get_providers_from_lockfile,
     get_tf_required_providers_from_tf_files, get_variables_from_tf_files, indent,
-    validate_tf_backend_not_set, validate_tf_required_providers_is_set,
+    validate_tf_backend_not_set, validate_tf_extra_environment_variables,
+    validate_tf_required_providers_is_set,
 };
 pub use module_diff::diff_modules;
 pub use provider_util::{

--- a/utils/src/variables.rs
+++ b/utils/src/variables.rs
@@ -336,6 +336,7 @@ mod tests {
                     sensitive: false,
                 },
             ],
+            tf_extra_environment_variables: vec![],
             tf_required_providers: vec![],
             tf_lock_providers: vec![],
             stack_data: None,


### PR DESCRIPTION
This pull request introduces support for allowing a user to create variables that will automatically be set during runtime, e.g. which `deployment_id`, who committed, which repo etc, by adding this to a module:

```tf
...

variable "INFRAWEAVE_GIT_COMMITTER_EMAIL" {
  type    = string
  default = ""
}

variable "INFRAWEAVE_REFERENCE"  {
  type    = string
  default = ""
}
```

Any variable starting with "INFRAWEAVE_" is reserved for this feature and will not be exposed to user as a regular variable. It is mandatory to set `type=string` and `default=""`, you can optionally set a description.

This is commonly used for tags, e.g.:

```tf
provider "aws" {
  default_tags {
    tags = merge(
      var.tags,
      {
        INFRAWEAVE_GIT_COMMITTER_EMAIL = var.INFRAWEAVE_GIT_COMMITTER_EMAIL
        INFRAWEAVE_REFERENCE = var.INFRAWEAVE_REFERENCE
      }
    )
  }
}
```

## Available Options

### Generic (always available)
These will always set a value if you decide to include it
```
INFRAWEAVE_DEPLOYMENT_ID
INFRAWEAVE_ENVIRONMENT
INFRAWEAVE_REFERENCE
INFRAWEAVE_MODULE_VERSION
INFRAWEAVE_MODULE_TYPE
INFRAWEAVE_MODULE_TRACK
INFRAWEAVE_DRIFT_DETECTION
INFRAWEAVE_DRIFT_DETECTION_INTERVAL
```

### GitHub Webhook Specific
Will only be set when pushing to a GitHub repository, otherwise it will be `""` (empty string)
```
INFRAWEAVE_GIT_COMMITTER_EMAIL
INFRAWEAVE_GIT_COMMITTER_NAME
INFRAWEAVE_GIT_ACTOR_USERNAME
INFRAWEAVE_GIT_ACTOR_PROFILE_URL
INFRAWEAVE_GIT_REPOSITORY_NAME
INFRAWEAVE_GIT_REPOSITORY_PATH
INFRAWEAVE_GIT_COMMIT_SHA
```

### Enhancements to Terraform module and stack handling:
* Added a new field `tf_extra_environment_variables` to the `ModuleResp` struct to store extra environment variables for Terraform modules (`defs/src/module.rs`).
* Updated the `publish_module` and `publish_stack` functions to filter and process Terraform variables starting with `INFRAWEAVE_` as extra environment variables (`env_common/src/logic/api_module.rs`, `env_common/src/logic/api_stack.rs`) 
* Modified the `generate_full_terraform_module` function to include `tf_extra_environment_variables` in the generated Terraform module and variables (`env_common/src/logic/api_stack.rs`)
* Enhanced the `generate_terraform_variables` and `generate_terraform_module_single` functions to incorporate extra environment variables into the Terraform configuration (`env_common/src/logic/api_stack.rs`) 
* Updated tests to validate the handling of extra environment variables in Terraform modules (`env_common/src/logic/api_stack.rs`) 

### Git provider enhancements:
* Introduced a new `User` struct to represent user details and added it to the `GitHubCheckRun` struct (`defs/src/gitprovider.rs`).
* Exported the `User` struct for use in other modules (`defs/src/lib.rs`).

### Logging improvements:
* Added `debug` logging for better traceability in Terraform variable generation (`env_common/src/logic/api_stack.rs`).