### PR TITLE
fix: add git-managed deployment deletion warning

### DIFF
--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -69,6 +69,7 @@ pub struct Deployment {
     pub environment: String,
     pub epoch: u128,
     pub timestamp: String,
+    pub reference: String,
 }
 
 /// Main application state
@@ -784,6 +785,7 @@ impl App {
                     environment: d.environment,
                     epoch: d.epoch,
                     timestamp,
+                    reference: d.reference,
                 }
             })
             .collect();

--- a/cli/src/tui/events/main_handler.rs
+++ b/cli/src/tui/events/main_handler.rs
@@ -53,20 +53,50 @@ impl MainHandler {
                         let filtered_deployments = app.get_filtered_deployments();
                         if app.selected_index < filtered_deployments.len() {
                             let deployment = &filtered_deployments[app.selected_index];
-                            let message = format!(
-                                "⚠️  WARNING: Are you sure you want to DESTROY this deployment?\n\n\
-                                Deployment ID: {}\n\
-                                Module: {} ({})\n\
-                                Environment: {}\n\
-                                Status: {}\n\n\
-                                This action cannot be undone!\n\
-                                Press 'y' to confirm or 'n' to cancel.",
-                                deployment.deployment_id,
-                                deployment.module,
-                                deployment.module_version,
-                                deployment.environment,
-                                deployment.status
-                            );
+
+                            // Check if this deployment is managed by GitHub (quick check)
+                            let is_github_managed = !deployment.reference.is_empty()
+                                && deployment.reference.contains("github");
+
+                            let message = if is_github_managed {
+                                format!(
+                                    "🚨 IMPORTANT WARNING: GITHUB-MANAGED DEPLOYMENT 🚨\n\n\
+                                    ⚠️  This deployment's lifecycle is managed in Git!\n\
+                                        Deleting it here may cause inconsistencies!\n\n\
+                                    Deployment ID: {}\n\
+                                    Module: {} ({})\n\
+                                    Environment: {}\n\
+                                    Status: {}\n\
+                                    Managed in: {}\n\n\
+                                    🔴 DISCOURAGED: The deployment will also the handled\n\
+                                    by your GitOps workflow if the manifest still exists in Git.\n\n\
+                                    Instead, remove the deployment from your Git repository\n\
+                                    and let your GitOps process handle the deletion.\n\n\
+                                    Are you ABSOLUTELY SURE you want to proceed?\n\
+                                    Press 'y' to confirm or 'n' to cancel.",
+                                    deployment.deployment_id,
+                                    deployment.module,
+                                    deployment.module_version,
+                                    deployment.environment,
+                                    deployment.status,
+                                    deployment.reference
+                                )
+                            } else {
+                                format!(
+                                    "⚠️  WARNING: Are you sure you want to DESTROY this deployment?\n\n\
+                                    Deployment ID: {}\n\
+                                    Module: {} ({})\n\
+                                    Environment: {}\n\
+                                    Status: {}\n\n\
+                                    This action cannot be undone!\n\
+                                    Press 'y' to confirm or 'n' to cancel.",
+                                    deployment.deployment_id,
+                                    deployment.module,
+                                    deployment.module_version,
+                                    deployment.environment,
+                                    deployment.status
+                                )
+                            };
 
                             // Update modal_state directly
                             app.modal_state.show_confirmation(


### PR DESCRIPTION
This pull request enhances the deployment deletion workflow in the TUI by adding a new `reference` field to the `Deployment` struct and introducing a warning for GitHub-managed deployments. Now, when attempting to delete a deployment that is managed by GitHub (as indicated by the `reference` field), users receive a clear warning about potential inconsistencies and are advised to use their GitOps workflow for deletion instead.

**Deployment data model enhancement:**

* Added a new `reference` field to the `Deployment` struct in `app.rs` to store information about the source or manager of the deployment, such as a GitHub reference.
* Updated the mapping logic in `App` to populate the new `reference` field from deployment data.

**User experience improvements for deletion:**

* Modified the confirmation prompt in `main_handler.rs` to detect if a deployment is GitHub-managed (by checking the `reference` field) and display a detailed warning message discouraging direct deletion, guiding users to use their GitOps workflow instead. [[1]](diffhunk://#diff-b816cb8d01fdb91e484e7d20bf720dc35e34c824ec92cc98e02c494e52592dc1L56-R85) [[2]](diffhunk://#diff-b816cb8d01fdb91e484e7d20bf720dc35e34c824ec92cc98e02c494e52592dc1L69-R99)