### PR TITLE
ci: add necessary permissions in build-workflows

### DIFF
--- a/.github/workflows/docker-cli.yml
+++ b/.github/workflows/docker-cli.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker-gitops-aws.yml
+++ b/.github/workflows/docker-gitops-aws.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker-operator.yml
+++ b/.github/workflows/docker-operator.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker-reconciler-aws.yml
+++ b/.github/workflows/docker-reconciler-aws.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker-runner.yml
+++ b/.github/workflows/docker-runner.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 jobs:
   build-and-push-image-terraform:

--- a/.github/workflows/docker-webserver-openapi.yml
+++ b/.github/workflows/docker-webserver-openapi.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  id-token: write
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
This pull request updates the permissions for several GitHub Actions workflow files to enable writing to GitHub Packages and allow the use of OpenID Connect (OIDC) tokens. These changes are necessary for workflows that need to publish Docker images or interact with cloud services using secure authentication.

**Workflow permissions updates:**

* Added `packages: write` and `id-token: write` permissions to the following workflow files to support pushing Docker images and OIDC-based authentication:
  - `.github/workflows/docker-cli.yml`
  - `.github/workflows/docker-gitops-aws.yml`
  - `.github/workflows/docker-operator.yml`
  - `.github/workflows/docker-reconciler-aws.yml`
  - `.github/workflows/docker-runner.yml`
  - `.github/workflows/docker-webserver-openapi.yml`