### PR TITLE
fix: cleanup azure integration-test function app code

### DIFF
--- a/integration-tests/azure-function-code/function_app.py
+++ b/integration-tests/azure-function-code/function_app.py
@@ -1,28 +1,20 @@
-import os
+import azure.functions as func
+from azure.cosmos import CosmosClient, exceptions
+from azure.storage.blob import BlobServiceClient, generate_blob_sas, BlobSasPermissions
 import base64
+from bootstrap import bootstrap_tables, bootstrap_buckets
 from datetime import datetime, timedelta
 import json
-import uuid
-import azure.functions as func
 import logging
-from azure.identity import DefaultAzureCredential
+import os
+import re
+import traceback
 
-from bootstrap import bootstrap_tables, bootstrap_buckets
-
+COSMOS_DB_ENDPOINT = os.getenv("COSMOS_DB_ENDPOINT")
+COSMOS_DB_DATABASE = os.getenv("COSMOS_DB_DATABASE")
 COSMOS_KEY = os.environ.get("COSMOS_KEY")
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS) # only for testing
-
-from azure.mgmt.containerinstance import ContainerInstanceManagementClient
-from azure.mgmt.containerinstance.models import (
-    ContainerGroup,
-    Container,
-    ContainerGroupNetworkProtocol,
-    ContainerPort,
-    ResourceRequests,
-    ResourceRequirements,
-    OperatingSystemTypes
-)
+app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
 @app.function_name(name="generic_api")
 @app.route(route="api")
@@ -35,7 +27,6 @@ def handler(req: func.HttpRequest) -> func.HttpResponse:
     logging.info(req_body)
 
     event = req_body.get('event')
-    import traceback
     try:
         if event == 'bootstrap_tables':
             bootstrap_tables()
@@ -65,23 +56,14 @@ def handler(req: func.HttpRequest) -> func.HttpResponse:
         return func.HttpResponse(json.dumps({"result":f"Api error: {e}", "tb": tb}), status_code=500)
     
 def transact_write(req: func.HttpRequest) -> func.HttpResponse:
-    from azure.cosmos import CosmosClient, exceptions
-
     try:
         req_body = req.get_json()
     except ValueError:
         return func.HttpResponse("Invalid JSON body.", status_code=400)
-    
-    
-    COSMOS_DB_ENDPOINT = os.getenv("COSMOS_DB_ENDPOINT")
-    COSMOS_DB_DATABASE = os.getenv("COSMOS_DB_DATABASE")
 
