### PR TITLE
fix: use storage_basepath for tf-state and change-records when storing files

### DIFF
--- a/defs/src/provider.rs
+++ b/defs/src/provider.rs
@@ -41,6 +41,7 @@ pub trait CloudProvider: Send + Sync {
     fn get_function_endpoint(&self) -> Option<String>;
     fn get_cloud_provider(&self) -> &str;
     fn get_backend_provider(&self) -> &str;
+    fn get_storage_basepath(&self) -> String;
     async fn set_backend(
         &self,
         exec: &mut tokio::process::Command,

--- a/env_aws/src/backend.rs
+++ b/env_aws/src/backend.rs
@@ -2,15 +2,15 @@ use std::env;
 
 pub async fn set_backend(
     exec: &mut tokio::process::Command,
+    storage_basepath: &str,
     deployment_id: &str,
     environment: &str,
 ) {
-    let account_id = get_env_var("ACCOUNT_ID");
     let tf_bucket = get_env_var("TF_BUCKET");
     let region = get_env_var("REGION");
     let key = format!(
-        "{}/{}/{}/terraform.tfstate",
-        account_id, environment, deployment_id
+        "{}{}/{}/terraform.tfstate",
+        storage_basepath, environment, deployment_id
     );
     let dynamodb_table = get_env_var("TF_DYNAMODB_TABLE");
     exec.arg(format!("-backend-config=bucket={}", tf_bucket));

--- a/env_aws/src/provider.rs
+++ b/env_aws/src/provider.rs
@@ -38,13 +38,22 @@ impl CloudProvider for AwsCloudProvider {
     fn get_backend_provider(&self) -> &str {
         "s3"
     }
+    fn get_storage_basepath(&self) -> String {
+        format!("{}/", self.project_id) // Shared storage bucket with all projects
+    }
     async fn set_backend(
         &self,
         exec: &mut tokio::process::Command,
         deployment_id: &str,
         environment: &str,
     ) {
-        crate::set_backend(exec, deployment_id, environment).await;
+        crate::set_backend(
+            exec,
+            &self.get_storage_basepath(),
+            deployment_id,
+            environment,
+        )
+        .await;
     }
     async fn get_current_job_id(&self) -> Result<String, anyhow::Error> {
         crate::get_current_job_id().await

--- a/env_azure/src/backend.rs
+++ b/env_azure/src/backend.rs
@@ -2,14 +2,15 @@ use std::env;
 
 pub async fn set_backend(
     exec: &mut tokio::process::Command,
+    storage_basepath: &str,
     deployment_id: &str,
     environment: &str,
 ) {
     let account_id = get_env_var("ACCOUNT_ID");
     let tf_bucket = get_env_var("TF_BUCKET");
     let key = format!(
-        "{}/{}/{}/terraform.tfstate",
-        account_id, environment, deployment_id
+        "{}{}/{}/terraform.tfstate",
+        storage_basepath, environment, deployment_id
     );
     let storage_account = get_env_var("STORAGE_ACCOUNT");
     let resource_group_name = get_env_var("RESOURCE_GROUP_NAME");

--- a/env_azure/src/provider.rs
+++ b/env_azure/src/provider.rs
@@ -38,13 +38,22 @@ impl CloudProvider for AzureCloudProvider {
     fn get_backend_provider(&self) -> &str {
         "azurerm"
     }
+    fn get_storage_basepath(&self) -> String {
+        "".to_string() // Every subscription has its own storage blob container
+    }
     async fn set_backend(
         &self,
         exec: &mut tokio::process::Command,
         deployment_id: &str,
         environment: &str,
     ) {
-        crate::set_backend(exec, deployment_id, environment).await;
+        crate::set_backend(
+            exec,
+            &self.get_storage_basepath(),
+            deployment_id,
+            environment,
+        )
+        .await;
     }
     async fn get_current_job_id(&self) -> Result<String, anyhow::Error> {
         crate::get_current_job_id().await

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -166,6 +166,9 @@ impl CloudProvider for GenericCloudHandler {
     fn get_backend_provider(&self) -> &str {
         self.provider.get_backend_provider()
     }
+    fn get_storage_basepath(&self) -> String {
+        self.provider.get_storage_basepath()
+    }
     async fn set_backend(
         &self,
         exec: &mut tokio::process::Command,

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -389,10 +389,13 @@ pub async fn terraform_show(
                 }
             }
 
-            let account_id = get_env_var("ACCOUNT_ID");
             let plan_raw_json_key = format!(
-                "{}/{}/{}/{}_{}_plan_output.json",
-                account_id, environment, deployment_id, command, job_id
+                "{}{}/{}/{}_{}_plan_output.json",
+                handler.get_storage_basepath(),
+                environment,
+                deployment_id,
+                command,
+                job_id
             );
 
             let infra_change_record = InfraChangeRecord {


### PR DESCRIPTION
This pull request introduces changes to standardize and extend the handling of storage base paths across different cloud providers. Key changes include adding a new `get_storage_basepath` method to the `CloudProvider` trait, updating implementations for AWS, Azure, and a generic handler, and modifying backend-related functions to use this new method. 

The reason is that AWS uses one shared bucket for tf-state and change-records, meanwhile Azure has its own storage blob container, due to access management and quota limit differences.

### Enhancements to `CloudProvider` trait and implementations:

* Added a new `get_storage_basepath` method to the `CloudProvider` trait to standardize the retrieval of storage base paths. 
* Implemented `get_storage_basepath` for `AwsCloudProvider` to return a formatted path based on the project ID. 
* Implemented `get_storage_basepath` for `AzureCloudProvider` to return an empty string, as each subscription uses its own storage container. 
* Updated the `GenericCloudHandler` to delegate `get_storage_basepath` calls to the underlying provider. 

### Refactoring of backend-related functions:

* Modified `set_backend` functions for AWS and Azure to accept `storage_basepath` as a parameter and updated the key formatting to use this new parameter. 
* Updated `terraform_show` to use the `get_storage_basepath` method for constructing the plan output JSON key, enhancing consistency across providers.