### PR TITLE
fix: require INFRAWEAVE_ENV to be set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ integration-tests: aws-integration-tests azure-integration-tests
 aws-integration-tests:
 	@echo "Running AWS integration tests..."
 	PROVIDER=aws \
+	INFRAWEAVE_ENV=dev \
 	INFRAWEAVE_API_FUNCTION=function \
 	AWS_ACCESS_KEY_ID=dummy \
 	AWS_SECRET_ACCESS_KEY=dummy \
@@ -20,6 +21,7 @@ aws-integration-tests:
 azure-integration-tests:
 	@echo "Running Azure integration tests..."
 	PROVIDER=azure \
+	INFRAWEAVE_ENV=dev \
 	INFRAWEAVE_API_FUNCTION=function \
 	AZURE_CLIENT_ID=dummy \
 	AZURE_CLIENT_SECRET=dummy \

--- a/defs/src/errors.rs
+++ b/defs/src/errors.rs
@@ -13,4 +13,7 @@ pub enum CloudHandlerError {
 
     #[error("An error occured when serving the request: {0}")]
     OtherError(String),
+
+    #[error("Please make sure to set the platform environment, for example: \"export INFRAWEAVE_ENV=dev\"")]
+    MissingEnvironment(),
 }

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, process::exit};
 
 use anyhow::Result;
 use azure_core::auth::TokenCredential;
@@ -38,7 +38,15 @@ pub async fn run_function(
         function_endpoint.clone().unwrap_or("notset".to_string())
     );
     let region = crate::get_region().await;
-    let api_environment = std::env::var("INFRAWEAVE_ENV").unwrap_or("prod".to_string());
+    let api_environment = match std::env::var("INFRAWEAVE_ENV") {
+        Ok(env) => env,
+        Err(_) => {
+            println!("Please make sure to set the platform environment, for example: \"export INFRAWEAVE_ENV=dev\"");
+            exit(1);
+            // TODO: Remove unwraps in cli and then throw error instead of exit(1)
+            // return Err(CloudHandlerError::MissingEnvironment());
+        }
+    };
     let base_url = function_endpoint.clone().unwrap_or_else(|| {
         let subscription_id =
             std::env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -58,8 +58,15 @@ mod operator_tests {
             let exists = crd_exists(&client, "s3buckets.infraweave.io").await;
             assert_eq!(exists, false); // Operator has not started yet, no CRD should exist
 
-            let current_environment =
-                std::env::var("INFRAWEAVE_ENVIRONMENT").unwrap_or_else(|_| "dev".to_string());
+            let current_environment = match std::env::var("INFRAWEAVE_ENV") {
+                    Ok(env) => env,
+                    Err(_) => {
+                        println!("Please make sure to set the platform environment, for example: \"export INFRAWEAVE_ENV=dev\"");
+                        std::process::exit(1);
+                        // TODO: Handle errors and then throw error instead of exit(1)
+                        // return Err(CloudHandlerError::MissingEnvironment());
+                    }
+                };
             info!("Current environment: {}", current_environment);
 
             let modules_watched_set: HashSet<String> = HashSet::new();

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -64,8 +64,15 @@ async fn acquire_leadership_and_run_once(
             if lease.acquired_lease {
                 println!("Acquired leadership as {}", get_holder_id());
 
-                let current_environment =
-                    std::env::var("INFRAWEAVE_ENVIRONMENT").unwrap_or_else(|_| "dev".to_string());
+                let current_environment = match std::env::var("INFRAWEAVE_ENV") {
+                    Ok(env) => env,
+                    Err(_) => {
+                        println!("Please make sure to set the platform environment, for example: \"export INFRAWEAVE_ENV=dev\"");
+                        std::process::exit(1);
+                        // TODO: Handle errors and then throw error instead of exit(1)
+                        // return Err(CloudHandlerError::MissingEnvironment());
+                    }
+                };
                 info!("Current environment: {}", current_environment);
 
                 let modules_watched_set: HashSet<String> = HashSet::new();


### PR DESCRIPTION
This pull request introduces changes to enforce the use of the `INFRAWEAVE_ENV` environment variable across multiple components, improving error handling and consistency. Key updates include adding a new error type for missing environment variables, updating environment variable handling logic to provide clear error messages, and modifying integration tests and operator logic to align with these changes.

### Environment Variable Handling Improvements:
* Added a new error type `MissingEnvironment` in `CloudHandlerError` to handle cases where the `INFRAWEAVE_ENV` variable is not set. 
* Updated `run_function` in both `env_aws/src/api.rs` and `env_azure/src/api.rs` to use a `match` statement for retrieving `INFRAWEAVE_ENV`. If the variable is missing, an error message is printed, and the process exits.

### Integration with Build and Test Processes:
* Added `INFRAWEAVE_ENV=dev` to the `Makefile` for both AWS and Azure integration tests to ensure the environment variable is set during test execution. 

### Operator Logic Updates:
* Replaced `unwrap_or` with a `match` statement for `INFRAWEAVE_ENV` in `operator/src/operator.rs` and `integration-tests/tests/operator.rs`. If the variable is missing, an error message is displayed, and the process exits. 

### Codebase Enhancements:
* Added `std::process::exit` to handle missing environment variables gracefully in both AWS and Azure modules. 