### PR TITLE
fix: ensure lowercase environment in gitops

### DIFF
--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -527,7 +527,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                                 .namespace
                                 .unwrap_or("default".to_string());
                             // Prevent collision between repos by using repo_full_name
-                            let repo_full_name_dash = repo_full_name.replace("/", "-");
+                            let repo_full_name_dash = repo_full_name.replace("/", "-").to_lowercase();
                             match run_claim(
                                 &handler,
                                 &yaml,
@@ -659,7 +659,7 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                                 .namespace
                                 .unwrap_or("default".to_string());
                             // Prevent collision between repos by using repo_full_name
-                            let repo_full_name_dash = repo_full_name.replace("/", "-");
+                            let repo_full_name_dash = repo_full_name.replace("/", "-").to_lowercase();
                             match run_claim(
                                 &handler,
                                 &yaml,


### PR DESCRIPTION
This pull request improves the handling of repository names in the `handle_process_push_event` function within `gitops/src/github.rs`. The changes ensure that repository names are consistently converted to lowercase to prevent potential issues with case sensitivity.

Key changes:

* **Repository name normalization**:
  - Updated `repo_full_name_dash` to convert repository names to lowercase after replacing slashes with dashes. This change was applied in two separate instances within the `handle_process_push_event` function. [[1]](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L530-R530) [[2]](diffhunk://#diff-065650989661b2606f2cf134c04cc39495141e434b6fb5704096b40a2e1e1f75L662-R662)