### PR TITLE
ci: add cli build targets

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -21,9 +21,18 @@ jobs:
           - name: linux-amd64
             runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          - name: linux-arm64
+            runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - name: macos-amd64
+            runner: macos-latest
+            target: x86_64-apple-darwin
           - name: macos-arm64
             runner: macos-latest
             target: aarch64-apple-darwin
+          - name: windows-amd64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
 
     steps:
       - name: Checkout Code
@@ -37,8 +46,17 @@ jobs:
       - name: Setup Cache for Cargo
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 
-      - name: Build Binary
-        run: cargo build -p ${PROJECT_NAME} --verbose --locked --release --target ${{ matrix.target }}
+      - name: Install cross
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cargo install cross --locked
+
+      - name: Build with cross
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cross build -p ${{ env.PROJECT_NAME }} --verbose --locked --release --target ${{ matrix.target }}
+
+      - name: Build with cargo
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        run: cargo build -p ${{ env.PROJECT_NAME }} --verbose --locked --release --target ${{ matrix.target }}
 
       - name: Prepare Binary for Release
         shell: bash


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building CLI binaries to support additional platforms and improve build compatibility. The key changes include adding new build targets and introducing conditional logic to use `cross` for Linux builds while retaining `cargo` for others.

### Platform Support Enhancements:
* Added new build targets for `linux-arm64`, `macos-amd64`, and `windows-amd64` to the `jobs` matrix, expanding cross-platform compatibility. 

### Build Process Improvements:
* Introduced conditional logic to use `cross` for building binaries on Linux runners, enabling easier cross-compilation for arm target for linux, while retaining `cargo` for macOS and Windows builds.