### PR TITLE
fix: use changes from apply/destroy in InfraChangeRecord

### DIFF
--- a/defs/src/infra_change_record.rs
+++ b/defs/src/infra_change_record.rs
@@ -25,6 +25,14 @@ pub struct InfraChangeRecord {
     // TODO: add variables since it might be interesting here
     pub epoch: u128,
     pub timestamp: String,
+    /// Human-readable text output from terraform command.
+    /// For plan commands: contains `terraform plan` stdout showing planned changes.
+    /// For apply/destroy commands: contains `terraform apply/destroy` stdout showing
+    /// what actually happened (including "Apply complete! Resources: 2 added, 0 changed, 0 destroyed").
     pub plan_std_output: String,
+    /// Storage key/path to the raw JSON output from terraform show.
+    /// For plan commands: points to `{command}_{job_id}_plan_output.json`
+    /// For apply commands: points to `{command}_{job_id}_apply_output.json`
+    /// The actual file path distinguishes between planned vs applied changes.
     pub plan_raw_json_key: String,
 }

--- a/terraform_runner/src/lib.rs
+++ b/terraform_runner/src/lib.rs
@@ -19,7 +19,7 @@ pub use runner::{run_terraform_runner, setup_misc};
 pub use terraform::{
     run_terraform_command, set_up_provider_mirror, store_backend_file, store_tf_vars_json,
     terraform_apply_destroy, terraform_init, terraform_output, terraform_plan, terraform_show,
-    terraform_validate,
+    terraform_show_after_apply, terraform_validate,
 };
 pub use utils::get_env_var;
 pub use webhook::post_webhook;


### PR DESCRIPTION
This pull request enhances how infrastructure changes are recorded after running Terraform operations, especially for apply/destroy commands. It introduces a new function to capture the actual infrastructure state after these operations, ensures more accurate and complete change records, and refines how outputs are handled and stored.

**Infrastructure Change Recording Improvements:**

* Added `plan_std_output` and `plan_raw_json_key` fields to the `InfraChangeRecord` struct to store human-readable Terraform output and the storage path for raw JSON output, respectively.
* Updated `terraform_show` to only insert an `InfraChangeRecord` for plan commands, and made record insertion failures non-blocking for the plan step. [[1]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07R392-R394) [[2]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07L415-R435)

**Apply/Destroy Command Enhancements:**

* Introduced the `terraform_show_after_apply` function to capture and record the actual state after apply/destroy commands, ensuring that the change record reflects what really happened.
* Modified the Terraform flow to call `terraform_show_after_apply` after apply/destroy, passing in the actual output from the operation.

**Output Handling and API Changes:**

* Changed `terraform_apply_destroy` to return the combined stdout and stderr output, so all informational messages are captured and available for downstream processes. [[1]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07L480-R578) [[2]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07L505-R603) [[3]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07L517-R622)
* Updated imports and public exports to include the new `terraform_show_after_apply` function. [[1]](diffhunk://#diff-04b487c8215f20a2726287d98fce7a42c35744d2bcc74c80e5e6bbea620db500L22-R22) [[2]](diffhunk://#diff-df0568d93755a170be598c2f1ed4459ec500e7e073503946f8c4cc1b71a60f3aL20-R20)