### PR TITLE
docs: add pypi docs link

### DIFF
--- a/infraweave_py/README.md
+++ b/infraweave_py/README.md
@@ -3,3 +3,5 @@
 This package is a minimal python wrapper to interface with InfraWeave to set up you modules and stacks
 
 > Note: this is a preview version
+
+Read the [docs here](https://infraweave-io.github.io/infraweave/infraweave.html)


### PR DESCRIPTION
This pull request updates the `infraweave_py/README.md` file to include a link to the documentation for easier access.

* [`infraweave_py/README.md`](diffhunk://#diff-f8f18e2c0a95a68daeb4f3a3ea04a7eb982453607cb5e4df095a51154ea23ad6R6-R7): Added a link to the InfraWeave documentation to guide users to detailed information.