### PR TITLE
fix: remove user-info in logs

### DIFF
--- a/env_aws/src/api.rs
+++ b/env_aws/src/api.rs
@@ -36,8 +36,6 @@ pub async fn get_user_id() -> Result<String, anyhow::Error> {
         .arn()
         .ok_or_else(|| anyhow::anyhow!("User ID not found"))?;
 
-    info!("User ID: {}", user_id);
-
     Ok(user_id.to_string())
 }
 

--- a/webserver-openapi/src/auth.rs
+++ b/webserver-openapi/src/auth.rs
@@ -373,7 +373,6 @@ fn get_user_identifier(claims: &Claims) -> Option<String> {
     for key in &["oid", "user_id", "username", "email", "upn", "appid"] {
         if let Some(value) = claims.custom.get(*key) {
             if let Some(user_id) = value.as_str() {
-                debug!("Using {} as user identifier: {}", key, user_id);
                 return Some(user_id.to_string());
             }
         }
@@ -529,8 +528,7 @@ pub async fn project_access_middleware(
 
     // Log successful authentication and project access
     log::info!(
-        "Authenticated access granted - User: {}, Project: {}, Path: {}, Accessible Projects: {:?}",
-        user_identifier,
+        "Authenticated access granted - Project: {}, Path: {}, Accessible Projects: {:?}",
         project_id,
         uri_path_str,
         accessible_projects


### PR DESCRIPTION
This pull request primarily removes unnecessary logging of user identifiers from authentication-related code. These changes help reduce potential exposure of sensitive information in logs and streamline log output.

**Logging changes to reduce sensitive information:**

* Removed logging of the user ID in the `get_user_id` function in `env_aws/src/api.rs`, eliminating unnecessary exposure of user identifiers in logs.
* Removed debug logging of user identifiers in the `get_user_identifier` function in `webserver-openapi/src/auth.rs` to avoid logging potentially sensitive data.
* Modified the info log in `project_access_middleware` in `webserver-openapi/src/auth.rs` to exclude the user identifier, logging only project and path information instead.