### PR TITLE
fix: shorten azure function api name and fix tofu build

### DIFF
--- a/.github/workflows/build-and-push-docker-template.yml
+++ b/.github/workflows/build-and-push-docker-template.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: Dockerfile
+      tag_prefix:
+        required: false
+        type: string
+        default: ""
     secrets:
       DOCKER_USERNAME:
         required: true
@@ -83,17 +87,17 @@ jobs:
 
       - name: Build AMD64 Image
         run: |
-          docker build --build-arg ARCH=amd64 -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
-          docker push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64
+          docker build --build-arg ARCH=amd64 -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
+          docker push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
 
-          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64
-          docker push ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64
+          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
+          docker push ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
 
-          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64
-          docker push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64
+          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
+          docker push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
 
-          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64
-          docker push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64
+          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
+          docker push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
 
   build-arm64:
     runs-on: ubuntu-24.04-arm
@@ -141,17 +145,17 @@ jobs:
 
       - name: Build ARM64 Image
         run: |
-          docker buildx build --build-arg ARCH=arm64 --load --platform linux/arm64 -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
-          docker push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
+          docker buildx build --build-arg ARCH=arm64 --load --platform linux/arm64 -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
+          docker push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
 
-          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64 ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker push ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
+          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64 ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker push ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
 
-          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64 ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
+          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64 ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
 
-          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64 ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
+          docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64 ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
 
   create-manifest:
     needs: [build-amd64, build-arm64]
@@ -195,43 +199,43 @@ jobs:
       - name: Create and Push Manifests
         run: |
           # Versioned
-          docker manifest create ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }} \
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}
+          docker manifest create ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }} \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}
 
-          docker manifest create ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }} \
-            ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}
+          docker manifest create ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }} \
+            ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}
 
-          docker manifest create ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }} \
-            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}
+          docker manifest create ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }} \
+            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}
 
-          docker manifest create ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }} \
-            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}
+          docker manifest create ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }} \
+            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}
 
           # Latest
-          docker manifest create ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:latest \
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:latest
+          docker manifest create ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest
 
-          docker manifest create ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:latest \
-            ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:latest
+          docker manifest create ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest \
+            ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest
 
-          docker manifest create ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:latest \
-            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:latest
+          docker manifest create ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest \
+            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest
 
-          docker manifest create ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:latest \
-            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-amd64 \
-            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.version }}-arm64
-          docker manifest push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:latest
+          docker manifest create ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest \
+            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 \
+            ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
+          docker manifest push ${{ env.PUBLIC_ECR_REGISTRY }}/${{ env.ECR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}latest

--- a/.github/workflows/docker-runner.yml
+++ b/.github/workflows/docker-runner.yml
@@ -24,9 +24,10 @@ jobs:
     uses: ./.github/workflows/build-and-push-docker-template.yml
     with:
       version: ${{ github.ref_name }}
-      image_name: tofu-runner
+      image_name: runner
       folder: terraform_runner
       dockerfile: Dockerfile.tofu
+      tag_prefix: "tofu-"
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -42,9 +42,9 @@ pub async fn run_function(
     let base_url = function_endpoint.clone().unwrap_or_else(|| {
         let subscription_id =
             std::env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
-        let truncated_subscription_id = &subscription_id[..8.min(subscription_id.len())];
+        let truncated_subscription_id = &subscription_id[..18.min(subscription_id.len())];
         format!(
-            "https://infraweave-func-{}-{}-{}.azurewebsites.net",
+            "https://iw-{}-{}-{}.azurewebsites.net",
             truncated_subscription_id, region, api_environment
         )
     });


### PR DESCRIPTION
This pull request includes a small but important change to the `run_function` method in `env_azure/src/api.rs`. The changes update the format of the Azure function endpoint URL and increase the length of the truncated subscription ID.

* [`env_azure/src/api.rs`](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL45-R47): Updated the Azure function endpoint URL format to use a shorter prefix (`iw` instead of `infraweave-func`) and increased the truncation length of the subscription ID from 8 to 18 characters.
* Added a new `tag_prefix` input to the `build-and-push-docker-template.yml` workflow, allowing for customizable prefixes in Docker image tags. (`.github/workflows/build-and-push-docker-template.yml`, [.github/workflows/build-and-push-docker-template.ymlR19-R22](diffhunk://#diff-535f184848ef51c98fdd9ae9b5acf3e60321e864337d2b41d2ab1b6a83002240R19-R22))
* Updated the `docker-runner.yml` workflow to use the new `tag_prefix` input, setting it to `"tofu-"` for the `runner` image. (`.github/workflows/docker-runner.yml`, [.github/workflows/docker-runner.ymlL27-R30](diffhunk://#diff-9edca618eb421d563563a49b062f144eedaf2e9bd5cc56c92310052c6ae14b61L27-R30))