### PR TITLE
fix: resolve the important difference of explicitly set default = null vs not setting it

### DIFF
--- a/integration-tests/modules/s3bucket-defaults/.terraform.lock.hcl
+++ b/integration-tests/modules/s3bucket-defaults/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.81.0"
+  hashes = [
+    "h1:YoOBDt9gdoivbUh1iGoZNqRBUdBO+PBAxpSZFeTLLYE=",
+    "zh:05534adf6f02d6ec26dbeb37a4d2b6edb63f12dc9ab5cc05ab89329fcd793194",
+    "zh:1d224056866abc4c8f893d55bc6493b73688126fbeaf017ecfbcf5d2f16649c4",
+    "zh:486d28a0a4af2ea23964a8e9087d66e8d794e3438976633b8554684a9237499d",
+    "zh:4bc17c2e93034099b64eb94eaea31b48888b6abdf170e26cf0f6ea734926084c",
+    "zh:5c48c8e82fa8c410499eaa5980c0ebcf6a42360742dfd695393eb9b0bffd4232",
+    "zh:60c387caa94d67e0b768f5874abbd103638c4c9b14073b6cd121018efdfc77bc",
+    "zh:72ddd5e5e07aac1c1c54659df238e6490aac3abbd2e4f13ccf7a9d877c2e2d0f",
+    "zh:8b03d7c4e23a51c9d323f24784d6bfd044f03e6e512df8d458abc97c943a3d3e",
+    "zh:93b6a3c3299fc67d349f8ab80a9b6b65e0e9f3a7e7ea3da0cd87e3ca3b48137b",
+    "zh:9982fc3885797ee97aa45ac7eba0fe6870220748bfa3091141ff513dd7583809",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b7d60f8527dbffe11c83a05b63459d18fda921616242246a73cf3044b8732bcf",
+    "zh:be7a57524298df3c377cdd676e691500277a423ac50f7b33dd02b7d6f4e924fd",
+    "zh:c6ae0b1510804c705aab99659f228bdbafa663fa72ace50c811c0b9220c7dafb",
+    "zh:cdf524a269b4aeb5b1f081d91f54bae967ad50d9c392073a0db1602166a48dff",
+  ]
+}

--- a/integration-tests/modules/s3bucket-defaults/main.tf
+++ b/integration-tests/modules/s3bucket-defaults/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "dummy-test-bucket"
+}

--- a/integration-tests/modules/s3bucket-defaults/module.yaml
+++ b/integration-tests/modules/s3bucket-defaults/module.yaml
@@ -1,0 +1,12 @@
+apiVersion: infraweave.io/v1
+kind: Module
+metadata:
+  name: s3bucket # The name of the module you define
+spec:
+  moduleName: S3Bucket # metadata.name cannot have any uppercase, which is why we need this
+  # version: 0.0.36-dev+test.11 # The released version to use
+  reference: https://github.com/infreweave-io/modules/s3bucket # The URL to the module's source code
+  cpu: "1024"
+  memory: "4096"
+  description: |
+    Very simple, unusable module, only to test the variable defaults.

--- a/integration-tests/modules/s3bucket-defaults/variables.tf
+++ b/integration-tests/modules/s3bucket-defaults/variables.tf
@@ -1,0 +1,12 @@
+variable "nullable_with_default" {
+  type     = string
+  default  = null
+  nullable = true
+  description = "This is a nullable variable with a default value = null"
+}
+
+variable "nullable_without_default" {
+  type     = string
+  nullable = true
+  description = "This is a nullable variable with a default value = null"
+}


### PR DESCRIPTION
This pull request introduces changes to improve the handling of nullable Terraform variables with default values, updates the integration tests, and adds a new test module for validating these changes. Below is a summary of the most important updates grouped by theme:

### Enhancements to Terraform variable handling:
* Updated the `TfVariable` struct in `defs/src/module.rs` to include a custom deserializer (`deserialize_default_value_option`) for handling nullable variables with explicit `null` values versus missing fields. This ensures better alignment with Terraform's behavior.
* Refactored `generate_terraform_variable_single` in `env_common/src/logic/api_stack.rs` to handle `default_value` as an `Option<String>` instead of a plain `String`, improving clarity and correctness when dealing with nullable variables. 

### Integration test updates:
* Added a new integration test (`test_module_publish_s3bucket_defaults`) in `integration-tests/tests/module.rs` to verify the behavior of nullable variables with and without default values.
* Introduced a test module (`integration-tests/modules/s3bucket-defaults`) with Terraform configuration and metadata to validate the handling of nullable variables. This includes `variables.tf` defining two test cases: one with a default `null` value and one without. 

### Minor fixes and cleanups:
* Updated imports in `defs/src/module.rs` to include `serde::de::Deserializer`, which is required for the custom deserializer.
* Removed redundant `default = null` lines in Terraform variable definitions in `env_common/src/logic/api_stack.rs` to align with the new handling logic.