### PR TITLE
ci: add git to operator dockerfile

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim-bullseye AS builder
 
 ENV K8S_OPENAPI_ENABLED_VERSION=v1.31
 
-RUN apt-get update && apt-get install -y pkg-config libssl-dev make
+RUN apt-get update && apt-get install -y pkg-config libssl-dev make git
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request makes a minor update to the `operator/Dockerfile` by adding `git` to the list of packages installed in the build environment. This ensures that any build steps requiring `git` will work correctly.

- Build environment update:
  * Added `git` to the list of installed packages in the `operator/Dockerfile` to support build processes that require Git.