### PR TITLE
fix: add get-claim for deployment in cli

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -337,6 +337,20 @@ async fn main() {
                 .about("Delete resources in cloud"),
         )
         .subcommand(
+            SubCommand::with_name("get-claim")
+                .about("Get YAML claim from a deployment")
+                .arg(
+                    Arg::with_name("environment")
+                        .help("Environment of the existing deployment, e.g. cli or playground")
+                        .required(true),
+                )
+                .arg(
+                    Arg::with_name("deployment_id")
+                        .help("Deployment id to get claim for, e.g. s3bucket-my-s3-bucket-7FV")
+                        .required(true),
+                )
+        )
+        .subcommand(
             SubCommand::with_name("deployments")
                 .about("Work with deployments")
                 .subcommand(
@@ -549,6 +563,43 @@ async fn main() {
                 }
             }
         }
+        Some(("get-claim", run_matches)) => {
+            let environment_arg = run_matches.value_of("environment").unwrap();
+            let deployment_id = run_matches.value_of("deployment_id").unwrap();
+            let environment = get_environment(environment_arg);
+            match current_region_handler()
+                .await
+                .get_deployment(deployment_id, &environment, false)
+                .await
+            {
+                Ok(deployment) => {
+                    if let Some(deployment) = deployment {
+                        let module = current_region_handler()
+                            .await
+                            .get_module_version(
+                                &deployment.module,
+                                &deployment.module_track,
+                                &deployment.module_version,
+                            )
+                            .await
+                            .unwrap()
+                            .unwrap();
+
+                        println!(
+                            "{}",
+                            env_utils::generate_deployment_claim(&deployment, &module)
+                        );
+                    } else {
+                        error!("Deployment not found: {}", deployment_id);
+                        std::process::exit(1);
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to get claim: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
         Some(("plan", run_matches)) => {
             let environment_arg = run_matches.value_of("environment").unwrap();
             let environment = get_environment(environment_arg);
@@ -641,17 +692,25 @@ async fn main() {
                     .await
                     .unwrap();
                 println!(
-                    "{:<50} {:<20} {:<20} {:<35} {:<10}",
-                    "Deployment ID", "Module", "Version", "Environment", "Status"
+                    "{:<15} {:<50} {:<20} {:<25} {:<40}",
+                    "Status", "Deployment ID", "Module", "Version", "Environment",
                 );
                 for entry in &deployments {
                     println!(
-                        "{:<50} {:<20} {:<20} {:<35} {:<10}",
+                        "{:<15} {:<50} {:<20} {:<25} {:<40}",
+                        entry.status,
                         entry.deployment_id,
                         entry.module,
-                        entry.module_version,
+                        format!(
+                            "{}{}",
+                            &entry.module_version.chars().take(21).collect::<String>(),
+                            if entry.module_version.len() > 21 {
+                                "..."
+                            } else {
+                                ""
+                            },
+                        ),
                         entry.environment,
-                        entry.status,
                     );
                 }
             }

--- a/utils/src/deployment.rs
+++ b/utils/src/deployment.rs
@@ -1,4 +1,5 @@
-use env_defs::{ModuleExample, ModuleSpec};
+use crate::to_camel_case;
+use env_defs::{DeploymentResp, ModuleExample, ModuleResp, ModuleSpec};
 
 pub fn generate_module_example_deployment(
     module: &ModuleSpec,
@@ -23,4 +24,50 @@ spec:
     manifest["spec"]["variables"] = serde_yaml::to_value(module_example.variables.clone()).unwrap();
 
     manifest
+}
+
+pub fn generate_deployment_claim(deployment: &DeploymentResp, module: &ModuleResp) -> String {
+    let variables = match &deployment.module_type.as_str() {
+        &"stack" => deployment.variables.clone(),
+        &"module" => {
+            let mut vars = serde_json::Map::new();
+            for (key, value) in deployment.variables.as_object().unwrap().iter() {
+                vars.insert(to_camel_case(key), value.clone());
+            }
+            let vars = serde_json::Value::Object(vars);
+            vars
+        }
+        _ => panic!("Unsupported module type: {}", deployment.module_type),
+    };
+
+    format!(
+        r#"
+apiVersion: infraweave.io/v1
+kind: {}
+metadata:
+  name: {}
+  namespace: {}
+spec:
+  {}
+  region: {}
+  variables:
+{}
+"#,
+        module.module_name,
+        deployment.deployment_id.split("/").last().unwrap(),
+        deployment.environment,
+        if module.module_type == "stack" {
+            format!("stackVersion: {}", &module.version)
+        } else {
+            format!("moduleVersion: {}", &module.version)
+        },
+        deployment.region,
+        serde_yaml::to_string(&variables)
+            .unwrap()
+            .trim_start_matches("---\n")
+            .lines()
+            .map(|line| format!("    {}", line))
+            .collect::<Vec<String>>()
+            .join("\n"),
+    )
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -15,7 +15,7 @@ mod time;
 mod variables;
 mod versioning;
 
-pub use deployment::generate_module_example_deployment;
+pub use deployment::{generate_deployment_claim, generate_module_example_deployment};
 pub use file::{
     download_zip, download_zip_to_vec, get_terraform_lockfile, get_terraform_tfvars, get_zip_file,
     get_zip_file_from_str, merge_zips, read_tf_directory, read_tf_from_zip, unzip_file, ZipInput,


### PR DESCRIPTION
This pull request introduces a new CLI subcommand, `get-claim`, to retrieve YAML claims for deployments, along with enhancements to the deployment listing format and the addition of a utility function to generate deployment claims. Below is a summary of the most significant changes grouped by theme.

### CLI Enhancements

* Added a new `get-claim` subcommand to the CLI, allowing users to retrieve YAML claims for deployments. This includes required arguments for `environment` and `deployment_id` and logic for fetching deployment data and generating claims. (`cli/src/main.rs`, [[1]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR339-R352) [[2]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR566-R602)

* Updated the deployment listing format to improve readability by reordering columns and truncating long module version strings. (`cli/src/main.rs`, [cli/src/main.rsL644-L654](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL644-L654))

### Utility Functionality

* Added a new `generate_deployment_claim` function in `utils/src/deployment.rs` to generate YAML claims for deployments based on their type and variables. This function supports both "stack" and "module" types and formats the output in a structured YAML format. (`utils/src/deployment.rs`, [utils/src/deployment.rsR28-R73](diffhunk://#diff-ae3bde421766a5aba2795b494cdd569fc57b4d05d601b8ddc11759c93302bff5R28-R73))

* Exported the `generate_deployment_claim` function from `utils/src/lib.rs` for use in other parts of the codebase. (`utils/src/lib.rs`, [utils/src/lib.rsL18-R18](diffhunk://#diff-2a68e14bf95d2e3c7c7c72b92741c10dc2ea9027388a899a65a9a73b4152b80fL18-R18))