### PR TITLE
fix: rename auto_remediate to camelCase

### DIFF
--- a/defs/src/deployment.rs
+++ b/defs/src/deployment.rs
@@ -138,6 +138,7 @@ pub struct DriftDetection {
     pub interval: String,
 
     #[serde(default = "default_drift_detection_false")]
+    #[serde(rename = "autoRemediate")]
     pub auto_remediate: bool,
 
     #[serde(default = "default_drift_detection_empty_list")]


### PR DESCRIPTION
This pull request makes a small change to the `DriftDetection` struct in `defs/src/deployment.rs`, updating the serialization of the `auto_remediate` field to use the `autoRemediate` key in serialized output, to align with Kubernetes-styled claims.