### PR TITLE
fix: add hidden generate-docs command to cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1560,7 @@ dependencies = [
  "arboard",
  "chrono",
  "clap",
+ "clap-markdown",
  "colored",
  "crossterm",
  "env_common",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+clap-markdown = "0.1"
 reqwest = "0.11"
 tokio = { version = "1", features = ["full"] }
 colored = "2.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -91,6 +91,9 @@ enum Commands {
     },
     /// Launch interactive TUI for exploring modules and deployments
     Ui,
+    /// Generate markdown documentation (hidden)
+    #[command(hide = true)]
+    GenerateDocs,
 }
 
 #[derive(Subcommand)]
@@ -376,6 +379,9 @@ async fn main() {
                 eprintln!("Error running TUI: {}", e);
                 std::process::exit(1);
             }
+        }
+        Commands::GenerateDocs => {
+            clap_markdown::print_help_markdown::<Cli>();
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a hidden CLI command for generating Markdown documentation, and adds a new dependency to support this feature. The changes are focused on enhancing developer tooling for documentation generation.

**Documentation tooling:**

* Added the `clap-markdown` dependency to `cli/Cargo.toml` to enable Markdown documentation generation for CLI commands.
* Introduced a hidden `GenerateDocs` command to the `Commands` enum in `cli/src/main.rs`, allowing users to generate Markdown documentation for the CLI.
* Implemented the logic for the `GenerateDocs` command in the main function, using `clap_markdown::print_help_markdown::<Cli>()` to output the documentation.