### PR TITLE
docs: use namespace in readme python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ bucket_module = S3Bucket(
 
 bucket1 = Deployment(
     name="bucket1",
-    environment="playground",
+    namespace="playground",
     module=bucket_module,
     region="us-west-2"
 )


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file to correct a parameter name in the `S3Bucket` deployment example.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L218-R218): Updated the `Deployment` example to replace the `environment` parameter with `namespace` for consistency with the `S3Bucket` module's expected arguments.