-    # credential = DefaultAzureCredential()
-    credential = COSMOS_KEY
-    # client = CosmosClient(COSMOS_DB_ENDPOINT, credential=credential)
     client = CosmosClient(
         COSMOS_DB_ENDPOINT,
-        credential=credential,
+        credential=COSMOS_KEY,
         connection_mode="Gateway",
         consistency_level="Session",
         enable_endpoint_discovery=False,
@@ -112,7 +94,6 @@ def transact_write(req: func.HttpRequest) -> func.HttpResponse:
 
         except exceptions.CosmosHttpResponseError as e:
             responses.append({
-                # "item_id": item.get('Put', {}).get('Item', {}).get('id', "N/A") or item.get('Delete', {}).get('Key', {}).get('id', "N/A"),
                 "error": str(e)
             })
     return func.HttpResponse(
@@ -127,8 +108,6 @@ def generate_presigned_url(req: func.HttpRequest) -> func.HttpResponse:
         req_body = req.get_json()
     except ValueError:
         return func.HttpResponse("Invalid JSON body.", status_code=400)
-    
-    from azure.storage.blob import BlobServiceClient, generate_blob_sas, BlobSasPermissions
 
     req_body = req.get_json()
     payload = req_body.get('data')
@@ -136,23 +115,11 @@ def generate_presigned_url(req: func.HttpRequest) -> func.HttpResponse:
     blob_name = payload.get("key")
     expires_in = payload.get("expires_in", 3600)
 
-
     sas_expiry = datetime.utcnow() + timedelta(seconds=expires_in)
-
-    # blob_service_client = BlobServiceClient(
-    #     account_url=f"https://{account_name}.blob.core.windows.net",
-    #     credential=DefaultAzureCredential()
-    # )
     conn_str = os.environ["AZURITE_CONNECTION_STRING"]
     blob_service_client = BlobServiceClient.from_connection_string(conn_str)
 
     account_name = blob_service_client.account_name #os.getenv("STORAGE_ACCOUNT_NAME") #or "storageAccount1"
-    
-    # # Get the user delegation key using AAD credentials
-    # user_delegation_key = blob_service_client.get_user_delegation_key(
-    #     key_start_time=datetime.utcnow(),
-    #     key_expiry_time=sas_expiry
-    # )
     account_key = blob_service_client.credential.account_key 
 
     sas_token = generate_blob_sas(
@@ -162,10 +129,8 @@ def generate_presigned_url(req: func.HttpRequest) -> func.HttpResponse:
         permission=BlobSasPermissions(read=True),  # Use read permissions for download access
         expiry=sas_expiry,
         account_key=account_key,
-        # user_delegation_key=user_delegation_key,
     )
 
-    # blob_url = f"https://{account_name}.blob.core.windows.net/{container_name}/{blob_name}?{sas_token}"
     blob_url = f"http://127.0.0.1:10000/{account_name}/{container_name}/{blob_name}?{sas_token}" # it will be pulled from the host machine in the test
 
     return func.HttpResponse(
@@ -175,97 +140,15 @@ def generate_presigned_url(req: func.HttpRequest) -> func.HttpResponse:
     )
 
 def start_runner(req: func.HttpRequest) -> func.HttpResponse:
-
+    # TODO: Implement the ACI task start logic as another docker container
     return func.HttpResponse(json.dumps({"result":"Would have been started", "job_id": "test-job-id"}), status_code=200)
-
-    from azure.identity import DefaultAzureCredential
-    credential = DefaultAzureCredential()
-
-    try:
-        req_body = req.get_json()
-    except ValueError:
-        return func.HttpResponse("Invalid JSON body.", status_code=400)
-
-    image_name = req_body.get("image_name", "mcr.microsoft.com/azuredocs/aci-helloworld")  # Default if not provided
-
-    # Subscription ID from environment variable
-    subscription_id = os.getenv("SUBSCRIPTION_ID")
-    resource_group_name = os.getenv("RESOURCE_GROUP_NAME")  # Make sure this environment variable is set
-
-    # Initialize the Container Instance Management Client
-    client = ContainerInstanceManagementClient(credential, subscription_id)
-
-    app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
-
-
-    logging.info('Python HTTP trigger function processed a request.')
-
-    # Generate a unique container group name
-    container_group_name = f"ephemeral-task-{str(uuid.uuid4())[:8]}"
-
-
-    try:
-        # Define container configuration
-        container_resource_requirements = ResourceRequirements(
-            requests=ResourceRequests(memory_in_gb=1.5, cpu=1.0)
-        )
-        container = Container(
-            name="runner",
-            image=image_name,
-            resources=container_resource_requirements,
-            ports=[ContainerPort(port=80)],
-            environment_variables=[
-                {"name": "ENVIRONMENT", "value": "dev"},
-                # {"name": "REGION", "value": os.getenv("REGION")}
-            ]
-        )
-
-        # Define container group configuration
-        container_group = ContainerGroup(
-            location=os.getenv("LOCATION"),
-            containers=[container],
-            os_type=OperatingSystemTypes.Linux,
-            restart_policy="Never"
-        )
-
-        # Start the container group
-        client.container_groups.begin_create_or_update(
-            resource_group_name=resource_group_name,
-            container_group_name=container_group_name,
-            container_group=container_group
-        )
-        
-        logging.info("ACI task started successfully.")
-        return func.HttpResponse(f"ACI task started successfully.", status_code=200)
-
-    except Exception as e:
-        logging.error(f"Error starting ACI task: {e}")
-        return func.HttpResponse(f"Error starting ACI task {e}", status_code=500)
-
-# needs to be cleaned up manually, exmaple: (max 100 containers regardless of state (running, stopped, etc.))
-
-# #!/bin/bash
-# # Lists all stopped containers and deletes them
-
-# resource_group="your-resource-group"
-# containers=$(az container list --resource-group $resource_group --query "[?provisioningState=='Succeeded' && instanceView.state=='Stopped'].name" -o tsv)
-
-# for container in $containers; do
-#   echo "Deleting container group: $container"
-#   az container delete --resource-group $resource_group --name $container --yes
-# done
-
-import urllib.parse
-
+    
 def get_id(body):
-    return urllib.parse.quote(f'{body.get("PK")}~{body.get("SK")}', safe="")
+    raw = f"{body['PK']}~{body['SK']}".lower()
+    safe = re.sub(r'[^0-9a-z]', '_', raw)
+    return safe
 
 def insert_db(req: func.HttpRequest) -> func.HttpResponse:
-    from azure.cosmos import CosmosClient, exceptions
-    
-    COSMOS_DB_ENDPOINT = os.getenv("COSMOS_DB_ENDPOINT")
-    COSMOS_DB_DATABASE = os.getenv("COSMOS_DB_DATABASE")
-
     try:
         req_body = req.get_json()
     except ValueError:
@@ -275,12 +158,9 @@ def insert_db(req: func.HttpRequest) -> func.HttpResponse:
     item = req_body.get('data')
     item.update({'id': get_id(req_body)}) # Reserved field that should not be used in InfraWeave rows, but is required by Cosmos DB
 
-    # credential = DefaultAzureCredential()
-    credential = COSMOS_KEY
-    # client = CosmosClient(COSMOS_DB_ENDPOINT, credential=credential)
     client = CosmosClient(
         COSMOS_DB_ENDPOINT,
-        credential=credential,
+        credential=COSMOS_KEY,
         connection_mode="Gateway",
         consistency_level="Session",
         enable_endpoint_discovery=False,
@@ -299,26 +179,16 @@ def insert_db(req: func.HttpRequest) -> func.HttpResponse:
 
 
 def read_db(req: func.HttpRequest) -> func.HttpResponse:
-    from azure.cosmos import CosmosClient, exceptions
-    
-    COSMOS_DB_ENDPOINT = os.getenv("COSMOS_DB_ENDPOINT")
-    COSMOS_DB_DATABASE = os.getenv("COSMOS_DB_DATABASE")
-
     try:
         req_body = req.get_json()
     except ValueError:
         return func.HttpResponse("Invalid JSON body.", status_code=400)
 
-
     container_name = req_body.get('table')
     query = req_body.get('data').get('query')
-
-    # credential = DefaultAzureCredential()
-    credential = COSMOS_KEY
-    # client = CosmosClient(COSMOS_DB_ENDPOINT, credential=credential)
     client = CosmosClient(
         COSMOS_DB_ENDPOINT,
-        credential=credential,
+        credential=COSMOS_KEY,
         connection_mode="Gateway",
         consistency_level="Session",
         enable_endpoint_discovery=False,
@@ -341,7 +211,6 @@ def read_db(req: func.HttpRequest) -> func.HttpResponse:
             query=query,
             enable_cross_partition_query=True
         ))
-        import json
         logging.info(f"Read operation succeeded, found {len(items)} items.")
         return func.HttpResponse(json.dumps(items), status_code=200)
     except exceptions.CosmosHttpResponseError as e:
@@ -349,20 +218,11 @@ def read_db(req: func.HttpRequest) -> func.HttpResponse:
         return func.HttpResponse(f"error querying: {e}", status_code=500)
 
 def upload_file_base64(req: func.HttpRequest) -> func.HttpResponse:
-    from azure.storage.blob import BlobServiceClient, BlobClient, ContainerClient
-    
     try:
         req_body = req.get_json()
     except ValueError:
         return func.HttpResponse("Invalid JSON body.", status_code=400)
-
     
-    account_name = os.getenv("STORAGE_ACCOUNT_NAME")
-    # container_name = os.getenv("CONTAINER_NAME")
-    # blob_service_client = BlobServiceClient(
-    #     account_url=f"https://{account_name}.blob.core.windows.net",
-    #     credential=DefaultAzureCredential()
-    # )
     conn_str = os.environ["AZURITE_CONNECTION_STRING"]
     blob_service_client = BlobServiceClient.from_connection_string(conn_str)
 


### PR DESCRIPTION
This pull request refactors the Azure Function code in integration test-file `function_app.py` to align with the actual files in the terraform-azure-modules.

### Refactoring and Code Simplification:
* Consolidated imports by removing unused modules like `DefaultAzureCredential` and redundant imports of `os` and `traceback`. 
* Removed commented-out code and unused variables related to Azure Container Instances (ACI) and Blob Storage configurations, simplifying the logic in `generate_presigned_url` and `start_runner` functions.

### Azure Cosmos DB Enhancements:
* Streamlined Cosmos DB client initialization by directly using the `COSMOS_KEY` environment variable instead of conditional credential handling.
* Removed unused error-handling logic and redundant comments in database operations (`transact_write`, `insert_db`, `read_db`).

### Azure Blob Storage Improvements:
* Simplified Blob Storage logic by removing unused delegation key logic and hardcoding the local Azurite URL for testing. 

### Miscellaneous Changes:
* Replaced the `get_id` function's URL encoding logic with a safer and more readable implementation using regex for ID sanitization.