### PR TITLE
fix: add region+project-id to tui

### DIFF
--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -89,6 +89,8 @@ pub struct App {
     pub is_loading: bool,
     pub loading_message: String,
     pub pending_action: PendingAction,
+    pub project_id: String,
+    pub region: String,
 
     // ==================== BACKGROUND TASKS ====================
     pub background_sender:
@@ -172,6 +174,16 @@ impl App {
         let search_state = SearchState::new();
         let claim_builder_state = ClaimBuilderState::new();
 
+        // Get project ID and region from OnceCell globals
+        let project_id = env_common::logic::PROJECT_ID
+            .get()
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let region = env_common::logic::REGION
+            .get()
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+
         Self {
             // Core app state
             should_quit: false,
@@ -179,6 +191,8 @@ impl App {
             is_loading: false,
             loading_message: String::new(),
             pending_action: PendingAction::LoadModules,
+            project_id,
+            region,
 
             // Background tasks
             background_sender: None,

--- a/cli/src/tui/renderers/common.rs
+++ b/cli/src/tui/renderers/common.rs
@@ -19,7 +19,7 @@ pub fn render_loading(frame: &mut Frame, area: Rect, app: &App) {
 
 /// Render navigation menu bar
 pub fn render_navigation(frame: &mut Frame, area: Rect, app: &App) {
-    let widget = NavigationBar::new(&app.current_view);
+    let widget = NavigationBar::new(&app.current_view, &app.project_id, &app.region);
     widget.render(frame, area);
 }
 


### PR DESCRIPTION
This pull request enhances the TUI navigation bar by displaying the current project ID and region, making it easier for users to see which project and region they are working in. 

**Project metadata integration:**

* Added `project_id` and `region` fields to the `App` struct, initializing them from (`PROJECT_ID` and `REGION`). [[1]](diffhunk://#diff-0f855151e2417aa069969c0934270e54e5454e0e5f8d6961fcb59a8161b0c661R92-R93) [[2]](diffhunk://#diff-0f855151e2417aa069969c0934270e54e5454e0e5f8d6961fcb59a8161b0c661R177-R195)

**Navigation bar improvements:**

* Updated the `NavigationBar` widget to accept and store `project_id` and `region` as parameters, and adjusted its constructor accordingly.
* Modified the navigation bar renderer to display the project ID and region on the right side, including logic for dynamic spacing and styling.
* Updated the call to `NavigationBar::new` in the common renderer to pass the new metadata fields.

**Code structure updates:**

* Adjusted local variables in the navigation bar renderer to accommodate the new project info display logic.