### PR TITLE
fix: add reference + oneOf in kubernetes crd schema

### DIFF
--- a/crd-templator/templates/module_crd_template.yaml
+++ b/crd-templator/templates/module_crd_template.yaml
@@ -29,6 +29,8 @@ spec:
                   type: "string"
                 region:
                   type: "string"
+                reference:
+                  type: "string"
                 variables:
                   type: "object"
                   x-kubernetes-preserve-unknown-fields: true
@@ -53,6 +55,9 @@ spec:
               required:
                 - "region"
                 - "variables"
+              oneOf:
+                - required: ["moduleVersion"]
+                - required: ["stackVersion"]
             status:
               type: object
               properties:


### PR DESCRIPTION
This pull request updates the `module_crd_template.yaml` file to enhance the CRD (Custom Resource Definition) schema for modules. The changes introduce a new `reference` field and add validation logic to ensure either `moduleVersion` or `stackVersion` is specified.

Schema improvements:

* Added a new `reference` field of type `string` to the module specification, allowing modules to reference external resources or identifiers.
* Introduced a `oneOf` validation rule requiring that either `moduleVersion` or `stackVersion` must be provided, improving data integrity and schema enforcement.