### PR TITLE
fix: use any namespace in helm chart

### DIFF
--- a/operator/e2e-tests/test_aws_eks.sh
+++ b/operator/e2e-tests/test_aws_eks.sh
@@ -14,6 +14,8 @@ kind create cluster --name=$CLUSTER_NAME
 kind load docker-image infraweave-operator:latest --name $CLUSTER_NAME
 
 helm upgrade -i infraweave-operator ./operator/infraweave-helm \
+  -n infraweave \
+  --create-namespace \
   --set aws.accessKeyId=$AWS_ACCESS_KEY_ID \
   --set aws.secretAccessKey=$AWS_SECRET_ACCESS_KEY \
   --set aws.sessionToken=$AWS_SESSION_TOKEN \

--- a/operator/infraweave-helm/templates/rbac.yaml
+++ b/operator/infraweave-helm/templates/rbac.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infraweave-service-account
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infraweave-admission-controller-service-account
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -38,7 +38,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: infraweave-service-account
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: infraweave-cluster-role
@@ -51,7 +51,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: infraweave-admission-controller-service-account
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: infraweave-admission-controller-cluster-role


### PR DESCRIPTION
This pull request improves the Helm deployment of the Infraweave Operator by ensuring that Kubernetes resources are created in the correct namespace, making the deployment more flexible and robust. The main changes are focused on updating namespace references in the Helm chart and test scripts.

Helm chart improvements for namespace handling:

* Updated all `ServiceAccount` resources in `rbac.yaml` to use the Helm release namespace (`{{ .Release.Namespace }}`) instead of hardcoding `default`.
* Updated `RoleBinding` and `ClusterRoleBinding` subjects in `rbac.yaml` to use the Helm release namespace for `ServiceAccount` references. [[1]](diffhunk://#diff-826f726e52d3776dc033b43b82416c2c084771de857ab510349dbbb37a5ddcdcL41-R41) [[2]](diffhunk://#diff-826f726e52d3776dc033b43b82416c2c084771de857ab510349dbbb37a5ddcdcL54-R54)

Test script enhancement:

* Modified the E2E test script (`test_aws_eks.sh`) to explicitly set the namespace to `infraweave` and create it during Helm installation, ensuring resources are deployed in the intended namespace.