### PR TITLE
fix: improve azure authentication

### DIFF
--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -2,7 +2,7 @@ use std::{env, process::exit};
 
 use anyhow::Result;
 use azure_core::auth::TokenCredential;
-use azure_identity::{DefaultAzureCredential, EnvironmentCredential, TokenCredentialOptions};
+use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 use env_defs::{
     get_change_record_identifier, get_deployment_identifier, get_event_identifier,
     get_module_identifier, get_policy_identifier, GenericFunctionResponse,
@@ -30,14 +30,9 @@ pub async fn get_user_id() -> Result<String, anyhow::Error> {
 pub async fn run_function(
     function_endpoint: &Option<String>,
     payload: &Value,
-    _project_id: &str, // TODO: start using this
-    _region: &str,     // TODO: start using this
+    project_id: &str,
+    region: &str,
 ) -> Result<GenericFunctionResponse> {
-    println!(
-        "run_function {}",
-        function_endpoint.clone().unwrap_or("notset".to_string())
-    );
-    let region = crate::get_region().await;
     let api_environment = match std::env::var("INFRAWEAVE_ENV") {
         Ok(env) => env,
         Err(_) => {
@@ -47,9 +42,8 @@ pub async fn run_function(
             // return Err(CloudHandlerError::MissingEnvironment());
         }
     };
+    let subscription_id = project_id;
     let base_url = function_endpoint.clone().unwrap_or_else(|| {
-        let subscription_id =
-            std::env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
         let truncated_subscription_id = &subscription_id[..18.min(subscription_id.len())];
         format!(
             "https://iw-{}-{}-{}.azurewebsites.net",
@@ -59,30 +53,31 @@ pub async fn run_function(
 
     let function_url = format!("{}/api/api", base_url);
 
+    let scope = format!(
+        "api://infraweave-broker-{}-{}-{}/.default",
+        subscription_id, api_environment, region
+    );
+
     let token = if env::var("TEST_MODE").is_ok() {
         let token = "TEST_TOKEN";
         token.to_string()
     } else if env::var("AZURE_CONTAINER_INSTANCE").is_ok() {
         let credential = CustomImdsCredential::new();
         credential
-            .get_token(&["https://management.azure.com/.default"])
+            .get_token(&[&scope])
             .await?
             .token
             .secret()
             .to_string()
     } else {
-        // TODO: Check if this can replace the above
         match DefaultAzureCredential::create(TokenCredentialOptions::default())?
-            .get_token(&["https://management.azure.com/.default"])
+            .get_token(&[&scope])
             .await
         {
-            Ok(token) => token.token.secret().to_string(),
-            Err(_e) => {
-                let credential = EnvironmentCredential::create(TokenCredentialOptions::default())?;
-                let token_response = credential
-                    .get_token(&["https://management.azure.com/.default"])
-                    .await?;
-                token_response.token.secret().to_string()
+            Ok(token) => token.token.secret().to_owned(),
+            Err(e) => {
+                error!("Failed to get token for scope {}: {}", &scope, e);
+                "error".to_string()
             }
         }
     };


### PR DESCRIPTION
This pull request introduces updates to the `env_azure/src/api.rs` file to enhance token handling and streamline the `run_function` implementation. Key changes include the removal of unused imports, updates to the function parameters, and improvements to token acquisition logic, including better error handling and the introduction of dynamic scopes.

### Token handling improvements:
* Updated the token acquisition logic to dynamically use a scope based on the `subscription_id` and `api_environment` variables, replacing hardcoded scopes like `https://management.azure.com/.default`. This includes constructing the scope dynamically using the format `api://infraweave-broker-{subscription_id}-{api_environment}/.default`.
* Improved error handling for token retrieval by logging errors when token acquisition fails and returning a default "error" string instead of crashing.

### Code simplifications and refactoring:
* Removed the `EnvironmentCredential` fallback logic and consolidated token acquisition to rely on `DefaultAzureCredential` or custom credentials.
* Replaced unused `_project_id` and `_region` parameters in the `run_function` method with actively used `project_id` and `region` parameters.
* Removed the unused `EnvironmentCredential` import and cleaned up other unused code. [[1]](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL5-R5) [[2]](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL33-L40)

These changes make the codebase more robust, maintainable, and aligned with best practices for Azure authentication.