### PR TITLE
fix: add destroy version-override

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -322,8 +322,7 @@ async fn main() {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("teardown")
-                .about("Work with environments")
+            SubCommand::with_name("destroy")
                 .arg(
                     Arg::with_name("environment")
                         .help("Environment used when deploying, e.g. dev, prod")
@@ -333,6 +332,12 @@ async fn main() {
                     Arg::with_name("deployment_id")
                         .help("Deployment id to remove, e.g. s3bucket-my-s3-bucket-7FV")
                         .required(true),
+                )
+                .arg(
+                    Arg::with_name("version")
+                        .help("Optional override version of module/stack used during destroy (instead of the version that was last used), e.g. 0.1.4-dev+1234567")
+                        .takes_value(true)
+                        .required(false),
                 )
                 .about("Delete resources in cloud"),
         )
@@ -595,15 +600,17 @@ async fn main() {
                 }
             };
         }
-        Some(("teardown", run_matches)) => {
+        Some(("destroy", run_matches)) => {
             let deployment_id = run_matches.value_of("deployment_id").unwrap();
             let environment_arg = run_matches.value_of("environment").unwrap();
             let environment = get_environment(environment_arg);
+            let version = run_matches.value_of("version");
             match destroy_infra(
                 &current_region_handler().await,
                 deployment_id,
                 &environment,
                 ExtraData::None,
+                version,
             )
             .await
             {
@@ -661,7 +668,7 @@ async fn main() {
             }
         },
         _ => {
-            error!("Invalid subcommand, must be one of 'module', 'apply', 'plan', 'environment', or 'cloud'");
+            error!("Invalid subcommand, must be one of 'module', 'apply', 'plan' or 'destroy'");
             std::process::exit(1);
         }
     }

--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -61,6 +61,9 @@ pub enum ModuleError {
     #[error("The manifest \"{0}\" is missing the \"version\" field")]
     ModuleVersionMissing(String),
 
+    #[error("The module version \"{0}\" for \"{1}\" could not be found")]
+    ModuleVersionNotFound(String, String),
+
     #[error("Other error occurred: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -429,6 +429,7 @@ async fn run_job(
                 &deployment.deployment_id,
                 &deployment.namespace,
                 ExtraData::None,
+                None,
             )
             .await
         }


### PR DESCRIPTION
This pull request introduces several updates to the CLI and backend logic for managing cloud infrastructure deployments. The most notable changes include renaming the `teardown` subcommand to `destroy`, adding support for overriding module versions during resource destruction, and implementing version verification logic to ensure the specified override exists.

### CLI Updates:

* Renamed the `teardown` subcommand to `destroy` for better clarity and added an optional `version` argument to allow overriding the module/stack version during resource destruction. (`cli/src/main.rs`, [[1]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL325-R325) [[2]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR336-R341) [[3]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL598-R613) [[4]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL664-R671)

### Backend Logic Enhancements:

* Updated the `destroy_infra` function to accept an optional `override_version` parameter and implemented logic to verify the existence of the specified version before proceeding with destruction. (`env_common/src/logic/api_infra.rs`, [[1]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R272) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L290-R298)
* Added a helper function `verify_module_version` to check if a given module version exists in the cloud environment. (`env_common/src/logic/api_infra.rs`, [env_common/src/logic/api_infra.rsR348-R372](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R348-R372))

### Error Handling:

* Introduced a new error type `ModuleVersionNotFound` to handle cases where the specified module version does not exist. (`env_common/src/errors.rs`, [env_common/src/errors.rsR64-R66](diffhunk://#diff-c6d872fdae44796737bb215d4a4711cbc0ecc171a501c67c73a410b6174823daR64-R66))

### Miscellaneous:

* Updated calls to `destroy_infra` in other parts of the codebase to include the new `override_version` parameter. (`infraweave_py/src/deployment.rs`, [infraweave_py/src/deployment.rsR432](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5R432))