### PR TITLE
fix: replace deprecated base64 function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-ssm",
  "aws-sdk-sts",
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "env_defs",
  "env_utils",
@@ -2357,7 +2357,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.13.1",
+ "base64 0.22.1",
  "env_aws",
  "env_azure",
  "env_defs",
@@ -2428,7 +2428,7 @@ name = "env_utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "env_defs",
  "fern",
@@ -2938,7 +2938,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-ssm",
  "aws_lambda_events",
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "env_common",
  "env_defs",
@@ -3814,7 +3814,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "dirs",
  "env_aws",
@@ -5103,7 +5103,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.1",
  "axum-server",
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "crd_templator",
  "env_common",

--- a/env_aws/Cargo.toml
+++ b/env_aws/Cargo.toml
@@ -22,7 +22,7 @@ zip = "0.6.6"
 reqwest = "0.11"
 tempfile = "3.10.1"
 rand = "0.8.5"
-base64 = "0.13"
+base64 = "0.22"
 regex = "1.11.0"
 hcl-rs = "0.18.4"
 

--- a/env_common/Cargo.toml
+++ b/env_common/Cargo.toml
@@ -13,7 +13,7 @@ serde_yaml = "0.8"
 tokio = { version = "1" }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-base64 = "0.13"
+base64 = "0.22"
 hcl-rs = "0.18.4"
 regex = "1.11.0"
 once_cell = "1.20.2"

--- a/env_common/src/logic/api_change_record.rs
+++ b/env_common/src/logic/api_change_record.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use env_defs::{get_change_record_identifier, CloudProvider, InfraChangeRecord};
 use env_utils::merge_json_dicts;
 
