### PR TITLE
fix: cleanup clippy warnings

### DIFF
--- a/defs/src/gitprovider.rs
+++ b/defs/src/gitprovider.rs
@@ -87,6 +87,7 @@ pub struct GitHubCheckRun {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)] // Used for trying to deserialize into one of the variants
+#[allow(clippy::large_enum_variant)]
 pub enum ExtraData {
     GitHub(GitHubCheckRun),
 

--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -508,7 +508,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
 ```yaml
 {}
 ```"#,
-                                canonical.trim_start_matches("---").to_string()
+                                canonical.trim_start_matches("---")
                             )),
                             annotations: None,
                         });
@@ -636,7 +636,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
 ```yaml
 {}
 ```"#,
-                                canonical.trim_start_matches("---").to_string()
+                                canonical.trim_start_matches("---")
                             )),
                             annotations: None,
                         });
@@ -764,7 +764,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                                 set_deployment(&handler, &deployment, false).await.unwrap();
 
                                 github_check_run.check_run.name =
-                                    get_check_run_name(&name, &renamed.path, &region, &namespace);
+                                    get_check_run_name(&name, &renamed.path, region, &namespace);
                                 github_check_run.check_run.status = "completed".to_string();
                                 github_check_run.check_run.conclusion = Some("success".to_string());
                                 github_check_run.check_run.completed_at =
@@ -775,9 +775,9 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                                         "File `{}` has been renamed; the reference has been updated for `{}`.",
                                         renamed.path, &deployment_id
                                     ),
-                                    text: Some(format!(
-                                        "No run has been triggered, only the reference has been updated."
-                                    )),
+                                    text: Some(
+                                        "No run has been triggered, only the reference has been updated.".to_string()
+                                    ),
                                     annotations: None,
                                 });
                             }

--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -217,7 +217,7 @@ impl Deployment {
     }
 
     // Called at the start of a `with Deployment(...) as d:` block.
-    fn __enter__<'p>(slf: PyRefMut<'p, Self>) -> PyResult<PyRefMut<'p, Self>> {
+    fn __enter__(slf: PyRefMut<Self>) -> PyResult<PyRefMut<Self>> {
         Ok(slf)
     }
 
