### PR TITLE
fix: refactor cli

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt, clippy
           override: true
 
       - name: Run cargo fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,17 +316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,21 +1430,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
@@ -1472,8 +1446,8 @@ checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.4",
- "strsim 0.11.1",
+ "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -1490,15 +1464,6 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
@@ -1509,7 +1474,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 3.2.25",
+ "clap",
  "colored",
  "env_common",
  "env_defs",
@@ -1830,7 +1795,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.90",
 ]
 
@@ -2990,15 +2955,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
@@ -3658,7 +3614,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3840,7 +3796,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bytecount",
- "clap 4.5.23",
+ "clap",
  "fancy-regex 0.10.0",
  "fraction 0.12.2",
  "iso8601",
@@ -4880,12 +4836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,7 +5212,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 0.38.41",
  "tracing",
@@ -6910,12 +6860,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -7141,15 +7085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terraform_runner"
 version = "0.1.0"
 dependencies = [
@@ -7208,12 +7143,6 @@ checksum = "064a2677e164cad39ef3c1abddb044d5a25c49d27005804563d8c4227aac8bd0"
 dependencies = [
  "testcontainers",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,7 +6,7 @@ license-file = "../LICENSE"
 build = "build.rs"
 
 [dependencies]
-clap = "3.0"
+clap = { version = "4.5", features = ["derive"] }
 reqwest = "0.11"
 tokio = { version = "1", features = ["full"] }
 colored = "2.0"

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -1,0 +1,64 @@
+use env_common::logic::{destroy_infra, driftcheck_infra};
+use env_defs::ExtraData;
+use log::{error, info};
+
+use crate::run::run_claim_file;
+use crate::utils::current_region_handler;
+
+pub async fn handle_plan(environment: &str, claim: &str, store_plan: bool) {
+    run_claim_file(environment, claim, "plan", store_plan)
+        .await
+        .unwrap();
+}
+
+pub async fn handle_driftcheck(deployment_id: &str, environment: &str, remediate: bool) {
+    match driftcheck_infra(
+        &current_region_handler().await,
+        deployment_id,
+        environment,
+        remediate,
+        ExtraData::None,
+    )
+    .await
+    {
+        Ok(_) => {
+            info!("Successfully requested drift check");
+        }
+        Err(e) => {
+            error!("Failed to request drift check: {}", e);
+            std::process::exit(1);
+        }
+    };
+}
+
+pub async fn handle_apply(environment: &str, claim: &str) {
+    match run_claim_file(environment, claim, "apply", false).await {
+        Ok(_) => {
+            info!("Successfully applied claim");
+        }
+        Err(e) => {
+            error!("Failed to apply claim: {}", e);
+            std::process::exit(1);
+        }
+    };
+}
+
+pub async fn handle_destroy(deployment_id: &str, environment: &str, version: Option<&str>) {
+    match destroy_infra(
+        &current_region_handler().await,
+        deployment_id,
+        environment,
+        ExtraData::None,
+        version,
+    )
+    .await
+    {
+        Ok(_) => {
+            info!("Successfully requested destroying deployment");
+        }
+        Err(e) => {
+            error!("Failed to request destroying deployment: {}", e);
+            std::process::exit(1);
+        }
+    };
+}

--- a/cli/src/commands/deployment.rs
+++ b/cli/src/commands/deployment.rs
@@ -1,0 +1,84 @@
+use log::error;
+
+use crate::current_region_handler;
+use env_defs::CloudProvider;
+
+pub async fn handle_describe(deployment_id: &str, environment: &str) {
+    let (deployment, _) = current_region_handler()
+        .await
+        .get_deployment_and_dependents(deployment_id, environment, false)
+        .await
+        .unwrap();
+    if deployment.is_some() {
+        let deployment = deployment.unwrap();
+        println!(
+            "Deployment: {}",
+            serde_json::to_string_pretty(&deployment).unwrap()
+        );
+    }
+}
+
+pub async fn handle_list() {
+    let deployments = current_region_handler()
+        .await
+        .get_all_deployments("")
+        .await
+        .unwrap();
+    println!(
+        "{:<15} {:<50} {:<20} {:<25} {:<40}",
+        "Status", "Deployment ID", "Module", "Version", "Environment",
+    );
+    for entry in &deployments {
+        println!(
+            "{:<15} {:<50} {:<20} {:<25} {:<40}",
+            entry.status,
+            entry.deployment_id,
+            entry.module,
+            format!(
+                "{}{}",
+                &entry.module_version.chars().take(21).collect::<String>(),
+                if entry.module_version.len() > 21 {
+                    "..."
+                } else {
+                    ""
+                },
+            ),
+            entry.environment,
+        );
+    }
+}
+
+pub async fn handle_get_claim(deployment_id: &str, environment: &str) {
+    match current_region_handler()
+        .await
+        .get_deployment(deployment_id, environment, false)
+        .await
+    {
+        Ok(deployment) => {
+            if let Some(deployment) = deployment {
+                let module = current_region_handler()
+                    .await
+                    .get_module_version(
+                        &deployment.module,
+                        &deployment.module_track,
+                        &deployment.module_version,
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap();
+
+                println!(
+                    "{}",
+                    env_utils::generate_deployment_claim(&deployment, &module)
+                );
+            } else {
+                error!("Deployment not found: {}", deployment_id);
+                std::process::exit(1);
+            }
+        }
+        Err(e) => {
+            error!("Failed to get claim: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,6 @@
+pub mod claim;
+pub mod deployment;
+pub mod module;
+pub mod policy;
+pub mod project;
+pub mod stack;

--- a/cli/src/commands/module.rs
+++ b/cli/src/commands/module.rs
@@ -1,0 +1,84 @@
+use env_common::{
+    errors::ModuleError,
+    logic::{precheck_module, publish_module},
+};
+use log::{error, info};
+
+use crate::current_region_handler;
+use env_defs::CloudProvider;
+
+pub async fn handle_publish(
+    path: &str,
+    track: &str,
+    version: Option<&str>,
+    no_fail_on_exist: bool,
+) {
+    match publish_module(&current_region_handler().await, path, track, version, None).await {
+        Ok(_) => {
+            info!("Module published successfully");
+        }
+        Err(ModuleError::ModuleVersionExists(version, error)) => {
+            if no_fail_on_exist {
+                info!(
+                    "Module version {} already exists: {}, but continuing due to --no-fail-on-exist exits with success",
+                    version, error
+                );
+            } else {
+                error!("Module already exists, exiting with error: {}", error);
+                std::process::exit(1);
+            }
+        }
+        Err(e) => {
+            error!("Failed to publish module: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub async fn handle_precheck(file: &str) {
+    match precheck_module(&file.to_string()).await {
+        Ok(_) => {
+            info!("Module prechecked successfully");
+        }
+        Err(e) => {
+            error!("Failed during module precheck: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub async fn handle_list(track: &str) {
+    let modules = current_region_handler()
+        .await
+        .get_all_latest_module(track)
+        .await
+        .unwrap();
+    println!(
+        "{:<20} {:<20} {:<20} {:<15} {:<10}",
+        "Module", "ModuleName", "Version", "Track", "Ref"
+    );
+    for entry in &modules {
+        println!(
+            "{:<20} {:<20} {:<20} {:<15} {:<10}",
+            entry.module, entry.module_name, entry.version, entry.track, entry.reference,
+        );
+    }
+}
+
+pub async fn handle_get(module: &str, version: &str) {
+    let track = "dev".to_string();
+    match current_region_handler()
+        .await
+        .get_module_version(module, &track, version)
+        .await
+        .unwrap()
+    {
+        Some(module) => {
+            println!("Module: {}", serde_json::to_string_pretty(&module).unwrap());
+        }
+        None => {
+            error!("Module not found");
+            std::process::exit(1);
+        }
+    }
+}

--- a/cli/src/commands/policy.rs
+++ b/cli/src/commands/policy.rs
@@ -1,0 +1,33 @@
+use env_common::logic::publish_policy;
+use log::{error, info};
+
+use crate::current_region_handler;
+use env_defs::CloudProvider;
+
+pub async fn handle_publish(file: &str, environment: &str) {
+    match publish_policy(&current_region_handler().await, file, environment).await {
+        Ok(_) => {
+            info!("Policy published successfully");
+        }
+        Err(e) => {
+            error!("Failed to publish policy: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub async fn handle_list(environment: &str) {
+    current_region_handler()
+        .await
+        .get_all_policies(environment)
+        .await
+        .unwrap();
+}
+
+pub async fn handle_get(policy: &str, environment: &str, version: &str) {
+    current_region_handler()
+        .await
+        .get_policy(policy, environment, version)
+        .await
+        .unwrap();
+}

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -1,0 +1,36 @@
+use log::error;
+
+use crate::current_region_handler;
+use env_defs::CloudProvider;
+
+pub async fn handle_get_current() {
+    match current_region_handler().await.get_current_project().await {
+        Ok(project) => {
+            println!(
+                "Project: {}",
+                serde_json::to_string_pretty(&project).unwrap()
+            );
+        }
+        Err(e) => {
+            error!("Failed to insert project: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub async fn handle_get_all() {
+    match current_region_handler().await.get_all_projects().await {
+        Ok(projects) => {
+            for project in projects {
+                println!(
+                    "Project: {}",
+                    serde_json::to_string_pretty(&project).unwrap()
+                );
+            }
+        }
+        Err(e) => {
+            error!("Failed to insert project: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/cli/src/commands/stack.rs
+++ b/cli/src/commands/stack.rs
@@ -1,0 +1,48 @@
+use env_common::{
+    errors::ModuleError,
+    logic::{get_stack_preview, publish_stack},
+};
+use log::{error, info};
+
+use crate::current_region_handler;
+
+pub async fn handle_preview(path: &str) {
+    match get_stack_preview(&current_region_handler().await, &path.to_string()).await {
+        Ok(stack_module) => {
+            info!("Stack generated successfully");
+            println!("{}", stack_module);
+        }
+        Err(e) => {
+            error!("Failed to generate preview for stack: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub async fn handle_publish(
+    path: &str,
+    track: &str,
+    version: Option<&str>,
+    no_fail_on_exist: bool,
+) {
+    match publish_stack(&current_region_handler().await, path, track, version, None).await {
+        Ok(_) => {
+            info!("Stack published successfully");
+        }
+        Err(ModuleError::ModuleVersionExists(version, error)) => {
+            if no_fail_on_exist {
+                info!(
+                    "Stack version {} already exists: {}, but continuing due to --no-fail-on-exist exits with success",
+                    version, error
+                );
+            } else {
+                error!("Stack already exists, exiting with error: {}", error);
+                std::process::exit(1);
+            }
+        }
+        Err(e) => {
+            error!("Failed to publish stack: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod commands;
 mod defs;
 mod plan;
 mod run;


### PR DESCRIPTION
This pull request introduces a major refactor to the CLI codebase, modularizing command logic into dedicated files and adding structured handlers for various CLI operations. It also updates dependencies to improve maintainability and feature support. The most significant changes are the creation of new command handler modules, the reorganization of imports, and the upgrade of the `clap` dependency.

**Command handler modularization and new features:**

* Moved code to new modules under `cli/src/commands/` for `claim`, `deployment`, `module`, `policy`, `project`, and `stack`, each containing async handler functions for relevant CLI operations such as publish, list, get, apply, drift check, and destroy. These handlers centralize and clarify command logic, improve error handling, and ensure consistent output and process exit behavior. 
* Introduced a new `commands` module in `cli/src/lib.rs` to expose the new command handler modules.
* Updated the `cli/src/commands/mod.rs` file to include all new command modules for easier access and maintainability.

**Dependency and configuration updates:**

* Upgraded the `clap` dependency from version 3.0 to 4.5 and enabled the `derive` feature, allowing for more ergonomic CLI argument parsing.

These changes collectively improve the structure, maintainability, and clarity of the CLI codebase, making it easier to extend and debug.