### PR TITLE
fix: pass deployment claim variables using db instead of env-payload

### DIFF
--- a/defs/src/infra.rs
+++ b/defs/src/infra.rs
@@ -20,7 +20,6 @@ pub struct ApiInfraPayload {
     pub region: String,
     pub drift_detection: DriftDetection,
     pub next_drift_check_epoch: i128,
-    pub variables: serde_json::value::Value,
     pub annotations: serde_json::value::Value,
     pub dependencies: Vec<Dependency>,
     pub initiated_by: String,
@@ -28,4 +27,10 @@ pub struct ApiInfraPayload {
     pub memory: String,
     pub reference: String,
     pub extra_data: ExtraData,
+}
+
+#[derive(Clone)]
+pub struct ApiInfraPayloadWithVariables {
+    pub payload: ApiInfraPayload,
+    pub variables: serde_json::value::Value,
 }

--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -28,7 +28,7 @@ pub use gitprovider::{
     CheckRun, CheckRunOutput, ExtraData, GitHubCheckRun, Installation, JobDetails, Owner,
     Repository, User,
 };
-pub use infra::ApiInfraPayload;
+pub use infra::{ApiInfraPayload, ApiInfraPayloadWithVariables};
 pub use infra_change_record::{get_change_record_identifier, InfraChangeRecord};
 pub use log::LogData;
 pub use module::{


### PR DESCRIPTION
due to environment variable length constraint

This pull request introduces a new struct, `ApiInfraPayloadWithVariables`, to encapsulate `ApiInfraPayload` along with its associated `variables`. This change centralizes the handling of variables and simplifies the codebase by ensuring consistency across multiple functions and modules. Key updates include modifying function signatures, updating logic to accommodate the new struct, and refactoring payload handling in the `terraform_runner` module.

### Struct and Type Updates:
* Introduced `ApiInfraPayloadWithVariables` in `defs/src/infra.rs` to bundle `ApiInfraPayload` with its `variables`.
* Updated exports in `defs/src/lib.rs` to include `ApiInfraPayloadWithVariables`.

### Refactoring in `env_common`:
* Replaced `ApiInfraPayload` with `ApiInfraPayloadWithVariables` in function signatures and logic for `run_claim`, `destroy_infra`, and `driftcheck_infra`. This ensures that variables are consistently passed and handled. 
* Updated `submit_claim_job` and `insert_request_event` to use `ApiInfraPayloadWithVariables` instead of `ApiInfraPayload`. 

### Updates in `terraform_runner`:
* Refactored the `main` function to fetch deployment variables dynamically from the database and construct `ApiInfraPayloadWithVariables`. 
* Modified `initiate_deployment_status_handler` to accept `ApiInfraPayloadWithVariables` and handle variables appropriately. 

These changes improve code maintainability and ensure that deployment variables are handled more robustly across the application.