@@ -71,7 +73,7 @@ async fn upload_plan_output_file<T: CloudProvider>(
     key: &str,
     content: &str,
 ) -> Result<String, anyhow::Error> {
-    let base64_content = base64::encode(content);
+    let base64_content = base64.encode(content);
 
     let payload = serde_json::json!({
         "event": "upload_file_base64",

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use env_defs::{
     get_module_identifier, CloudProvider, ModuleManifest, ModuleResp, ModuleVersionDiff,
     OciArtifactSet, TfLockProvider, TfVariable,
@@ -69,7 +71,7 @@ pub async fn publish_module_from_zip(
     oci_artifact_set: Option<OciArtifactSet>,
 ) -> Result<(), ModuleError> {
     // Encode the zip file content to Base64
-    let zip_base64 = base64::encode(&zip_file);
+    let zip_base64 = base64.encode(&zip_file);
 
     let tf_content = read_tf_from_zip(&zip_file).unwrap(); // Get all .tf-files concatenated into a single string
 

--- a/env_common/src/logic/api_oci_registry.rs
+++ b/env_common/src/logic/api_oci_registry.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use env_defs::ModuleResp;
 use std::collections::BTreeMap;
 
@@ -51,7 +53,7 @@ impl OCIRegistryProvider {
             "io.infraweave.module.manifest".to_string(),
             serde_json::to_string(&module)?,
         );
-        let zip_bytes = base64::decode(zip_base64)?;
+        let zip_bytes = base64.decode(zip_base64)?;
 
         let zip_layer = ImageLayer::new(
             zip_bytes.clone(),
@@ -111,7 +113,7 @@ impl OCIRegistryProvider {
         println!("Extracted module: {:?}", module);
 
         let zip_bytes = &artifact.layers[0].data;
-        let base64_zip = base64::encode(zip_bytes);
+        let base64_zip = base64.encode(zip_bytes);
         println!("Base64 zip: {}", base64_zip);
 
         Ok(module.clone())

--- a/env_common/src/logic/api_policy.rs
+++ b/env_common/src/logic/api_policy.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use std::path::Path;
 
 use env_defs::{
@@ -23,7 +25,7 @@ pub async fn publish_policy(
 
     let zip_file = env_utils::get_zip_file(Path::new(manifest_path), &policy_yaml_path).await?;
     // Encode the zip file content to Base64
-    let zip_base64 = base64::encode(&zip_file);
+    let zip_base64 = base64.encode(&zip_file);
 
     match validate_policy_schema(&manifest) {
         std::result::Result::Ok(_) => (),

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use env_defs::{
     CloudProvider, DeploymentManifest, ModuleExample, ModuleManifest, ModuleResp,
     ModuleVersionDiff, OciArtifactSet, StackManifest, TfLockProvider, TfOutput, TfRequiredProvider,
@@ -259,7 +261,7 @@ pub async fn publish_stack(
     }
 
     let full_zip = merge_zips(env_utils::ZipInput::WithFolders(zip_parts)).unwrap();
-    let zip_base64 = base64::encode(&full_zip);
+    let zip_base64 = base64.encode(&full_zip);
 
     match compare_latest_version(
         handler,

--- a/gitops/Cargo.toml
+++ b/gitops/Cargo.toml
@@ -19,7 +19,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 lambda_runtime = "0.13.0"
 aws_lambda_events = "0.16"
 futures = "0.3.31"
-base64 = "0.13"
+base64 = "0.22"
 jsonwebtoken = "9.3.1"
 hmac = "0.12"
 sha2 = "0.10"

--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -1,4 +1,5 @@
-use base64::decode;
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use chrono::{DateTime, Utc};
 use env_common::interface::GenericCloudHandler;
 use env_common::logic::{
@@ -308,7 +309,7 @@ fn get_file_content_option(
     if file.encoding != "base64" {
         return Err("Unexpected encoding".into());
     }
-    let decoded_bytes = decode(file.content.replace("\n", ""))?;
+    let decoded_bytes = base64.decode(file.content.replace("\n", ""))?;
     let content = String::from_utf8(decoded_bytes)?;
     Ok(Some(content))
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -30,6 +30,6 @@ kube-runtime = "0.96.0"
 rustls = "0.23.18"
 dirs = "4.0"
 operator = { path = "../operator" }
-base64 = "0.13"
+base64 = "0.22"
 axum = "0.8.1"
 tower = "0.5"

--- a/integration-tests/tests/utils.rs
+++ b/integration-tests/tests/utils.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use env_common::interface::{initialize_project_id_and_region, GenericCloudHandler};
 
 use env_defs::CloudProvider;
@@ -290,7 +292,7 @@ pub async fn upload_file(
 ) -> Result<(), anyhow::Error> {
     let file_content = std::fs::read(file_path)
         .map_err(|e| anyhow::anyhow!("Failed to read file {}: {}", file_path, e))?;
-    let zip_base64 = base64::encode(file_content);
+    let zip_base64 = base64.encode(file_content);
 
     let payload = serde_json::json!({
         "event": "upload_file_base64",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 fern = "0.6"
 anyhow = "1.0"
 chrono = "0.4.31"
-base64 = "0.13"
+base64 = "0.22"
 openssl = { version = "0.10.72", features = ["vendored"] }
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2.0"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -24,7 +24,7 @@ tar = "0.4"
 sha2 = "0.10"
 oci-distribution = "0.11.0"
 sigstore = "0.12.0"
-base64 = "0.21"
+base64 = "0.22"
 regorus = "0.4.0"
 
 env_defs = { path = "../defs" }

--- a/utils/src/file.rs
+++ b/utils/src/file.rs
@@ -1,4 +1,6 @@
 use anyhow::Context;
+use base64::engine::general_purpose::STANDARD as base64;
+use base64::Engine;
 use log::info;
 use std::collections::HashMap;
 use std::fs;
@@ -237,7 +239,7 @@ pub fn unzip_file(zip_path: &Path, extract_path: &Path) -> Result<(), anyhow::Er
 pub fn read_file_base64(file_path: &Path) -> Result<String, anyhow::Error> {
     let file_content = fs::read(file_path)
         .with_context(|| format!("Failed to read file at {}", file_path.display()))?;
-    let base64_content = base64::encode(&file_content);
+    let base64_content = base64.encode(&file_content);
     Ok(base64_content)
 }
 


### PR DESCRIPTION
This pull request updates the `base64` crate to version `0.22` across all Rust projects and refactors code to use the new API for encoding and decoding. The main changes involve replacing deprecated usage of `base64::encode` and `base64::decode` with the recommended `Engine` trait and `general_purpose::STANDARD` engine. This ensures compatibility with the latest crate version and improves code consistency.

**Dependency version updates:**

* Updated the `base64` crate to version `0.22` in all relevant `Cargo.toml` files (`env_aws`, `env_common`, `gitops`, `integration-tests`, `operator`, `utils`). 

**Refactoring to use new base64 API:**

* Replaced all instances of `base64::encode` and `base64::decode` with `base64.encode` and `base64.decode` using the `Engine` trait and `general_purpose::STANDARD` engine in code files such as `api_change_record.rs`, `api_module.rs`, `api_oci_registry.rs`, `api_policy.rs`, `api_stack.rs`, `github.rs`, `utils.rs`, and `file.rs`. 

**Consistency and code modernization:**

* Ensured all base64 operations across the codebase use the same engine and trait, improving maintainability and reducing future upgrade friction. (all above references)