### PR TITLE
ci: pass version to docker build

### DIFF
--- a/.github/workflows/build-and-push-docker-template.yml
+++ b/.github/workflows/build-and-push-docker-template.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Build AMD64 Image
         run: |
-          docker build --build-arg ARCH=amd64 -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
+          docker build --build-arg ARCH=amd64 --build-arg VERSION=${{ inputs.version }} -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
           docker push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
 
           docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64 ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-amd64
@@ -145,7 +145,7 @@ jobs:
 
       - name: Build ARM64 Image
         run: |
-          docker buildx build --build-arg ARCH=arm64 --load --platform linux/arm64 -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
+          docker buildx build --build-arg ARCH=arm64 --build-arg VERSION=${{ inputs.version }} --load --platform linux/arm64 -t ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64 -f ${{ inputs.folder }}/${{ inputs.dockerfile }} .
           docker push ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64
 
           docker tag ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64 ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPO }}/${{ inputs.image_name }}:${{ inputs.tag_prefix }}${{ inputs.version }}-arm64

--- a/.github/workflows/docker-cli.yml
+++ b/.github/workflows/docker-cli.yml
@@ -12,8 +12,6 @@ jobs:
       version: ${{ github.ref_name }}
       image_name: cli
       folder: cli
-    env:
-      VERSION: ${{ github.ref_name }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This pull request updates Docker workflow files to improve build processes and simplify configurations. The most important changes include adding a new build argument for Docker versions and removing redundant environment variables.

### Improvements to Docker build processes:
* [`.github/workflows/build-and-push-docker-template.yml`](diffhunk://#diff-535f184848ef51c98fdd9ae9b5acf3e60321e864337d2b41d2ab1b6a83002240L90-R90): Added `--build-arg VERSION=${{ inputs.version }}` to both AMD64 and ARM64 Docker build commands to explicitly pass the version as a build argument. [[1]](diffhunk://#diff-535f184848ef51c98fdd9ae9b5acf3e60321e864337d2b41d2ab1b6a83002240L90-R90) [[2]](diffhunk://#diff-535f184848ef51c98fdd9ae9b5acf3e60321e864337d2b41d2ab1b6a83002240L148-R148)

### Simplification of workflow configuration:
* [`.github/workflows/docker-cli.yml`](diffhunk://#diff-dbf61abd869f700a90ee4c7a759edd3f3bb52a5d5de14586357511f06c092aaeL15-L16): Removed the redundant `VERSION` environment variable, as the version is already derived from `github.ref_name`.