### PR TITLE
fix: update CLI app name and bin name for consistency

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,8 +15,9 @@ use log::{error, info};
 
 #[tokio::main]
 async fn main() {
-    let matches = App::new("CLI App")
+    let matches = App::new("InfraWeave CLI")
         .version(env!("APP_VERSION"))
+        .bin_name("infraweave")
         .author("InfraWeave <opensource@infraweave.com>")
         .about("Handles all InfraWeave CLI operations")
         .subcommand(


### PR DESCRIPTION
This pull request updates the command-line interface (CLI) application to improve branding and user clarity. 

Branding and user clarity improvements:

* [`cli/src/main.rs`](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL18-R20): Updated the application name from "CLI App" to "InfraWeave CLI" and set the binary name to `infraweave` for consistent branding.