### PR TITLE
fix: add job-id verification-check

### DIFF
--- a/defs/src/deployment.rs
+++ b/defs/src/deployment.rs
@@ -91,6 +91,13 @@ pub struct DeploymentResp {
 }
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Deserialize, Clone, Debug, Serialize)]
+pub struct JobStatus {
+    pub job_id: String,
+    pub is_running: bool,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Dependency {
     pub project_id: String,

--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -19,8 +19,8 @@ mod stack;
 pub use api::GenericFunctionResponse;
 pub use deployment::{
     get_deployment_identifier, Dependency, Dependent, DeploymentManifest, DeploymentResp,
-    DeploymentSpec, DriftDetection, Metadata as DeploymentMetadata, ProjectData, Webhook,
-    DEFAULT_DRIFT_DETECTION_INTERVAL,
+    DeploymentSpec, DriftDetection, JobStatus, Metadata as DeploymentMetadata, ProjectData,
+    Webhook, DEFAULT_DRIFT_DETECTION_INTERVAL,
 };
 pub use environment::EnvironmentResp;
 pub use errors::CloudHandlerError;

--- a/defs/src/provider.rs
+++ b/defs/src/provider.rs
@@ -1,8 +1,8 @@
 use std::{future::Future, pin::Pin};
 
 use crate::{
-    Dependent, DeploymentResp, EventData, GenericFunctionResponse, InfraChangeRecord, LogData,
-    ModuleResp, NotificationData, PolicyResp, ProjectData,
+    deployment::JobStatus, Dependent, DeploymentResp, EventData, GenericFunctionResponse,
+    InfraChangeRecord, LogData, ModuleResp, NotificationData, PolicyResp, ProjectData,
 };
 
 use async_trait::async_trait;
@@ -116,6 +116,7 @@ pub trait CloudProvider: Send + Sync {
         environment: &str,
         include_deleted: bool,
     ) -> Result<Option<DeploymentResp>, anyhow::Error>;
+    async fn get_job_status(&self, job_id: &str) -> Result<Option<JobStatus>, anyhow::Error>;
     async fn get_deployments_using_module(
         &self,
         module: &str,

--- a/env_aws/src/api.rs
+++ b/env_aws/src/api.rs
@@ -304,6 +304,15 @@ pub fn get_generate_presigned_url_query(key: &str, bucket: &str) -> Value {
     })
 }
 
+pub fn get_job_status_query(job_id: &str) -> Value {
+    json!({
+        "event": "get_job_status",
+        "data": {
+            "job_id": job_id
+        }
+    })
+}
+
 pub fn get_all_deployments_query(project_id: &str, region: &str, environment: &str) -> Value {
     json!({
         "IndexName": "DeletedIndex",

--- a/env_aws/src/job_id.rs
+++ b/env_aws/src/job_id.rs
@@ -11,7 +11,7 @@ use std::env;
 
 pub async fn get_current_job_id() -> Result<String, anyhow::Error> {
     if std::env::var("TEST_MODE").is_ok() {
-        return Ok("test-job-id".to_string());
+        return Ok("running-test-job-id".to_string());
     };
 
     let metadata_uri = env::var("ECS_CONTAINER_METADATA_URI_V4")

--- a/env_aws/src/lib.rs
+++ b/env_aws/src/lib.rs
@@ -25,6 +25,7 @@ pub use api::{
     get_deployments_using_module_query,
     get_events_query,
     get_generate_presigned_url_query,
+    get_job_status_query,
     get_latest_module_version_query,
     get_latest_stack_version_query,
     get_module_version_query,

--- a/env_aws/src/provider.rs
+++ b/env_aws/src/provider.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use env_defs::{
     CloudHandlerError, CloudProvider, Dependent, DeploymentResp, EventData,
-    GenericFunctionResponse, InfraChangeRecord, ModuleResp, PolicyResp, ProjectData,
+    GenericFunctionResponse, InfraChangeRecord, JobStatus, ModuleResp, PolicyResp, ProjectData,
 };
 use env_utils::{
     _get_change_records, _get_dependents, _get_deployment, _get_deployment_and_dependents,
@@ -146,6 +146,22 @@ impl CloudProvider for AwsCloudProvider {
         track: &str,
     ) -> Result<Option<ModuleResp>, anyhow::Error> {
         _get_module_optional(self, crate::get_latest_stack_version_query(stack, track)).await
+    }
+    async fn get_job_status(&self, job_id: &str) -> Result<Option<JobStatus>, anyhow::Error> {
+        match crate::run_function(
+            &self.function_endpoint,
+            &crate::get_job_status_query(job_id),
+            &self.project_id,
+            &self.region,
+        )
+        .await
+        {
+            Ok(response) => {
+                let job_status: JobStatus = serde_json::from_value(response.payload)?;
+                Ok(Some(job_status))
+            }
+            Err(e) => Err(e.into()),
+        }
     }
     async fn generate_presigned_url(
         &self,

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -176,6 +176,15 @@ pub fn get_generate_presigned_url_query(key: &str, bucket: &str) -> Value {
     })
 }
 
+pub fn get_job_status_query(job_id: &str) -> Value {
+    json!({
+        "event": "get_job_status",
+        "data": {
+            "job_id": job_id
+        }
+    })
+}
+
 pub fn get_all_latest_modules_query(track: &str) -> Value {
     _get_all_latest_modules_query("LATEST_MODULE", track)
 }

--- a/env_azure/src/lib.rs
+++ b/env_azure/src/lib.rs
@@ -25,6 +25,7 @@ pub use api::{
     get_deployments_using_module_query,
     get_events_query,
     get_generate_presigned_url_query,
+    get_job_status_query,
     get_latest_module_version_query,
     get_latest_stack_version_query,
     get_module_version_query,

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -6,8 +6,8 @@ use env_aws::AwsCloudProvider;
 use env_azure::AzureCloudProvider;
 use env_defs::{
     CloudProvider, CloudProviderCommon, Dependent, DeploymentResp, EventData,
-    GenericFunctionResponse, InfraChangeRecord, LogData, ModuleResp, NotificationData, PolicyResp,
-    ProjectData,
+    GenericFunctionResponse, InfraChangeRecord, JobStatus, LogData, ModuleResp, NotificationData,
+    PolicyResp, ProjectData,
 };
 use serde_json::Value;
 
@@ -312,6 +312,9 @@ impl CloudProvider for GenericCloudHandler {
         self.provider
             .get_deployment(deployment_id, environment, include_deleted)
             .await
+    }
+    async fn get_job_status(&self, job_id: &str) -> Result<Option<JobStatus>, anyhow::Error> {
+        self.provider.get_job_status(job_id).await
     }
     async fn get_deployments_using_module(
         &self,

--- a/env_common/src/interface/no_cloud_provider.rs
+++ b/env_common/src/interface/no_cloud_provider.rs
@@ -1,7 +1,7 @@
 use env_defs::{
     CloudProvider, CloudProviderCommon, Dependent, DeploymentResp, EventData,
-    GenericFunctionResponse, InfraChangeRecord, LogData, ModuleResp, NotificationData, PolicyResp,
-    ProjectData,
+    GenericFunctionResponse, InfraChangeRecord, JobStatus, LogData, ModuleResp, NotificationData,
+    PolicyResp, ProjectData,
 };
 use serde_json::Value;
 use std::{future::Future, pin::Pin};
@@ -137,6 +137,10 @@ impl CloudProvider for NoCloudProvider {
         _stack: &str,
         _track: &str,
     ) -> Result<Option<ModuleResp>, anyhow::Error> {
+        Ok(None)
+    }
+
+    async fn get_job_status(&self, _job_id: &str) -> Result<Option<JobStatus>, anyhow::Error> {
         Ok(None)
     }
 

--- a/integration-tests/azure-function-code/function_app.py
+++ b/integration-tests/azure-function-code/function_app.py
@@ -64,6 +64,8 @@ def handler(req: func.HttpRequest) -> func.HttpResponse:
             return read_logs(req)
         elif event == 'generate_presigned_url':
             return generate_presigned_url(req)
+        elif event == 'get_job_status':
+            return get_job_status(req)
         elif event == 'transact_write':
             return transact_write(req)
         elif event == 'publish_notification':
@@ -160,9 +162,19 @@ def generate_presigned_url(req: func.HttpRequest) -> func.HttpResponse:
         mimetype="application/json"
     )
 
+def get_job_status(req: func.HttpRequest) -> func.HttpResponse:
+    req_body = req.get_json()
+    payload = req_body.get('data')
+    job_id = payload.get('job_id')
+    # For testing purposes, we can simulate different scenarios:
+    # - If job_id starts with 'running-', return is_running=True
+    # - Otherwise, return is_running=False
+    is_running = job_id.startswith('running-') if job_id else False
+    return func.HttpResponse(json.dumps({'job_id': job_id, 'is_running': is_running}), status_code=200, mimetype="application/json")
+
 def start_runner(req: func.HttpRequest) -> func.HttpResponse:
     # TODO: Implement the ACI task start logic as another docker container
-    return func.HttpResponse(json.dumps({"result":"Would have been started", "job_id": "test-job-id"}), status_code=200)
+    return func.HttpResponse(json.dumps({"result":"Would have been started", "job_id": "running-test-job-id"}), status_code=200)
     
 def get_id(body):
     raw = f"{body['PK']}~{body['SK']}".lower()

--- a/integration-tests/lambda-code/test-api.py
+++ b/integration-tests/lambda-code/test-api.py
@@ -199,11 +199,20 @@ def generate_presigned_url(event):
     url = 'http://127.0.0.1:' + ':'.join(url.split(':')[2:]) # MinIO is running in a separate network and interfaces with lambda via 172.18.x.x and local rust app using 127.0.0.1
     return {'url': url}
 
+def get_job_status(event):
+    payload = event.get('data')
+    job_id = payload.get('job_id')
+    # For testing purposes, we can simulate different scenarios:
+    # - If job_id starts with 'running-', return is_running=True
+    # - Otherwise, return is_running=False
+    is_running = job_id.startswith('running-') if job_id else False
+    return {'job_id': job_id, 'is_running': is_running}
+
 def start_runner(event):
     # ecs = boto3.client('ecs')
     payload = event.get('data')
     
-    return {'job_id': 'test-job-id'}
+    return {'job_id': 'running-test-job-id'}
 
 processes = {
     'insert_db': insert_db,
@@ -214,6 +223,7 @@ processes = {
     'start_runner': start_runner,
     'read_logs': read_logs,
     'generate_presigned_url': generate_presigned_url,
+    'get_job_status': get_job_status,
     'publish_notification': lambda event: {'status': 'success', 'message': 'Notification published successfully'},
 }
 

--- a/integration-tests/tests/runner.rs
+++ b/integration-tests/tests/runner.rs
@@ -66,7 +66,7 @@ mod runner_tests {
             println!("Job ID: {}", job_id);
             println!("Deployment ID: {}", deployment_id);
 
-            assert_eq!(job_id, "test-job-id");
+            assert_eq!(job_id, "running-test-job-id");
 
             let (deployment, dependencies) = match handler
                 .get_deployment_and_dependents(&deployment_id, &environment, false)
@@ -92,7 +92,7 @@ mod runner_tests {
                     env::set_var("TF_DYNAMODB_TABLE", "dummy-dynamodb-table");
                 }
                 "azure" => {
-                    env::set_var("CONTAINER_GROUP_NAME", "test-job-id");
+                    env::set_var("CONTAINER_GROUP_NAME", "running-test-job-id");
                     env::set_var("ACCOUNT_ID", "dummy-account-id");
                     env::set_var("STORAGE_ACCOUNT", "dummy-storage-account");
                     env::set_var("RESOURCE_GROUP_NAME", "dummy-resource-group");

--- a/integration-tests/tests/runner_oci.rs
+++ b/integration-tests/tests/runner_oci.rs
@@ -94,7 +94,7 @@ mod runner_tests {
             println!("Job ID: {}", job_id);
             println!("Deployment ID: {}", deployment_id);
 
-            assert_eq!(job_id, "test-job-id");
+            assert_eq!(job_id, "running-test-job-id");
 
             let (deployment, dependencies) = match handler
                 .get_deployment_and_dependents(&deployment_id, &environment, false)
@@ -121,7 +121,7 @@ mod runner_tests {
                     env::set_var("TF_DYNAMODB_TABLE", "dummy-dynamodb-table");
                 }
                 "azure" => {
-                    env::set_var("CONTAINER_GROUP_NAME", "test-job-id");
+                    env::set_var("CONTAINER_GROUP_NAME", "running-test-job-id");
                     env::set_var("ACCOUNT_ID", "dummy-account-id");
                     env::set_var("STORAGE_ACCOUNT", "dummy-storage-account");
                     env::set_var("RESOURCE_GROUP_NAME", "dummy-resource-group");


### PR DESCRIPTION
This pull request introduces a new mechanism for tracking and verifying the status of deployment jobs across cloud providers, ensuring that deployments are not started if a job is already running. The main changes include the addition of the `JobStatus` struct, updates to the cloud provider interfaces and implementations to support job status queries, integration of job status checks into deployment logic, and comprehensive tests to validate the new behavior.

### Job Status Tracking and API Integration

* Added a new `JobStatus` struct to `defs/src/deployment.rs` to represent job status information, and exposed it throughout the codebase (`defs/src/lib.rs`, `defs/src/provider.rs`, `env_aws/src/api.rs`, `env_aws/src/lib.rs`, `env_azure/src/api.rs`, `env_azure/src/lib.rs`). [[1]](diffhunk://#diff-4a4b233e5d4dcc00b749ac904746e8f09fe6aceaa6b660aabf9ff3034880fda6R93-R99) [[2]](diffhunk://#diff-dce60921cb288dcb0912a027091cc4fb5fd26c31685984760735db157e08ef08L22-R23) [[3]](diffhunk://#diff-89b7226cf04a3e2503474c49a8ea3a0dedd488c89f29a81bcaf25c0e14faf423L4-R5) [[4]](diffhunk://#diff-ec6cc060e90a57e823c143238cd50eb9ae461024e00c279f1b7d01d3a2695184R307-R315) [[5]](diffhunk://#diff-75c78f020a860553083f30d075517924ebae71155db1f30ba7f3688971d2b576R28) [[6]](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaR179-R187) [[7]](diffhunk://#diff-b106fc753612e3411e2ddfd01222413238c00d6bedb22d237e1292ee70bec747R28)
* Extended the `CloudProvider` trait and all provider implementations (`AwsCloudProvider`, `AzureCloudProvider`, `GenericCloudHandler`, `NoCloudProvider`) to support an asynchronous `get_job_status` method for querying job status by job ID. [[1]](diffhunk://#diff-89b7226cf04a3e2503474c49a8ea3a0dedd488c89f29a81bcaf25c0e14faf423R119) [[2]](diffhunk://#diff-b3a53a302ae9534b38dbf2b6144fce8af1ff0c6a709391ac41749f7876507dd0L4-R4) [[3]](diffhunk://#diff-b3a53a302ae9534b38dbf2b6144fce8af1ff0c6a709391ac41749f7876507dd0R150-R165) [[4]](diffhunk://#diff-e353cace0e989e1dc552e6d01e1b66dc2c20e66822d8fc401e6c03f4b1a0183bL4-R4) [[5]](diffhunk://#diff-e353cace0e989e1dc552e6d01e1b66dc2c20e66822d8fc401e6c03f4b1a0183bR126-R141) [[6]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7L9-R10) [[7]](diffhunk://#diff-b473a1fd63edfdb01e72f09169d2cb4b7bc57ca731e83e2509d6fcd79da61aa7R316-R318) [[8]](diffhunk://#diff-36a97437bb368d4b55083f1dd1514ac0e54be539dda1c98a48a19e84f026587dL3-R4) [[9]](diffhunk://#diff-36a97437bb368d4b55083f1dd1514ac0e54be539dda1c98a48a19e84f026587dR143-R146)

### Deployment Logic Enhancement

* Updated `env_common/src/logic/api_infra.rs` to check the actual running status of a deployment job via `get_job_status`, adding detailed logging and error handling to distinguish between jobs that are truly in progress and those that are not, even if the deployment status suggests otherwise. [[1]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L11-R11) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L575-R606)

### Cloud Function Support

* Added support for the `get_job_status` event in Azure and Lambda integration test functions, simulating job status responses based on job ID prefixes for testing purposes (`function_app.py`, `test-api.py`). [[1]](diffhunk://#diff-3c6f70a5246416dfe0e67c0703a1cc4d467f3cccaae569db3fbfeb1eeac08a88R67-R68) [[2]](diffhunk://#diff-3c6f70a5246416dfe0e67c0703a1cc4d467f3cccaae569db3fbfeb1eeac08a88R165-R174) [[3]](diffhunk://#diff-08647333a3f03ef481af63bc5dc0c1204803535db05a0f6ad1a6382f8dba9e56R202-R210) [[4]](diffhunk://#diff-08647333a3f03ef481af63bc5dc0c1204803535db05a0f6ad1a6382f8dba9e56R226)

### Comprehensive Testing

* Introduced a new integration test in `tests/infra.rs` that verifies deployments are blocked when a job is running and allowed when the job is not running, covering both positive and negative scenarios for job status checks. [[1]](diffhunk://#diff-3c1b043c8b2109fa53325fba609bb184b48620608b1365aed188b16344edde3fL8-R8) [[2]](diffhunk://#diff-3c1b043c8b2109fa53325fba609bb184b48620608b1365aed188b16344edde3fR292-R430)

These changes collectively ensure that deployment operations are reliably coordinated with the actual status of underlying jobs, preventing race conditions and improving robustness.