### PR TITLE
fix: add workflow permissions

### DIFF
--- a/.github/workflows/docker-cli.yml
+++ b/.github/workflows/docker-cli.yml
@@ -5,8 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push-image1:
+  build-and-push-image:
     uses: ./.github/workflows/build-and-push-docker-template.yml
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/docker-gitops-aws.yml
+++ b/.github/workflows/docker-gitops-aws.yml
@@ -5,8 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push-image1:
+  build-and-push-image:
     uses: ./.github/workflows/build-and-push-docker-template.yml
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/docker-operator.yml
+++ b/.github/workflows/docker-operator.yml
@@ -5,8 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push-image1:
+  build-and-push-image:
     uses: ./.github/workflows/build-and-push-docker-template.yml
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/docker-reconciler-aws.yml
+++ b/.github/workflows/docker-reconciler-aws.yml
@@ -5,8 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push-image1:
+  build-and-push-image:
     uses: ./.github/workflows/build-and-push-docker-template.yml
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/docker-runner.yml
+++ b/.github/workflows/docker-runner.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push-image-terraform:
     uses: ./.github/workflows/build-and-push-docker-template.yml

--- a/.github/workflows/docker-webserver-openapi.yml
+++ b/.github/workflows/docker-webserver-openapi.yml
@@ -5,8 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push-image1:
+  build-and-push-image:
     uses: ./.github/workflows/build-and-push-docker-template.yml
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+  id-token: write  # Required for publishing to PyPI with trusted publishing
+
 jobs:
   build-and-publish:
     name: Build and Publish ${{ matrix.name }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve security and standardize job naming. The main changes include adding explicit permissions to workflows and renaming jobs for consistency.

**Security improvements:**

* Added `permissions: contents: read` to all Docker-related workflow files and the tests workflow, limiting token permissions to read-only for repository contents. (`.github/workflows/docker-cli.yml`, [[1]](diffhunk://#diff-dbf61abd869f700a90ee4c7a759edd3f3bb52a5d5de14586357511f06c092aaeR8-R12); `.github/workflows/docker-gitops-aws.yml`, [[2]](diffhunk://#diff-adcd4bcc8a646c057d329c08cceda6e524899cfd393119576aed7c59514b0172R8-R12); `.github/workflows/docker-operator.yml`, [[3]](diffhunk://#diff-d04312ea06b4ca24e4ca5cd4d865fc4b3ba09c0ae218c8fa432e2a180f54fc94R8-R12); `.github/workflows/docker-reconciler-aws.yml`, [[4]](diffhunk://#diff-5ac101e5cd78d361098996efbbd72af02617421183d497e7d0960db2def6fe4bR8-R12); `.github/workflows/docker-runner.yml`, [[5]](diffhunk://#diff-9edca618eb421d563563a49b062f144eedaf2e9bd5cc56c92310052c6ae14b61R8-R10); `.github/workflows/docker-webserver-openapi.yml`, [[6]](diffhunk://#diff-2bcdae0dc8a3c9fa74bc00fff2445b54b7857ca61a13aca7046537b7482e5706R8-R12); `.github/workflows/pypi.yml`, [[7]](diffhunk://#diff-1baea138c19b06c7531655c5e977dbbcca5bd9147709625e2ee40984905502c5R8-R11); `.github/workflows/tests.yaml`, [[8]](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R11-R13)
* Added `id-token: write` permission to `.github/workflows/pypi.yml` to support trusted publishing to PyPI.

**Workflow standardization:**

* Renamed Docker workflow jobs from `build-and-push-image1` to `build-and-push-image` for consistency across files. (`.github/workflows/docker-cli.yml`, [[1]](diffhunk://#diff-dbf61abd869f700a90ee4c7a759edd3f3bb52a5d5de14586357511f06c092aaeR8-R12); `.github/workflows/docker-gitops-aws.yml`, [[2]](diffhunk://#diff-adcd4bcc8a646c057d329c08cceda6e524899cfd393119576aed7c59514b0172R8-R12); `.github/workflows/docker-operator.yml`, [[3]](diffhunk://#diff-d04312ea06b4ca24e4ca5cd4d865fc4b3ba09c0ae218c8fa432e2a180f54fc94R8-R12); `.github/workflows/docker-reconciler-aws.yml`, [[4]](diffhunk://#diff-5ac101e5cd78d361098996efbbd72af02617421183d497e7d0960db2def6fe4bR8-R12); `.github/workflows/docker-webserver-openapi.yml`, [[5]](diffhunk://#diff-2bcdae0dc8a3c9fa74bc00fff2445b54b7857ca61a13aca7046537b7482e5706R8-R12)