### PR TITLE
fix: add support for null values in deployment

### DIFF
--- a/integration-tests/claims/test-nullable-claim.yaml
+++ b/integration-tests/claims/test-nullable-claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: infraweave.io/v1
+kind: TestNullable
+metadata:
+  name: test-nullable-instance
+spec:
+  region: us-west-2
+  moduleVersion: 0.1.0-dev
+  reference: https://github.com/test/test-nullable-claim.yaml
+  variables:
+    anotherVar: "required-value"
+    myVar: null

--- a/integration-tests/modules/test-nullable-with-default/.terraform.lock.hcl
+++ b/integration-tests/modules/test-nullable-with-default/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.81.0"
+  hashes = [
+    "h1:YoOBDt9gdoivbUh1iGoZNqRBUdBO+PBAxpSZFeTLLYE=",
+    "zh:05534adf6f02d6ec26dbeb37a4d2b6edb63f12dc9ab5cc05ab89329fcd793194",
+    "zh:1d224056866abc4c8f893d55bc6493b73688126fbeaf017ecfbcf5d2f16649c4",
+    "zh:486d28a0a4af2ea23964a8e9087d66e8d794e3438976633b8554684a9237499d",
+    "zh:4bc17c2e93034099b64eb94eaea31b48888b6abdf170e26cf0f6ea734926084c",
+    "zh:5c48c8e82fa8c410499eaa5980c0ebcf6a42360742dfd695393eb9b0bffd4232",
+    "zh:60c387caa94d67e0b768f5874abbd103638c4c9b14073b6cd121018efdfc77bc",
+    "zh:72ddd5e5e07aac1c1c54659df238e6490aac3abbd2e4f13ccf7a9d877c2e2d0f",
+    "zh:8b03d7c4e23a51c9d323f24784d6bfd044f03e6e512df8d458abc97c943a3d3e",
+    "zh:93b6a3c3299fc67d349f8ab80a9b6b65e0e9f3a7e7ea3da0cd87e3ca3b48137b",
+    "zh:9982fc3885797ee97aa45ac7eba0fe6870220748bfa3091141ff513dd7583809",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b7d60f8527dbffe11c83a05b63459d18fda921616242246a73cf3044b8732bcf",
+    "zh:be7a57524298df3c377cdd676e691500277a423ac50f7b33dd02b7d6f4e924fd",
+    "zh:c6ae0b1510804c705aab99659f228bdbafa663fa72ace50c811c0b9220c7dafb",
+    "zh:cdf524a269b4aeb5b1f081d91f54bae967ad50d9c392073a0db1602166a48dff",
+  ]
+}

--- a/integration-tests/modules/test-nullable-with-default/main.tf
+++ b/integration-tests/modules/test-nullable-with-default/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {}
+
+resource "aws_s3_bucket" "example" {
+  bucket = var.another_var
+
+  tags = {
+    MyVar = var.my_var == null ? "was-null" : var.my_var
+  }
+}

--- a/integration-tests/modules/test-nullable-with-default/module.yaml
+++ b/integration-tests/modules/test-nullable-with-default/module.yaml
@@ -1,0 +1,11 @@
+apiVersion: infraweave.io/v1
+kind: Module
+metadata:
+  name: testnullable # The name of the module you define
+spec:
+  moduleName: TestNullable # metadata.name cannot have any uppercase, which is why we need this
+  reference: https://github.com/infraweave-io/test-nullable-with-default
+  cpu: "1024"
+  memory: "4096"
+  description: |
+    Test module to verify that nullable variables with defaults can be explicitly set to null.

--- a/integration-tests/modules/test-nullable-with-default/variables.tf
+++ b/integration-tests/modules/test-nullable-with-default/variables.tf
@@ -1,0 +1,12 @@
+variable "my_var" {
+  type     = string
+  default  = "standard"
+  nullable = true
+  description = "This is a nullable variable with a default value of 'standard', but can be set to null"
+}
+
+variable "another_var" {
+  type     = string
+  nullable = false
+  description = "A required non-nullable variable"
+}

--- a/utils/src/json.rs
+++ b/utils/src/json.rs
@@ -132,6 +132,45 @@ mod tests {
     }
 
     #[test]
+    fn test_convert_first_level_keys_to_snake_case_preserves_null() {
+        // Test that null values are preserved when converting keys to snake_case
+        let generated_variable_collection = convert_first_level_keys_to_snake_case(&json!({
+            "myVar": null,
+            "anotherVar": "some-value",
+            "thirdVar": null,
+        }));
+
+        let expected_variable_collection = json!({
+            "my_var": null,
+            "another_var": "some-value",
+            "third_var": null,
+        });
+
+        assert_eq!(
+            serde_json::to_string_pretty(&sorted_json(&generated_variable_collection)).unwrap(),
+            serde_json::to_string_pretty(&sorted_json(&expected_variable_collection)).unwrap()
+        );
+
+        // Explicitly verify null values are present and actually null
+        let result_obj = generated_variable_collection.as_object().unwrap();
+        assert!(result_obj.get("my_var").is_some(), "my_var should exist");
+        assert_eq!(
+            result_obj.get("my_var").unwrap(),
+            &Value::Null,
+            "my_var should be null"
+        );
+        assert!(
+            result_obj.get("third_var").is_some(),
+            "third_var should exist"
+        );
+        assert_eq!(
+            result_obj.get("third_var").unwrap(),
+            &Value::Null,
+            "third_var should be null"
+        );
+    }
+
+    #[test]
     fn test_flatten_and_convert_first_level_keys_to_snake_case() {
         let generated_variable_collection = flatten_and_convert_first_level_keys_to_snake_case(
             &json!({


### PR DESCRIPTION
This pull request addresses the handling of nullable variables in modules, specifically ensuring that variables marked as nullable can be explicitly set to `null` (even if they have a default value), and that non-nullable variables cannot be set to `null`. It introduces new integration and unit tests to verify this behavior, and updates the variable validation logic to correctly allow `null` values for nullable variables. Additionally, it ensures that JSON key conversion preserves `null` values.

**Validation logic improvements:**

* Updated the `verify_variable_existence_and_type` function to allow variables explicitly set to `null` if the module variable is marked as nullable, instead of treating this as a type mismatch.

**Testing and verification:**

* Added integration tests to verify that a nullable variable with a default value can be set to `null` via a claim, and that the deployment correctly reflects this. (`integration-tests/tests/infra.rs`, `integration-tests/claims/test-nullable-claim.yaml`, `integration-tests/modules/test-nullable-with-default/*`) [[1]](diffhunk://#diff-3c1b043c8b2109fa53325fba609bb184b48620608b1365aed188b16344edde3fR210-R291) [[2]](diffhunk://#diff-a5643f657c85cd00f5ddc66245cf8d7d686b722231d6b03653a44e44642206fbR1-R11) [[3]](diffhunk://#diff-1c96f24d584307f34abac2d1af0a78c680f701518bfbc3057dd17a7eab49bbdfR1-R18) [[4]](diffhunk://#diff-f497003f9a8d750e91a638951a8f9ce5ef2174e2c88fddab2a4331cca1cdd4afR1-R11) [[5]](diffhunk://#diff-084b2c178d3228c910f1bcf6c5d5163c8a0acff2c65f9598cf72369681318437R1-R12)
* Added unit tests to ensure that setting a nullable variable with a default to `null` is accepted, while setting a non-nullable variable to `null` is rejected. (`utils/src/variables.rs`)

**JSON processing:**

* Added a test to confirm that converting first-level JSON keys to snake_case preserves `null` values, ensuring data integrity during transformations. (`utils/src/json.rs`)