@@ -253,7 +253,7 @@ async fn run_job(
     let result = match command {
         "destroy" => {
             destroy_infra(
-                &handler,
+                handler,
                 &deployment.deployment_id,
                 &deployment.namespace,
                 ExtraData::None,
@@ -276,7 +276,7 @@ async fn run_job(
 
     loop {
         let (in_progress, _, _status, deployment_job_result) =
-            is_deployment_in_progress(&handler, &deployment.deployment_id, &deployment.namespace)
+            is_deployment_in_progress(handler, &deployment.deployment_id, &deployment.namespace)
                 .await;
         if !in_progress {
             let status = if command == "destroy" {

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -208,7 +208,7 @@ async fn watch_all_infraweave_resources(
                             "apply",
                             flags,
                             ExtraData::None,
-                            &reference_fallback,
+                            reference_fallback,
                         )
                         .await
                         {
@@ -253,7 +253,7 @@ async fn watch_all_infraweave_resources(
                             "destroy",
                             flags,
                             ExtraData::None,
-                            &reference_fallback,
+                            reference_fallback,
                         )
                         .await
                         {
@@ -669,6 +669,7 @@ async fn update_resource_status(
 //     Ok(())
 // }
 
+#[allow(clippy::too_many_arguments)]
 async fn follow_job_until_finished(
     handler: &GenericCloudHandler,
     client: kube::Client,

--- a/terraform_runner/src/module.rs
+++ b/terraform_runner/src/module.rs
@@ -56,7 +56,7 @@ pub async fn get_module(
                 status_handler.set_error_text(error_text.to_string());
                 status_handler.send_event(&handler).await;
                 status_handler.send_deployment(&handler).await;
-                return Err(anyhow::anyhow!("Module does not exist"));
+                Err(anyhow::anyhow!("Module does not exist"))
             } else {
                 let module = module.unwrap(); // Improve this
                 Ok(module)
@@ -71,7 +71,7 @@ pub async fn get_module(
             status_handler.set_error_text(error_text);
             status_handler.send_event(&handler).await;
             status_handler.send_deployment(&handler).await;
-            return Err(anyhow::anyhow!("Failed to get module"));
+            Err(anyhow::anyhow!("Failed to get module"))
         }
     }
 }

--- a/terraform_runner/src/opa.rs
+++ b/terraform_runner/src/opa.rs
@@ -89,9 +89,9 @@ pub fn get_all_rego_filenames_in_cwd() -> Vec<String> {
     rego_files
 }
 
-pub async fn run_opa_policy_checks<'a>(
+pub async fn run_opa_policy_checks(
     handler: &GenericCloudHandler,
-    status_handler: &mut DeploymentStatusHandler<'a>,
+    status_handler: &mut DeploymentStatusHandler<'_>,
 ) -> Result<(), anyhow::Error> {
     // Store specific environment variables in a JSON file to be used by OPA policies
     let file_path = "./env_data.json";

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -16,7 +16,7 @@ use std::fs::{write, File};
 use anyhow::{anyhow, Context, Result};
 use env_aws::assume_role;
 
-use crate::{get_env_var, post_webhook, run_generic_command, CommandResult};
+use crate::{post_webhook, run_generic_command, CommandResult};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_terraform_command(
@@ -594,7 +594,7 @@ pub async fn terraform_output(
 }
 
 async fn download_all_providers(
-    provider_versions: &Vec<TfLockProvider>,
+    provider_versions: &[TfLockProvider],
     target: &str,
 ) -> Result<(), anyhow::Error> {
     let categories = ["provider_binary", "shasum", "signature"];
@@ -647,7 +647,7 @@ async fn download_provider(
 }
 
 pub async fn set_up_provider_mirror(
-    provider_versions: &Vec<TfLockProvider>,
+    provider_versions: &[TfLockProvider],
     target: &str,
 ) -> Result<(), anyhow::Error> {
     let mirror_dir = "/app/.provider-mirror";

--- a/utils/src/file.rs
+++ b/utils/src/file.rs
@@ -78,9 +78,10 @@ fn should_be_excluded(entry: &walkdir::DirEntry) -> bool {
         || entry.file_name() == "terraform.tfvars.json"
         || entry.file_name() == "terraform.rc"
         || entry.file_name() == ".terraformrc"
-        || entry.file_name().to_str().map_or(false, |s| {
-            s.ends_with(".auto.tfvars") || s.ends_with(".auto.tfvars.json")
-        })
+        || entry
+            .file_name()
+            .to_str()
+            .is_some_and(|s| s.ends_with(".auto.tfvars") || s.ends_with(".auto.tfvars.json"))
 }
 fn is_terraform_dir(entry: &walkdir::DirEntry) -> bool {
     entry.file_type().is_dir() && entry.file_name() == ".terraform"
@@ -241,9 +242,7 @@ pub fn read_tf_directory(directory: &Path) -> io::Result<String> {
         .max_depth(1)
         .into_iter()
         .filter_map(Result::ok)
-        .filter(|e| {
-            e.file_type().is_file() && e.path().extension().map_or(false, |ext| ext == "tf")
-        })
+        .filter(|e| e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "tf"))
     {
         let content = fs::read_to_string(entry.path())?;
         combined_contents.push_str(&content);

--- a/utils/src/stack.rs
+++ b/utils/src/stack.rs
@@ -12,13 +12,13 @@ pub fn read_stack_directory(directory: &Path) -> anyhow::Result<Vec<DeploymentMa
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| {
-            e.file_type().is_file() && e.path().extension().map_or(false, |ext| ext == "yaml")
+            e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "yaml")
         })
         .filter(|e| {
             e.path()
                 .file_name()
                 .and_then(|f| f.to_str())
-                .map_or(false, |f| f != "stack.yaml")
+                .is_some_and(|f| f != "stack.yaml")
         })
     {
         let content = fs::read_to_string(entry.path())?;

--- a/webserver-openapi/src/main.rs
+++ b/webserver-openapi/src/main.rs
@@ -4,9 +4,7 @@ use axum::{Json, Router};
 use axum_macros::debug_handler;
 use log::error;
 
-use env_common::interface::{
-    get_current_identity, initialize_project_id_and_region, GenericCloudHandler,
-};
+use env_common::interface::{initialize_project_id_and_region, GenericCloudHandler};
 use env_defs::{
     CloudProvider, CloudProviderCommon, Dependency, Dependent, DeploymentResp, ModuleResp,
     PolicyResp, ProjectData,


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across multiple files, focusing on enhancing code readability, reducing redundancy, and improving maintainability. Key changes include code cleanup issues.

### Refactoring and Code Simplification:
* Introduced a new `ModuleStackData` struct to encapsulate Terraform module-related data, replacing multiple return values in `generate_full_terraform_module`. This change simplifies the function's interface and improves code clarity (`env_common/src/logic/api_stack.rs`). 
* Updated all references to use the new `ModuleStackData` struct in `publish_stack`, `get_stack_preview`, and related functions, reducing redundancy in handling Terraform module data (`env_common/src/logic/api_stack.rs`). 

### Logic Improvements:
* Replaced nested `if-else` statements with a `match` block in `compare_latest_version` for better readability and maintainability (`env_common/src/logic/api_module.rs`).
* Optimized variable validation checks by replacing `== None` with `.is_none()` in multiple locations, improving code readability (`env_common/src/logic/api_module.rs`, `env_common/src/logic/api_stack.rs`). 

### Performance Enhancements:
* Replaced `.map` and `.collect` with `.fold` in `generate_terraform_block` to construct provider strings more efficiently (`env_common/src/logic/api_stack.rs`).

### Minor Code Cleanup:
* Removed unnecessary `.to_string()` calls and adjusted function parameter references for better consistency (`gitops/src/github.rs`, `infraweave_py/src/deployment.rs`). 
* Added `#[allow(clippy::large_enum_variant)]` to suppress Clippy warnings in `ExtraData` enum (`defs/src/gitprovider.rs`).

### Dependency Updates:
* Added `std::cmp::Ordering` to imports in `api_module.rs`, preparing for the use of `Ordering` in comparison logic (`env_common/src/logic/api_module.rs`).