### PR TITLE
fix: add rustls dependency and initialize + align module/stack getter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4889,6 +4889,7 @@ dependencies = [
  "log",
  "openssl",
  "pretty_assertions",
+ "rustls 0.23.19",
  "schemars",
  "serde",
  "serde_json",

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -59,27 +59,9 @@ mod operator_tests {
             let exists = crd_exists(&client, "s3buckets.infraweave.io").await;
             assert_eq!(exists, false); // Operator has not started yet, no CRD should exist
 
-            let current_environment = match std::env::var("INFRAWEAVE_ENV") {
-                    Ok(env) => env,
-                    Err(_) => {
-                        println!("Please make sure to set the platform environment, for example: \"export INFRAWEAVE_ENV=dev\"");
-                        std::process::exit(1);
-                        // TODO: Handle errors and then throw error instead of exit(1)
-                        // return Err(CloudHandlerError::MissingEnvironment());
-                    }
-                };
-            info!("Current environment: {}", current_environment);
-
             let modules_watched_set: HashSet<String> = HashSet::new();
             // Try operator function to list and apply all existing modules as CRDs
-            match list_and_apply_modules(
-                &handler,
-                client.clone(),
-                &current_environment,
-                &modules_watched_set,
-            )
-            .await
-            {
+            match list_and_apply_modules(&handler, client.clone(), &modules_watched_set).await {
                 Ok(_) => println!("Successfully listed and applied modules"),
                 Err(e) => eprintln!("Failed to list and apply modules: {:?}", e),
             }

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0"
 chrono = "0.4.31"
 base64 = "0.13"
 openssl = { version = "0.10.72", features = ["vendored"] }
+rustls = { version = "0.23", features = ["ring"] }
 kube-leader-election = "0.37.0"
 
 crd_templator = { path = "../crd-templator" }

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -11,6 +11,9 @@ use operator::start_operator;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize rustls crypto provider
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     setup_logging().expect("Failed to initialize logging.");
     initialize_project_id_and_region().await;
 

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -64,26 +64,8 @@ async fn acquire_leadership_and_run_once(
             if lease.acquired_lease {
                 println!("Acquired leadership as {}", get_holder_id());
 
-                let current_environment = match std::env::var("INFRAWEAVE_ENV") {
-                    Ok(env) => env,
-                    Err(_) => {
-                        println!("Please make sure to set the platform environment, for example: \"export INFRAWEAVE_ENV=dev\"");
-                        std::process::exit(1);
-                        // TODO: Handle errors and then throw error instead of exit(1)
-                        // return Err(CloudHandlerError::MissingEnvironment());
-                    }
-                };
-                info!("Current environment: {}", current_environment);
-
                 let modules_watched_set: HashSet<String> = HashSet::new();
-                match list_and_apply_modules(
-                    handler,
-                    client.clone(),
-                    &current_environment,
-                    &modules_watched_set,
-                )
-                .await
-                {
+                match list_and_apply_modules(handler, client.clone(), &modules_watched_set).await {
                     Ok(_) => println!("Successfully listed and applied modules"),
                     Err(e) => eprintln!("Failed to list and apply modules: {:?}", e),
                 }
@@ -354,13 +336,12 @@ async fn initialize_kube_client() -> Result<KubeClient, Box<dyn std::error::Erro
 pub async fn list_and_apply_modules(
     handler: &GenericCloudHandler,
     client: KubeClient,
-    environment: &str,
     modules_watched_set: &HashSet<String>,
 ) -> Result<(), Box<dyn std::error::Error>>
 where {
-    let available_modules = handler.get_all_latest_module(environment).await.unwrap();
+    let available_modules = handler.get_all_latest_module("").await.unwrap();
 
-    let available_stack_modules = handler.get_all_latest_stack(environment).await.unwrap();
+    let available_stack_modules = handler.get_all_latest_stack("").await.unwrap();
 
     let all_available_modules = [
         available_modules.as_slice(),


### PR DESCRIPTION
This pull request adds initialization of the rustls crypto provider and the removal of environment variable handling for module operations.

**Security and crypto provider improvements:**

* Added `rustls` as a dependency in `Cargo.toml` with the `ring` feature enabled, and initialized the rustls crypto provider at startup in `main.rs`. This prepares the operator for using rustls-based cryptography, which is a modern, safe, and pure-Rust TLS implementation. [[1]](diffhunk://#diff-fa2e3014b632401a214e3fd555ac30a556df7ca84e01192da5344c8fc8b34b57R23) [[2]](diffhunk://#diff-6916676a025aa3cf9969dd3c2f318a3603f8159611320d3759f9de0ae4cf6633R14-R16)

**Environment handling simplification:**

* Removed the requirement to set the `INFRAWEAVE_ENV` environment variable when acquiring leadership and running module operations. The code no longer exits if the variable is missing, and instead passes an empty string to module-related functions. This makes the operator more robust and easier to run in different environments. [[1]](diffhunk://#diff-46cf44a083bd5f031887f93d91d7577de42bf49b6bc7bc08c0bd70b1597f1bb6L67-R68) [[2]](diffhunk://#diff-46cf44a083bd5f031887f93d91d7577de42bf49b6bc7bc08c0bd70b1597f1bb6L357-R344)