### PR TITLE
fix: add k8s claim-validation using admission controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +935,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.5.1",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.23.19",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tower-service",
 ]
 
 [[package]]
@@ -2602,6 +2630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad492b2cf1d89d568a43508ab24f98501fe03f2f31c01e1d0fe7366a71745d2"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,6 +3685,7 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum 0.8.1",
  "base64 0.13.1",
  "chrono",
  "dirs",
@@ -3669,6 +3708,7 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "tokio",
+ "tower 0.5.2",
 ]
 
 [[package]]
@@ -4874,6 +4914,8 @@ name = "operator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum 0.8.1",
+ "axum-server",
  "base64 0.13.1",
  "chrono",
  "crd_templator",
@@ -4890,11 +4932,14 @@ dependencies = [
  "openssl",
  "pretty_assertions",
  "rustls 0.23.19",
+ "rustls-pemfile 2.2.0",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
+ "tokio-rustls 0.26.1",
+ "tower 0.5.2",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ aws-integration-tests:
 	INFRAWEAVE_API_FUNCTION=function \
 	AWS_ACCESS_KEY_ID=dummy \
 	AWS_SECRET_ACCESS_KEY=dummy \
+ 	AWS_REGION=us-east-1 \
 	TEST_MODE=true \
 	CONCURRENCY_LIMIT=1 \
 	cargo test -p integration-tests -- --test-threads=1

--- a/crd-templator/templates/module_crd_template.yaml
+++ b/crd-templator/templates/module_crd_template.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: "{{ plural }}.{{ group }}"
+  annotations:
+    infraweave.io/validating-webhook: "enabled"
 spec:
   group: "{{ group }}"
   names:

--- a/env_common/src/interface/deployment_status_handler.rs
+++ b/env_common/src/interface/deployment_status_handler.rs
@@ -223,7 +223,10 @@ impl<'a> DeploymentStatusHandler<'a> {
         }
     }
 
-    pub async fn send_deployment(&self, handler: &GenericCloudHandler) {
+    pub async fn send_deployment(
+        &self,
+        handler: &GenericCloudHandler,
+    ) -> Result<(), anyhow::Error> {
         let deployment = DeploymentResp {
             epoch: get_epoch(),
             deployment_id: self.deployment_id.to_string(),
@@ -256,8 +259,8 @@ impl<'a> DeploymentStatusHandler<'a> {
                 info!("Deployment inserted");
             }
             Err(e) => {
-                println!("Error: {:?}", e);
-                panic!("Error inserting deployment");
+                error!("Error inserting deployment: {:?}", e);
+                return Err(anyhow::anyhow!("Error inserting deployment: {}", e));
             }
         }
 
@@ -268,11 +271,13 @@ impl<'a> DeploymentStatusHandler<'a> {
                     info!("Drifted deployment inserted");
                 }
                 Err(e) => {
-                    error!("Error: {:?}", e);
-                    panic!("Error inserting drifted deployment");
+                    error!("Error inserting drifted deployment: {:?}", e);
+                    return Err(anyhow::anyhow!("Error inserting drifted deployment: {}", e));
                 }
             }
         }
