### PR TITLE
fix: use user-defined functions for config table in azure

### DIFF
--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -527,12 +527,12 @@ pub fn get_policy_query(policy: &str, environment: &str, version: &str) -> Value
 
 pub fn get_project_map_query() -> Value {
     json!({
-        "query": "SELECT * FROM c WHERE c.PK = 'project_map'",
+        "query": "SELECT udf.getProjectMap() AS data",
     })
 }
 
 pub fn get_all_regions_query() -> Value {
     json!({
-        "query": "SELECT * FROM c WHERE c.PK = 'all_regions'",
+        "query": "SELECT udf.getAllRegions() AS data",
     })
 }

--- a/integration-tests/azure-function-code/bootstrap.py
+++ b/integration-tests/azure-function-code/bootstrap.py
@@ -73,14 +73,28 @@ def bootstrap_tables():
 
     container = database.get_container_client(config_container_name)
 
-    config_item = {
+    # Insert config item (uses UDF in real code and azure function)
+    all_regions_config_item = {
         "id": "all_regions",
         "PK": "all_regions",
         "data": {
             "regions": ["eastus"]
         }
     }
-    container.upsert_item(config_item)
+    container.upsert_item(all_regions_config_item)
+    project_map_config_item = {
+        "id": "project_map",
+        "PK": "project_map",
+        "data": {
+            "some-org/deploy-project-1": {
+                "project_id": "123400000000"
+            },
+            "some-org/deploy-project-1": {
+                "project_id": "987600000000"
+            }
+        }
+    }
+    container.upsert_item(project_map_config_item)
 
 def bootstrap_buckets():
     conn_str = os.environ["AZURITE_CONNECTION_STRING"]

--- a/integration-tests/azure-function-code/function_app.py
+++ b/integration-tests/azure-function-code/function_app.py
@@ -328,6 +328,14 @@ def read_db(req: func.HttpRequest) -> func.HttpResponse:
     database = client.get_database_client(COSMOS_DB_DATABASE)
     container = database.get_container_client(container_name)
 
+    # Due to UDF not being supported in Cosmos DB Emulator, we need to make regular query in tests
+    # https://learn.microsoft.com/en-us/azure/cosmos-db/emulator-linux#feature-support
+
+    if query["query"] == "SELECT udf.getAllRegions() AS data":
+        query["query"] = "SELECT * FROM c WHERE c.PK = 'all_regions'"
+    elif query["query"] == "SELECT udf.getProjectMap() AS data":
+        query["query"] = "SELECT * FROM c WHERE c.PK = 'project_map'"
+
     try:
         items = list(container.query_items(
             query=query,


### PR DESCRIPTION
This pull request refactors queries in the Azure integration codebase to utilize user-defined functions (UDFs) for retrieving data, while also adding test-specific fallbacks to handle the Cosmos DB Emulator's lack of UDF support. Additionally, it updates the test bootstrap code to align with these changes.

The reason to use user-defined functions is to make it easier to store data in table using terraform since azure is missing data-plane resource for cosmos db items.

### Query refactoring to use UDFs:
* [`env_azure/src/api.rs`](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL530-R536): Updated the `get_project_map_query` and `get_all_regions_query` functions to use UDFs (`udf.getProjectMap` and `udf.getAllRegions`) instead of direct queries.

### Test-specific fallbacks for UDFs:
* [`integration-tests/azure-function-code/function_app.py`](diffhunk://#diff-3c6f70a5246416dfe0e67c0703a1cc4d467f3cccaae569db3fbfeb1eeac08a88R331-R338): Added fallback logic in the `read_db` function to replace UDF-based queries with direct queries when running tests in the Cosmos DB Emulator, which does not support UDFs.

### Updates to test bootstrap code:
* [`integration-tests/azure-function-code/bootstrap.py`](diffhunk://#diff-504d88486a258de85297e62e7d0a86244319f299bc3b9981be8d36310920cfceL76-R97): Modified the `bootstrap_tables` function to insert test data for `all_regions` and `project_map` directly, aligning with the new query structure.