### PR TITLE
fix: better distinguish variable defaults between null and not set

### DIFF
--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -11,7 +11,7 @@ pub struct TfVariable {
     pub name: String,
     #[serde(rename = "type")]
     pub _type: serde_json::Value,
-    pub default: serde_json::Value,
+    pub default: Option<serde_json::Value>, // Default value is not always set
     pub description: String,
     pub nullable: bool,
     pub sensitive: bool,

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -594,7 +594,10 @@ fn is_all_module_example_variables_valid(
         }
         let tf_variable = tf_variable.unwrap();
         let is_nullable = tf_variable.nullable;
-        if tf_variable.default == serde_json::Value::Null && !is_nullable && value.is_null() {
+        if (tf_variable.default == Some(serde_json::Value::Null) || tf_variable.default == None)
+            && !is_nullable
+            && value.is_null()
+        {
             let error = format!("Required variable {} is null but mandatory", key_str);
             return (false, error); // Required variable is null
         }
@@ -602,7 +605,9 @@ fn is_all_module_example_variables_valid(
     // Check that all required variables are present in example_variables
     for tf_variable in tf_variables.iter() {
         let is_nullable = tf_variable.nullable;
-        if tf_variable.default == serde_json::Value::Null && !is_nullable {
+        if (tf_variable.default == Some(serde_json::Value::Null) || tf_variable.default == None)
+            && !is_nullable
+        {
             // This is a required variable
             let variable_exists = example_variables
                 .contains_key(&serde_yaml::Value::String(tf_variable.name.clone()));
@@ -672,7 +677,7 @@ portMapping:
             TfVariable {
                 name: "bucket_name".to_string(),
                 description: "The name of the bucket".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
@@ -680,7 +685,7 @@ portMapping:
             TfVariable {
                 name: "tags".to_string(),
                 description: "The tags to apply to the bucket".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("map".to_string()),
@@ -688,7 +693,7 @@ portMapping:
             TfVariable {
                 name: "port_mapping".to_string(),
                 description: "The port mapping".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("list".to_string()),
@@ -717,7 +722,7 @@ port_mapping:
             TfVariable {
                 name: "instance_name".to_string(),
                 description: "Instance name".to_string(),
-                default: serde_json::Value::String("my-instance".to_string()),
+                default: Some(serde_json::Value::String("my-instance".to_string())),
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
@@ -725,7 +730,7 @@ port_mapping:
             TfVariable {
                 name: "bucket_name".to_string(),
                 description: "Bucket name".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
@@ -748,7 +753,7 @@ bucket_name: some-bucket-name
             TfVariable {
                 name: "instance_name".to_string(),
                 description: "Instance name".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
@@ -756,7 +761,7 @@ bucket_name: some-bucket-name
             TfVariable {
                 name: "bucket_name".to_string(),
                 description: "Bucket name".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
@@ -779,7 +784,7 @@ bucket_name: some-bucket-name
             TfVariable {
                 name: "instance_name".to_string(),
                 description: "Instance name".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: true,
                 _type: serde_json::Value::String("string".to_string()),
@@ -787,7 +792,7 @@ bucket_name: some-bucket-name
             TfVariable {
                 name: "bucket_name".to_string(),
                 description: "Bucket name".to_string(),
-                default: serde_json::Value::Null,
+                default: None,
                 sensitive: false,
                 nullable: false,
                 _type: serde_json::Value::String("string".to_string()),
@@ -809,7 +814,7 @@ bucket_name: some-bucket-name
         let tf_variables = vec![TfVariable {
             name: "bucket_name".to_string(),
             description: "The name of the bucket".to_string(),
-            default: serde_json::Value::Null,
+            default: None,
             sensitive: false,
             nullable: false,
             _type: serde_json::Value::String("string".to_string()),
@@ -835,7 +840,7 @@ port_mapping:
         let tf_variables = vec![TfVariable {
             name: "bucketName".to_string(),
             description: "Bucket name".to_string(),
-            default: serde_json::Value::Null,
+            default: None,
             sensitive: false,
             nullable: false,
             _type: serde_json::Value::String("string".to_string()),

--- a/integration-tests/tests/stack.rs
+++ b/integration-tests/tests/stack.rs
@@ -301,37 +301,40 @@ mod stack_tests {
             assert_eq!(stacks[0].tf_variables[0]._type, "list(string)");
             assert_eq!(
                 stacks[0].tf_variables[0].default,
-                serde_json::json!(["dev1.example.com", "dev2.example.com"])
+                Some(serde_json::json!(["dev1.example.com", "dev2.example.com"]))
             );
 
             assert_eq!(stacks[0].tf_variables[1].name, "route1__tags");
             assert_eq!(stacks[0].tf_variables[1]._type, "map(string)");
             assert_eq!(
                 stacks[0].tf_variables[1].default,
-                serde_json::json!({"Name": "example.com", "Environment": "dev"})
+                Some(serde_json::json!({"Name": "example.com", "Environment": "dev"}))
             );
 
             assert_eq!(stacks[0].tf_variables[2].name, "route1__ttl");
             assert_eq!(stacks[0].tf_variables[2]._type, "number");
-            assert_eq!(stacks[0].tf_variables[2].default, serde_json::json!(300)); // Default value in variables.tf is null, but 300 is set in claim
+            assert_eq!(
+                stacks[0].tf_variables[2].default,
+                Some(serde_json::json!(300))
+            ); // Default value in variables.tf is null, but 300 is set in claim
 
             assert_eq!(stacks[0].tf_variables[3].name, "route2__records");
             assert_eq!(stacks[0].tf_variables[3]._type, "list(string)");
             assert_eq!(
                 stacks[0].tf_variables[3].default,
-                serde_json::json!(["uat1.example.com", "uat2.example.com"])
+                Some(serde_json::json!(["uat1.example.com", "uat2.example.com"]))
             ); // Default value in variables.tf is set, but overriding in claim
 
             assert_eq!(stacks[0].tf_variables[4].name, "route2__tags");
             assert_eq!(stacks[0].tf_variables[4]._type, "map(string)");
             assert_eq!(
                 stacks[0].tf_variables[4].default,
-                serde_json::json!({"override": true})
+                Some(serde_json::json!({"override": true}))
             ); // Default value in variables.tf is set, but overriding in claim
 
             assert_eq!(stacks[0].tf_variables[5].name, "route2__ttl");
             assert_eq!(stacks[0].tf_variables[5]._type, "number");
-            assert_eq!(stacks[0].tf_variables[5].default, serde_json::Value::Null);
+            assert_eq!(stacks[0].tf_variables[5].default, None);
             // No default value in variables.tf and nothing is set in claim
         })
         .await;

--- a/utils/src/module.rs
+++ b/utils/src/module.rs
@@ -131,7 +131,7 @@ pub fn validate_tf_extra_environment_variables(
     ];
     for tf_variable in tf_variables {
         if extra_environment_variables.contains(&tf_variable.name) {
-            if tf_variable.default != "" {
+            if tf_variable.default != Some(serde_json::json!("")) {
                 return Err(anyhow::anyhow!(
                     "Extra environment variable {} must set default value to \"\"",
                     tf_variable.name
@@ -225,10 +225,7 @@ pub fn get_variables_from_tf_files(contents: &str) -> Result<Vec<TfVariable>, St
                     }
                     _ => variable_type, // Keep as is for complex types like maps
                 };
-                let default_value = var_attrs
-                    .get("default")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
+                let default_value: Option<serde_json::Value> = var_attrs.get("default").cloned();
                 let description = var_attrs
                     .get("description")
                     .and_then(|v| v.as_str())
@@ -444,7 +441,7 @@ variable "bucket_name" {
             TfVariable {
                 name: "bucket_name".to_string(),
                 _type: serde_json::json!("string"),
-                default: serde_json::json!("some-bucket-name"),
+                default: Some(serde_json::json!("some-bucket-name")),
                 description: "".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -471,10 +468,10 @@ variable "tags" {
             TfVariable {
                 name: "tags".to_string(),
                 _type: serde_json::json!("map(string)"),
-                default: serde_json::json!({
+                default: Some(serde_json::json!({
                     "tag_environment": "some_value1",
                     "tag_name": "some_value2"
-                }),
+                })),
                 description: "".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -497,7 +494,7 @@ variable "tags" {
             TfVariable {
                 name: "tags".to_string(),
                 _type: serde_json::json!("map(string)"),
-                default: serde_json::json!(null),
+                default: None,
                 description: "".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -520,7 +517,7 @@ variable "tags" {
             TfVariable {
                 name: "tags".to_string(),
                 _type: serde_json::json!("set(string)"),
-                default: serde_json::json!(null),
+                default: None,
                 description: "".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -774,7 +771,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
             TfVariable {
                 name: "bucket_name".to_string(),
                 _type: serde_json::json!("string"),
-                default: serde_json::json!(""),
+                default: Some(serde_json::json!("")),
                 description: "".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -782,7 +779,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
             TfVariable {
                 name: "INFRAWEAVE_DEPLOYMENT_ID".to_string(),
                 _type: serde_json::json!("string"),
-                default: serde_json::json!(""),
+                default: Some(serde_json::json!("")),
                 description: "Some description maybe".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -803,7 +800,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
             TfVariable {
                 name: "bucket_name".to_string(),
                 _type: serde_json::json!("string"),
-                default: serde_json::json!(""),
+                default: Some(serde_json::json!("")),
                 description: "".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -811,7 +808,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
             TfVariable {
                 name: "INFRAWEAVE_DEPLOYMENT_ID".to_string(),
                 _type: serde_json::json!("string"),
-                default: serde_json::json!("some_value_here_not_allowed"),
+                default: Some(serde_json::json!("some_value_here_not_allowed")),
                 description: "Some description maybe".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -832,7 +829,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
             TfVariable {
                 name: "bucket_name".to_string(),
                 _type: serde_json::json!("string"),
-                default: serde_json::json!(""),
+                default: Some(serde_json::json!("")),
                 description: "".to_string(),
                 nullable: true,
                 sensitive: false,
@@ -840,7 +837,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
             TfVariable {
                 name: "INFRAWEAVE_DEPLOYMENT_ID".to_string(),
                 _type: serde_json::json!("bool"),
-                default: serde_json::json!(""),
+                default: Some(serde_json::json!("")),
                 description: "Some description maybe".to_string(),
                 nullable: true,
                 sensitive: false,


### PR DESCRIPTION
This pull request refactors the handling of default values in the `TfVariable` struct and related logic. The `default` field, which previously used `serde_json::Value`, now uses `Option<serde_json::Value>` to better represent when a default value is absent. This change simplifies null-checking logic and improves clarity in the codebase.

### Structural Changes to `TfVariable`:
* Updated the `default` field in the `TfVariable` struct to be of type `Option<serde_json::Value>` to explicitly represent the absence of a default value. 

### Logic Adjustments:
* Updated null-checking logic in `fn is_all_module_example_variables_valid` to handle `Option`-wrapped values, ensuring proper validation of required variables. (`env_common/src/logic/api_module.rs`)
* Refactored `fn generate_terraform_variable_single` to handle `Option` when converting default values to HCL format. 
* Adjusted `fn generate_dependency_map` to skip variables with `None` as their default value. 
* Updated `fn collect_module_variables` to wrap default values in `Some` when defined. 

### Test Updates:
* Modified test cases to align with the new `Option`-based `default` field, ensuring test coverage for both `Some` and `None` cases. (`env_common/src/logic/api_stack.rs`)