### PR TITLE
fix: use error_text directly in process_runner_event on failure

### DIFF
--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -147,22 +147,7 @@ async fn process_runner_event(payload: Value) -> Result<Value, Error> {
                 change_record.plan_std_output
             } else {
                 github_event.check_run.conclusion = Some("failure".into());
-
-                let deployment = handler
-                    .get_deployment(
-                        &github_event.job_details.deployment_id,
-                        &github_event.job_details.environment,
-                        false,
-                    )
-                    .await
-                    .expect("Failed to get deployment");
-
-                if deployment.is_some() {
-                    let deployment = deployment.unwrap();
-                    deployment.error_text
-                } else {
-                    "Failed to find deployment".to_string()
-                }
+                github_event.job_details.error_text.clone()
             };
 
             // Process GitHub event.


### PR DESCRIPTION
This pull request simplifies the error handling logic in the `process_runner_event` function and resolves a bug that made errors not showing for terraform plan. 
The field `error_text` is guaranteed to exist regardless, so no need to query for it, which in addition will fail for plans, since there is no deployment entry for plans.

Code simplification:

* [`gitops/src/main.rs`](diffhunk://#diff-dc5453bb76c985775aedb0cff6bd802776b1a286c35ee865822c0cd8a107a90cL150-R150): Removed the logic for fetching deployment details and checking for its existence when handling a failure. Instead, the `error_text` field from `github_event.job_details` is now used directly, reducing complexity and potential runtime errors.