### PR TITLE
fix: only use top level tf-files

### DIFF
--- a/utils/src/file.rs
+++ b/utils/src/file.rs
@@ -279,8 +279,8 @@ pub fn read_tf_from_zip(zip_data: &[u8]) -> io::Result<String> {
             )
         })?;
 
-        // Skip directories
-        if file.is_dir() {
+        // Skip directories and files in subdirectories
+        if file.is_dir() || file.name().contains('/') || file.name().contains('\\') {
             continue;
         }
 


### PR DESCRIPTION
This pull request makes a targeted improvement to the `read_tf_from_zip` function in `utils/src/file.rs`. The function now skips not only directories but also any files located within subdirectories when reading from a zip archive. This ensures that only top-level files are processed, which can help prevent unintended file handling and improve reliability.

* Updated `read_tf_from_zip` to skip both directories and files in subdirectories by checking for slashes in the file name.