+
+        Ok(())
     }
 
     fn is_plan(&self) -> bool {

--- a/env_common/src/logic/mod.rs
+++ b/env_common/src/logic/mod.rs
@@ -27,6 +27,7 @@ pub use api_notification::publish_notification;
 pub use api_infra::{
     destroy_infra, driftcheck_infra, get_deployment_details, is_deployment_in_progress,
     is_deployment_plan_in_progress, mutate_infra, run_claim, submit_claim_job,
+    validate_and_prepare_claim,
 };
 
 pub use api_change_record::insert_infra_change_record;

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -31,3 +31,5 @@ rustls = "0.23.18"
 dirs = "4.0"
 operator = { path = "../operator" }
 base64 = "0.13"
+axum = "0.8.1"
+tower = "0.5"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -21,7 +21,11 @@ chrono = "0.4.31"
 base64 = "0.13"
 openssl = { version = "0.10.72", features = ["vendored"] }
 rustls = { version = "0.23", features = ["ring"] }
+rustls-pemfile = "2.0"
+tokio-rustls = "0.26"
 kube-leader-election = "0.37.0"
+axum = "0.8.1"
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 
 crd_templator = { path = "../crd-templator" }
 env_common = { path = "../env_common" }
@@ -30,3 +34,4 @@ env_defs = { path = "../defs" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
+tower = "0.5"

--- a/operator/infraweave-helm/templates/_helpers.tpl
+++ b/operator/infraweave-helm/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "infraweave.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "infraweave.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "infraweave.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "infraweave.labels" -}}
+helm.sh/chart: {{ include "infraweave.chart" . }}
+{{ include "infraweave.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "infraweave.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "infraweave.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "infraweave.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "infraweave.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/operator/infraweave-helm/templates/deployment.yaml
+++ b/operator/infraweave-helm/templates/deployment.yaml
@@ -1,25 +1,49 @@
+{{- if .Values.operator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: infraweave
+  name: infraweave-operator
+  labels:
+    app: infraweave-operator
+    component: operator
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicaCount }}
   selector:
     matchLabels:
-      app: infraweave
+      app: infraweave-operator
+      component: operator
   template:
     metadata:
       labels:
-        app: infraweave
+        app: infraweave-operator
+        component: operator
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: infraweave-service-account
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-      - name: infraweave
-        image: infraweave-operator:latest
-        imagePullPolicy: Never
+      - name: operator
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
+        - name: MODE
+          value: {{ .Values.operator.mode | quote }}
         - name: AWS_REGION
-          value: {{ .Values.aws.region }}
+          value: {{ .Values.aws.region | quote }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -39,7 +63,137 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: INFRAWEAVE_CLUSTER_ID
+          value: {{ .Values.cluster.clusterId | quote }}
         - name: RUST_LOG
           value: info
         - name: RUST_BACKTRACE
           value: "1"
+        {{- with .Values.operator.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+---
+{{- if .Values.admissionController.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infraweave-admission-controller
+  labels:
+    app: infraweave-admission-controller
+    component: admission-controller
+spec:
+  replicas: {{ .Values.admissionController.replicaCount }}
+  selector:
+    matchLabels:
+      app: infraweave-admission-controller
+      component: admission-controller
+  template:
+    metadata:
+      labels:
+        app: infraweave-admission-controller
+        component: admission-controller
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: infraweave-admission-controller-service-account
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: admission-controller
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        env:
+        - name: MODE
+          value: {{ .Values.admissionController.mode | quote }}
+        - name: AWS_REGION
+          value: {{ .Values.aws.region | quote }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-tokens
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws-tokens
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_SESSION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: aws-tokens
+              key: AWS_SESSION_TOKEN
+        - name: WEBHOOK_PORT
+          value: {{ .Values.admissionController.port | quote }}
+        - name: RUST_LOG
+          value: info
+        - name: RUST_BACKTRACE
+          value: "1"
+        ports:
+        - containerPort: {{ .Values.admissionController.port }}
+          name: webhook
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.admissionController.port }}
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.admissionController.port }}
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        {{- with .Values.admissionController.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /etc/webhook/certs
+          readOnly: true
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: {{ .Values.admissionController.tls.secretName }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/operator/infraweave-helm/templates/rbac.yaml
+++ b/operator/infraweave-helm/templates/rbac.yaml
@@ -4,6 +4,12 @@ metadata:
   name: infraweave-service-account
   namespace: default
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: infraweave-admission-controller-service-account
+  namespace: default
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,6 +23,15 @@ rules:
   verbs: ["create", "get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: infraweave-admission-controller-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: infraweave-cluster-role-binding
@@ -27,4 +42,17 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: infraweave-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: infraweave-admission-controller-cluster-role-binding
+subjects:
+- kind: ServiceAccount
+  name: infraweave-admission-controller-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: infraweave-admission-controller-cluster-role
   apiGroup: rbac.authorization.k8s.io

--- a/operator/infraweave-helm/templates/service.yaml
+++ b/operator/infraweave-helm/templates/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.admissionController.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.admissionController.serviceName }}
+  labels:
+    app: infraweave-admission-controller
+    component: admission-controller
+spec:
+  type: {{ .Values.admissionController.service.type }}
+  ports:
+  - port: {{ .Values.admissionController.service.port }}
+    targetPort: {{ .Values.admissionController.service.targetPort }}
+    protocol: TCP
+    name: webhook
+  selector:
+    app: infraweave-admission-controller
+    component: admission-controller
+{{- end }}

--- a/operator/infraweave-helm/templates/validatingwebhook.yaml
+++ b/operator/infraweave-helm/templates/validatingwebhook.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.admissionController.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: infraweave-validating-webhook
+  annotations:
+    # If using cert-manager, uncomment this:
+    # cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/infraweave-admission-controller-certs
+webhooks:
+- name: validate.infraweave.io
+  admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: {{ .Values.admissionController.serviceName }}
+      namespace: {{ .Release.Namespace }}
+      path: "/validate"
+      port: {{ .Values.admissionController.service.port }}
+    # CA bundle will be injected by the patch job
+    caBundle: Cg==
+  rules:
+  - operations: ["CREATE", "UPDATE"]
+    apiGroups: ["infraweave.io"]
+    apiVersions: ["v1"]
+    resources: ["*"]
+    scope: "Namespaced"
+  failurePolicy: Fail
+  sideEffects: None
+  timeoutSeconds: 10
+{{- end }}

--- a/operator/infraweave-helm/templates/webhook-cert-job.yaml
+++ b/operator/infraweave-helm/templates/webhook-cert-job.yaml
@@ -1,0 +1,89 @@
+{{- if and .Values.admissionController.enabled (not .Values.admissionController.tls.useExistingSecret) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "infraweave.fullname" . }}-create-webhook-cert
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-cert-generator
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: {{ include "infraweave.fullname" . }}-create-webhook-cert
+    spec:
+      serviceAccountName: {{ include "infraweave.fullname" . }}-webhook-cert-sa
+      restartPolicy: OnFailure
+      containers:
+      - name: create
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
+        imagePullPolicy: IfNotPresent
+        args:
+        - create
+        - --host={{ .Values.admissionController.serviceName }},{{ .Values.admissionController.serviceName }}.{{ .Release.Namespace }}.svc
+        - --namespace={{ .Release.Namespace }}
+        - --secret-name={{ .Values.admissionController.tls.secretName }}
+        - --cert-name=tls.crt
+        - --key-name=tls.key
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-cert-sa
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-cert-generator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-cert-role
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-cert-generator
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-cert-rolebinding
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-cert-generator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "infraweave.fullname" . }}-webhook-cert-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "infraweave.fullname" . }}-webhook-cert-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/operator/infraweave-helm/templates/webhook-patch-job.yaml
+++ b/operator/infraweave-helm/templates/webhook-patch-job.yaml
@@ -1,0 +1,126 @@
+{{- if and .Values.admissionController.enabled (not .Values.admissionController.tls.useExistingSecret) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "infraweave.fullname" . }}-patch-webhook
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-patcher
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      name: {{ include "infraweave.fullname" . }}-patch-webhook
+    spec:
+      serviceAccountName: {{ include "infraweave.fullname" . }}-webhook-patch-sa
+      restartPolicy: OnFailure
+      containers:
+      - name: patch
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
+        imagePullPolicy: IfNotPresent
+        args:
+        - patch
+        - --webhook-name=infraweave-validating-webhook
+        - --namespace={{ .Release.Namespace }}
+        - --secret-name={{ .Values.admissionController.tls.secretName }}
+        - --patch-validating=true
+        - --patch-mutating=false
+        - --patch-failure-policy=Ignore
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-sa
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-patcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-role
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-patcher
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-rolebinding
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-patcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-sa
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-secret-role
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-patcher
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-secret-rolebinding
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "infraweave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook-patcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-secret-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "infraweave.fullname" . }}-webhook-patch-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/operator/infraweave-helm/values.yaml
+++ b/operator/infraweave-helm/values.yaml
@@ -1,6 +1,56 @@
 # Default values for infraweave-helm.
 
-replicaCount: 1
+# Cluster configuration
+cluster:
+  # Unique cluster ID for this Kubernetes cluster
+  clusterId: "production-cluster"
+
+# Operator configuration
+operator:
+  enabled: true
+  replicaCount: 1
+  mode: "operator"  # Must be "operator"
+  
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+# Admission Controller (webhook) configuration
+admissionController:
+  enabled: true
+  replicaCount: 3  # Multiple replicas for HA
+  mode: "webhook"  # Must be "webhook"
+  port: 8443
+  serviceName: "infraweave-admission-controller"  # Used for certificate generation
+  
+  service:
+    type: ClusterIP
+    port: 443
+    targetPort: 8443
+  
+  # TLS certificate for admission controller (required by Kubernetes)
+  tls:
+    # If true, provide your own certificates via existing secret
+    # If false, certificates will be auto-generated via a Kubernetes Job
+    useExistingSecret: false
+    # Name of the secret with tls.crt and tls.key
+    secretName: "infraweave-admission-controller-certs"
+    # Only used if useExistingSecret is true
+    caCert: ""
+    cert: ""
+    key: ""
+  
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 aws:
   accessKeyId: ""
@@ -9,10 +59,10 @@ aws:
   region: ""
 
 image:
-  repository: nginx
+  repository: infraweave-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -39,45 +89,6 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-
-service:
-  type: ClusterIP
-  port: 80
-
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod apply;
 pub mod defs;
 pub mod operator;
+pub mod validation;
+pub mod webhook;

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -1,13 +1,17 @@
 use env_common::interface::{initialize_project_id_and_region, GenericCloudHandler};
 use log::info;
+use std::env;
 
 mod apply;
 mod defs;
 mod logging;
 mod operator;
+mod validation;
+mod webhook;
 
 use logging::setup_logging;
 use operator::start_operator;
+use webhook::start_webhook_server;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -15,12 +19,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     setup_logging().expect("Failed to initialize logging.");
-    initialize_project_id_and_region().await;
 
-    info!("This message will be logged to both stdout and the file.");
+    let mode = env::var("MODE").unwrap_or_else(|_| "operator".to_string());
+
+    match mode.to_lowercase().as_str() {
+        "webhook" => {
+            info!("Starting in WEBHOOK mode");
+            run_webhook_mode().await?;
+        }
+        "operator" => {
+            info!("Starting in OPERATOR mode");
+            run_operator_mode().await?;
+        }
+        _ => {
+            return Err(format!("Invalid MODE '{}'. Must be 'operator' or 'webhook'", mode).into());
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_operator_mode() -> Result<(), Box<dyn std::error::Error>> {
+    initialize_project_id_and_region().await;
 
     let handler = GenericCloudHandler::default().await;
     start_operator(&handler).await?;
+
+    Ok(())
+}
+
+async fn run_webhook_mode() -> Result<(), Box<dyn std::error::Error>> {
+    let webhook_port = env::var("WEBHOOK_PORT")
+        .unwrap_or_else(|_| "8443".to_string())
+        .parse::<u16>()
+        .unwrap_or(8443);
+
+    let handler = GenericCloudHandler::default().await;
+
+    info!("Starting admission webhook server on port {}", webhook_port);
+    start_webhook_server(handler, webhook_port).await?;
 
     Ok(())
 }

--- a/operator/src/validation.rs
+++ b/operator/src/validation.rs
@@ -1,0 +1,78 @@
+use env_common::interface::GenericCloudHandler;
+use env_common::logic::validate_and_prepare_claim;
+use env_defs::ExtraData;
+use kube::api::DynamicObject;
+use log::{error, info};
+use std::env;
+
+/// Validates a claim before it's admitted to Kubernetes
+/// Returns (is_valid, message)
+pub async fn validate_claim(
+    handler: &GenericCloudHandler,
+    claim: &DynamicObject,
+) -> (bool, String) {
+    let claim_name = claim
+        .metadata
+        .name
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    let namespace = claim
+        .metadata
+        .namespace
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or("default");
+
+    info!(
+        "Validating claim: {} in namespace: {}",
+        claim_name, namespace
+    );
+
+    // Convert DynamicObject to serde_yaml::Value
+    let yaml_value = match serde_json::to_value(claim) {
+        Ok(json_val) => match serde_yaml::to_value(&json_val) {
+            Ok(yaml_val) => yaml_val,
+            Err(e) => {
+                let msg = format!("Failed to convert claim to YAML: {}", e);
+                error!("{}", msg);
+                return (false, msg);
+            }
+        },
+        Err(e) => {
+            let msg = format!("Failed to convert claim to JSON: {}", e);
+            error!("{}", msg);
+            return (false, msg);
+        }
+    };
+
+    // Use cluster ID as environment to match operator behavior
+    // Format: k8s-{cluster_id}/{namespace}
+    let cluster_id = env::var("INFRAWEAVE_CLUSTER_ID").unwrap_or_else(|_| "cluster-id".to_string());
+    let environment = format!("k8s-{}/{}", cluster_id, namespace);
+
+    info!("Using environment: {}", environment);
+
+    let validation_result = validate_and_prepare_claim(
+        handler,
+        &yaml_value,
+        &environment,
+        "apply",
+        vec![],
+        ExtraData::None,
+        "main",
+    )
+    .await;
+
+    match validation_result {
+        Ok((_deployment_id, _payload)) => {
+            info!("Claim '{}' validated successfully", claim_name);
+            (true, format!("Claim validated successfully"))
+        }
+        Err(e) => {
+            let msg = format!("Validation failed: {}", e);
+            error!("{}", msg);
+            (false, msg)
+        }
+    }
+}

--- a/operator/src/webhook.rs
+++ b/operator/src/webhook.rs
@@ -1,0 +1,294 @@
+use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Json, Router};
+use axum_server::tls_rustls::RustlsConfig;
+use env_common::interface::GenericCloudHandler;
+use kube::api::DynamicObject;
+use rustls::pki_types::CertificateDer;
+use rustls::ServerConfig;
+use rustls_pemfile::certs;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{BufReader, Cursor};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::validation::validate_claim;
+
+/// Kubernetes AdmissionReview request structure
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdmissionReview {
+    pub api_version: String,
+    pub kind: String,
+    pub request: AdmissionRequest,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdmissionRequest {
+    pub uid: String,
+    pub kind: GroupVersionKind,
+    pub resource: GroupVersionResource,
+    pub operation: String,
+    pub object: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupVersionKind {
+    pub group: String,
+    pub version: String,
+    pub kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupVersionResource {
+    pub group: String,
+    pub version: String,
+    pub resource: String,
+}
+
+/// Kubernetes AdmissionReview response structure
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdmissionReviewResponse {
+    pub api_version: String,
+    pub kind: String,
+    pub response: AdmissionResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdmissionResponse {
+    pub uid: String,
+    pub allowed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<Status>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Status {
+    pub message: String,
+}
+
+#[derive(Clone)]
+struct WebhookState {
+    handler: GenericCloudHandler,
+}
+
+/// Handler for admission webhook requests
+async fn validate_handler(
+    State(state): State<Arc<WebhookState>>,
+    Json(review): Json<AdmissionReview>,
+) -> impl IntoResponse {
+    // Parse the object from the request
+    let claim: DynamicObject = match serde_json::from_value(review.request.object.clone()) {
+        Ok(obj) => obj,
+        Err(e) => {
+            eprintln!("Failed to parse object: {:?}", e);
+            return (
+                StatusCode::OK,
+                Json(AdmissionReviewResponse {
+                    api_version: "admission.k8s.io/v1".to_string(),
+                    kind: "AdmissionReview".to_string(),
+                    response: AdmissionResponse {
+                        uid: review.request.uid,
+                        allowed: false,
+                        status: Some(Status {
+                            message: format!("Failed to parse object: {}", e),
+                        }),
+                    },
+                }),
+            );
+        }
+    };
+
+    // Validate the claim using the real validation logic
+    let (is_valid, message) = validate_claim(&state.handler, &claim).await;
+
+    let response = AdmissionReviewResponse {
+        api_version: "admission.k8s.io/v1".to_string(),
+        kind: "AdmissionReview".to_string(),
+        response: AdmissionResponse {
+            uid: review.request.uid,
+            allowed: is_valid,
+            status: if is_valid {
+                None
+            } else {
+                Some(Status { message })
+            },
+        },
+    };
+
+    (StatusCode::OK, Json(response))
+}
+
+/// Health check endpoint
+async fn health_handler() -> impl IntoResponse {
+    (StatusCode::OK, "OK")
+}
+
+/// Creates and returns the webhook server router
+pub fn create_webhook_router(handler: GenericCloudHandler) -> Router {
+    let state = Arc::new(WebhookState { handler });
+
+    Router::new()
+        .route("/validate", post(validate_handler))
+        .route("/health", axum::routing::get(health_handler))
+        .with_state(state)
+}
+
+/// Starts the webhook server on the specified port with TLS support
+pub async fn start_webhook_server(
+    handler: GenericCloudHandler,
+    port: u16,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let app = create_webhook_router(handler);
+    let addr = format!("0.0.0.0:{}", port);
+
+    // Check if TLS certificates are available
+    let cert_path = PathBuf::from("/etc/webhook/certs/tls.crt");
+    let key_path = PathBuf::from("/etc/webhook/certs/tls.key");
+
+    if cert_path.exists() && key_path.exists() {
+        println!("Starting webhook server with TLS on {}", addr);
+
+        // Load certificates
+        let cert_pem = fs::read(&cert_path)?;
+        let key_pem = fs::read(&key_path)?;
+
+        // Parse certificates
+        let certs: Vec<CertificateDer> =
+            certs(&mut BufReader::new(Cursor::new(&cert_pem))).collect::<Result<Vec<_>, _>>()?;
+
+        // Use rustls_pemfile::private_key which auto-detects format
+        let mut key_reader = BufReader::new(Cursor::new(&key_pem));
+        let private_key = rustls_pemfile::private_key(&mut key_reader)?
+            .ok_or("No private key found in key file - file may be empty or not in PEM format")?;
+
+        // Build TLS configuration
+        let tls_config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, private_key)?;
+
+        let rustls_config = RustlsConfig::from_config(Arc::new(tls_config));
+
+        // Start HTTPS server
+        axum_server::bind_rustls(addr.parse()?, rustls_config)
+            .serve(app.into_make_service())
+            .await?;
+    } else {
+        println!(
+            "TLS certificates not found, starting webhook server without TLS on {}",
+            addr
+        );
+        println!("  Expected cert at: {:?}", cert_path);
+        println!("  Expected key at: {:?}", key_path);
+
+        // Fallback to HTTP for development/testing
+        let listener = tokio::net::TcpListener::bind(&addr).await?;
+        axum::serve(listener, app).await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    // Helper to create a test handler
+    async fn create_test_handler() -> GenericCloudHandler {
+        // For unit tests, we'll need a mock or test handler
+        // This would require mocking infrastructure
+        // For now, these tests are commented out - use integration tests instead
+        unimplemented!("Use integration tests in integration-tests/tests/operator.rs")
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires test infrastructure setup
+    async fn test_health_endpoint() {
+        let handler = create_test_handler().await;
+        let app = create_webhook_router(handler);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires test infrastructure setup
+    async fn test_validate_endpoint() {
+        let handler = create_test_handler().await;
+        let app = create_webhook_router(handler);
+
+        let admission_review = serde_json::json!({
+            "apiVersion": "admission.k8s.io/v1",
+            "kind": "AdmissionReview",
+            "request": {
+                "uid": "test-uid-123",
+                "kind": {
+                    "group": "infraweave.io",
+                    "version": "v1",
+                    "kind": "S3Bucket"
+                },
+                "resource": {
+                    "group": "infraweave.io",
+                    "version": "v1",
+                    "resource": "s3buckets"
+                },
+                "operation": "CREATE",
+                "object": {
+                    "apiVersion": "infraweave.io/v1",
+                    "kind": "S3Bucket",
+                    "metadata": {
+                        "name": "test-bucket",
+                        "namespace": "default"
+                    },
+                    "spec": {
+                        "moduleVersion": "1.0.0",
+                        "region": "us-west-2",
+                        "variables": {
+                            "bucketName": "my-test-bucket"
+                        }
+                    }
+                }
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/validate")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&admission_review).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let review_response: AdmissionReviewResponse = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(review_response.response.uid, "test-uid-123");
+    }
+}

--- a/terraform_runner/src/module.rs
+++ b/terraform_runner/src/module.rs
@@ -134,7 +134,7 @@ pub async fn get_module(
                 status_handler.set_event_duration();
                 status_handler.set_error_text(error_text.to_string());
                 status_handler.send_event(&handler).await;
-                status_handler.send_deployment(&handler).await;
+                status_handler.send_deployment(&handler).await?;
                 Err(anyhow::anyhow!("Module does not exist"))
             } else {
                 let module = module.unwrap(); // Improve this
@@ -149,7 +149,7 @@ pub async fn get_module(
             status_handler.set_event_duration();
             status_handler.set_error_text(error_text);
             status_handler.send_event(&handler).await;
-            status_handler.send_deployment(&handler).await;
+            status_handler.send_deployment(&handler).await?;
             Err(anyhow::anyhow!("Failed to get module"))
         }
     }
@@ -178,7 +178,7 @@ pub async fn download_module(
                 status_handler.set_status(status);
                 status_handler.set_event_duration();
                 status_handler.send_event(handler).await;
-                status_handler.send_deployment(handler).await;
+                status_handler.send_deployment(handler).await?;
                 Err(anyhow!("Error running terraform init: {}", e))
             }
         }?;
@@ -227,7 +227,7 @@ async fn compare_module_integrity(
             status_handler.set_status(status);
             status_handler.set_event_duration();
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             return Err(anyhow!("Error when checking module integrity"));
         }
     }

--- a/terraform_runner/src/opa.rs
+++ b/terraform_runner/src/opa.rs
@@ -186,7 +186,7 @@ pub async fn run_opa_policy_checks(
                 status_handler.set_event_duration();
                 status_handler.set_error_text(error_text);
                 status_handler.send_event(handler).await;
-                status_handler.send_deployment(handler).await;
+                status_handler.send_deployment(handler).await?;
                 status_handler.set_error_text("".to_string());
                 exit(0);
             }
@@ -206,7 +206,7 @@ pub async fn run_opa_policy_checks(
         status_handler.set_status(status);
         status_handler.set_event_duration();
         status_handler.send_event(handler).await;
-        status_handler.send_deployment(handler).await;
+        status_handler.send_deployment(handler).await?;
         return Err(anyhow::anyhow!(
             "OPA Policy evaluation found policy violations"
         ));

--- a/terraform_runner/src/runner.rs
+++ b/terraform_runner/src/runner.rs
@@ -58,7 +58,7 @@ pub async fn run_terraform_runner(
         status_handler.set_is_drift_check();
     }
     status_handler.send_event(&handler).await;
-    status_handler.send_deployment(&handler).await;
+    status_handler.send_deployment(&handler).await?;
 
     let (result, error_text) =
         match terraform_flow(&handler, &mut status_handler, &payload, &job_id).await {
@@ -176,7 +176,7 @@ async fn terraform_flow<'a>(
         status_handler.set_event_duration();
         status_handler.set_last_event_epoch(); // Reset the event duration timer for the next event
         status_handler.send_event(handler).await;
-        status_handler.send_deployment(handler).await;
+        status_handler.send_deployment(handler).await?;
     }
 
     // if !dependents.is_empty() {
@@ -291,7 +291,7 @@ async fn ensure_valid_job_id(
         status_handler.set_status(status);
         status_handler.set_event_duration();
         status_handler.send_event(handler).await;
-        status_handler.send_deployment(handler).await;
+        let _ = status_handler.send_deployment(handler).await;
         exit(1);
     }
 }
@@ -348,7 +348,7 @@ async fn get_current_job_id(
             status_handler.set_status(status);
             status_handler.set_event_duration();
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            let _ = status_handler.send_deployment(handler).await;
             exit(1);
         }
     }
@@ -428,7 +428,7 @@ async fn check_dependencies(
         status_handler.set_status(status);
         status_handler.set_event_duration();
         status_handler.send_event(handler).await;
-        status_handler.send_deployment(handler).await;
+        status_handler.send_deployment(handler).await?;
         return Err(anyhow!("Dependencies not finished"));
     }
 
@@ -456,7 +456,7 @@ async fn check_dependants(
             status_handler.set_status(status);
             status_handler.set_event_duration();
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             return Err(anyhow!("Error getting deployment and dependants"));
         }
     };
@@ -467,7 +467,7 @@ async fn check_dependants(
         status_handler.set_status(status);
         status_handler.set_event_duration();
         status_handler.send_event(handler).await;
-        status_handler.send_deployment(handler).await;
+        status_handler.send_deployment(handler).await?;
         return Err(anyhow!("This deployment has dependants"));
     }
 

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -198,7 +198,7 @@ pub async fn terraform_init(
             status_handler.set_status(status);
             status_handler.set_event_duration();
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             Err(anyhow!("Error running terraform init: {}", e))
         }
     }
@@ -243,7 +243,7 @@ pub async fn terraform_validate(
             status_handler.set_event_duration();
             status_handler.set_error_text(error_text);
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             status_handler.set_error_text("".to_string());
             Err(anyhow!("Error running terraform validate: {}", e))
         }
@@ -293,7 +293,7 @@ pub async fn terraform_plan(
             status_handler.set_event_duration();
             status_handler.set_error_text(error_text);
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             status_handler.set_error_text("".to_string());
             Err(anyhow!("Error running terraform plan: {}", e))
         }
@@ -433,7 +433,7 @@ pub async fn terraform_show(
             status_handler.set_event_duration();
             status_handler.set_error_text(error_text);
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             status_handler.set_error_text("".to_string());
             Err(anyhow!("Error running terraform show: {}", e))
         }
@@ -513,7 +513,7 @@ pub async fn terraform_apply_destroy<'a>(
                 status_handler.set_deleted(true);
             }
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             Ok(())
         }
         Err(e) => {
@@ -524,7 +524,7 @@ pub async fn terraform_apply_destroy<'a>(
             status_handler.set_event_duration();
             status_handler.set_error_text(error_text);
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
             status_handler.set_error_text("".to_string());
             Err(anyhow!("Error running terraform {}: {}", cmd, e))
         }
@@ -576,7 +576,7 @@ pub async fn terraform_output(
 
             status_handler.set_status("successful".to_string());
             status_handler.set_output(output);
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
         }
         Err(e) => {
             println!("Error: {:?}", e);
@@ -586,7 +586,7 @@ pub async fn terraform_output(
             status_handler.set_event_duration();
             status_handler.set_last_event_epoch(); // Reset the event duration timer for the next event
             status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await;
+            status_handler.send_deployment(handler).await?;
         }
     }
 


### PR DESCRIPTION
This pull request introduces admission webhook support for validating InfraWeave custom resources in Kubernetes, improves error handling and modularity in deployment logic, and enhances the Helm chart to deploy both the operator and the admission controller with proper RBAC. It also adds integration tests for the webhook and updates dependencies to support the new features.

**Admission Webhook and Kubernetes Integration:**

* Adds an annotation (`infraweave.io/validating-webhook: "enabled"`) to the CRD template to enable webhook validation for custom resources.
* Extends the Helm chart to deploy a new `infraweave-admission-controller` Deployment, Service, ServiceAccount, and RBAC resources for the admission webhook, including TLS and health probes. [[1]](diffhunk://#diff-0091acc4a7ae708a711c2a4bafdcfc9cf1cc81f05e362cc92f59310c1c6f54b9R1-R46) [[2]](diffhunk://#diff-0091acc4a7ae708a711c2a4bafdcfc9cf1cc81f05e362cc92f59310c1c6f54b9R66-R199) [[3]](diffhunk://#diff-0db6ff43342319c8e24a2b50cab155ec8ff796656018677aad5dd5203046cf05R1-R19) [[4]](diffhunk://#diff-826f726e52d3776dc033b43b82416c2c084771de857ab510349dbbb37a5ddcdcR7-R12) [[5]](diffhunk://#diff-826f726e52d3776dc033b43b82416c2c084771de857ab510349dbbb37a5ddcdcR26-R34) [[6]](diffhunk://#diff-826f726e52d3776dc033b43b82416c2c084771de857ab510349dbbb37a5ddcdcR46-R58)
* Adds Helm template helpers for consistent naming and labeling across resources.

**Rust Backend Improvements:**

* Refactors deployment claim logic by splitting claim validation/preparation into a new `validate_and_prepare_claim` function, improving modularity and testability. [[1]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L49-R59) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R250-R272) [[3]](diffhunk://#diff-a0eea96a63345b5c7765c2ebdd9a0aede0aefbcf0ac3433b72026f6dc084f998R30)
* Improves error handling in `DeploymentStatusHandler::send_deployment` and related async functions, returning `Result` types and logging errors instead of panicking. [[1]](diffhunk://#diff-8eb7c47b8919d04b64ddd4341bcf6b112be128c13755d29101feeafc6a22f88bL226-R229) [[2]](diffhunk://#diff-8eb7c47b8919d04b64ddd4341bcf6b112be128c13755d29101feeafc6a22f88bL259-R263) [[3]](diffhunk://#diff-8eb7c47b8919d04b64ddd4341bcf6b112be128c13755d29101feeafc6a22f88bL271-R280) [[4]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L481-R506) [[5]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L490-R515) [[6]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L518-R544)

**Testing and Dependency Updates:**

* Adds an integration test for the admission webhook, verifying that valid claims are accepted.
* Updates dependencies to include `axum`, `tower`, and related crates for HTTP server and testing support in both the operator and integration tests. [[1]](diffhunk://#diff-ca620c1799a0fbfe846664793344b0d95a4f906636d2fbf307bff69f6ec81849R34-R35) [[2]](diffhunk://#diff-fa2e3014b632401a214e3fd555ac30a556df7ca84e01192da5344c8fc8b34b57R24-R28) [[3]](diffhunk://#diff-fa2e3014b632401a214e3fd555ac30a556df7ca84e01192da5344c8fc8b34b57R37)

These changes collectively enable secure, automated validation of custom resources via Kubernetes admission webhooks, improve code maintainability, and ensure robust testing and deployment of the new features.