### PR TITLE
fix: don't bundle terraform.tfvars (and similar variants) in module zip file

### DIFF
--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -4,8 +4,8 @@ use env_defs::{
     TfLockProvider, TfVariable,
 };
 use env_utils::{
-    contains_terraform_lockfile, generate_module_example_deployment, get_outputs_from_tf_files,
-    get_provider_url_key, get_providers_from_lockfile, get_tf_required_providers_from_tf_files,
+    generate_module_example_deployment, get_outputs_from_tf_files, get_provider_url_key,
+    get_providers_from_lockfile, get_terraform_lockfile, get_tf_required_providers_from_tf_files,
     get_timestamp, get_variables_from_tf_files, merge_json_dicts, read_tf_directory, semver_parse,
     validate_module_schema, validate_tf_backend_not_set, validate_tf_extra_environment_variables,
     validate_tf_required_providers_is_set, zero_pad_semver,
@@ -67,7 +67,7 @@ pub async fn publish_module(
         }
     }
 
-    let tf_lock_file_content = match contains_terraform_lockfile(&zip_file) {
+    let tf_lock_file_content = match get_terraform_lockfile(&zip_file) {
         std::result::Result::Ok(contents) => {
             if contents.is_empty() {
                 return Err(ModuleError::TerraformLockfileEmpty);

--- a/integration-tests/modules/s3bucket-dev/terraform.tfvars
+++ b/integration-tests/modules/s3bucket-dev/terraform.tfvars
@@ -1,0 +1,4 @@
+
+# This file should not be included in the zipped module!
+
+bucket_name = "dont-include-me-this-is-a-test"

--- a/integration-tests/tests/module.rs
+++ b/integration-tests/tests/module.rs
@@ -6,7 +6,7 @@ mod module_tests {
     use super::*;
     use env_common::{download_module_to_vec, interface::GenericCloudHandler};
     use env_defs::CloudProvider;
-    use env_utils::contains_terraform_lockfile;
+    use env_utils::{get_terraform_lockfile, get_terraform_tfvars};
     use pretty_assertions::assert_eq;
     use std::env;
 
@@ -65,8 +65,11 @@ mod module_tests {
             };
 
             let module_vec: Vec<u8> = download_module_to_vec(&handler, &modules[0].s3_key).await;
-            let lockfile_contents_result = contains_terraform_lockfile(&module_vec);
+            let lockfile_contents_result = get_terraform_lockfile(&module_vec);
             assert_eq!(lockfile_contents_result.is_ok(), true);
+
+            let terraform_tfvars_resul = get_terraform_tfvars(&module_vec);
+            assert_eq!(terraform_tfvars_resul.is_err(), true); // This is desired because the module should not include any tfvars file
 
             assert_eq!(modules.len(), 1);
             assert_eq!(modules[0].module, "s3bucket");

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -17,7 +17,7 @@ mod versioning;
 
 pub use deployment::generate_module_example_deployment;
 pub use file::{
-    contains_terraform_lockfile, download_zip, download_zip_to_vec, get_zip_file,
+    download_zip, download_zip_to_vec, get_terraform_lockfile, get_terraform_tfvars, get_zip_file,
     get_zip_file_from_str, merge_zips, read_tf_directory, read_tf_from_zip, unzip_file, ZipInput,
 };
 pub use general::merge_json_dicts;


### PR DESCRIPTION
This pull request introduces several changes to improve file exclusion logic to prevent certain Terraform-related files from being included in zipped modules.

### File Handling Improvements:
* Replaced `contains_terraform_lockfile` with `get_terraform_lockfile` for better naming consistency and functionality. The new function retrieves the `.terraform.lock.hcl` file from a zip archive. [[1]](diffhunk://#diff-746cbd4b151b79903f845ed3049a80fc66cebf46cda7ddf68b8106ccc3e1dea9L70-R70) [[2]](diffhunk://#diff-7f5d2b7e915c9b4314806364c4159b29c1a6709e1af3931dc956e02d52d0b928L285-R307)
* Introduced `get_terraform_tfvars` to identify and retrieve `terraform.tfvars` files from zip archives. This function ensures that `terraform.tfvars` files are correctly handled during module processing. [[1]](diffhunk://#diff-7f5d2b7e915c9b4314806364c4159b29c1a6709e1af3931dc956e02d52d0b928L285-R307) [[2]](diffhunk://#diff-a2fe0e28e280b30b0768243376d75b26f9d7e8e34d4d5a7e322b95e5e05bbd66L68-R73)
* Updated `get_zip_file` to use the new `should_be_excluded` function, which filters out additional Terraform-related files (e.g., `terraform.tfvars`, `terraform.tfstate`, `.terraformrc`) when creating zip archives. [[1]](diffhunk://#diff-7f5d2b7e915c9b4314806364c4159b29c1a6709e1af3931dc956e02d52d0b928L43-R43) [[2]](diffhunk://#diff-7f5d2b7e915c9b4314806364c4159b29c1a6709e1af3931dc956e02d52d0b928R71-R84)

### Test Enhancements:
* Added a test case to verify that `terraform.tfvars` files are excluded from zipped modules and that attempting to retrieve them results in an error.
* Updated imports in test files to reflect the new function names, ensuring consistency across the codebase.

### Refactoring for Clarity:
* Refactored the `get_file` helper function to support retrieving files by name, making it reusable for both `.terraform.lock.hcl` and `terraform.tfvars`.
* Updated module imports to remove references to the deprecated `contains_terraform_lockfile` and include the new `get_terraform_lockfile` and `get_terraform_tfvars` functions. 

These changes improve the maintainability of the codebase and enhance functionality for handling Terraform-related files.