### PR TITLE
fix: add JobAlreadyInProgress error

### DIFF
--- a/defs/src/errors.rs
+++ b/defs/src/errors.rs
@@ -16,4 +16,7 @@ pub enum CloudHandlerError {
 
     #[error("Please make sure to set the platform environment, for example: \"export INFRAWEAVE_ENV=dev\"")]
     MissingEnvironment(),
+
+    #[error("A job for this deployment is already in progress: {0}")]
+    JobAlreadyInProgress(String),
 }

--- a/env_common/src/logic/api_infra.rs
+++ b/env_common/src/logic/api_infra.rs
@@ -1,6 +1,6 @@
 use env_defs::{
-    ApiInfraPayload, CloudProvider, Dependency, DeploymentManifest, DeploymentResp, DriftDetection,
-    ExtraData, GenericFunctionResponse, Webhook,
+    ApiInfraPayload, CloudHandlerError, CloudProvider, Dependency, DeploymentManifest,
+    DeploymentResp, DriftDetection, ExtraData, GenericFunctionResponse, Webhook,
 };
 use env_utils::{
     convert_first_level_keys_to_snake_case, flatten_and_convert_first_level_keys_to_snake_case,
@@ -415,9 +415,7 @@ pub async fn submit_claim_job(
     let (in_progress, job_id, _, _) =
         is_deployment_in_progress(handler, &payload.deployment_id, &payload.environment).await;
     if in_progress {
-        info!("Deployment already requested, skipping");
-        println!("Deployment already requested, skipping");
-        return Ok(job_id);
+        return Err(CloudHandlerError::JobAlreadyInProgress(job_id).into());
     }
 
     let job_id: String = match mutate_infra(handler, payload.clone()).await {


### PR DESCRIPTION
This pull request introduces a new error type to handle deployment job conflicts and updates the logic to return this error when a deployment job is already in progress. Additionally, it updates imports to include the new error type.

This will ensure an error is thrown when a job cannot be launched, which is crucial feedback e.g. when it is triggered via GitOps or a python job instead of a silent failure.

### Error Handling Enhancements:

* Added a new error type `JobAlreadyInProgress` to the `CloudHandlerError` enum in `defs/src/errors.rs` to handle cases where a deployment job is already in progress.
* Updated the `submit_claim_job` function in `env_common/src/logic/api_infra.rs` to return the `JobAlreadyInProgress` error instead of proceeding or logging a message when a deployment job is already in progress.

### Codebase Maintenance:

* Updated imports in `env_common/src/logic/api_infra.rs` to include the newly added `CloudHandlerError` type.