### PR TITLE
feat: add manual-intervention to cli

### DIFF
--- a/cli/src/commands/manual_intervention.rs
+++ b/cli/src/commands/manual_intervention.rs
@@ -1,0 +1,139 @@
+use std::{collections::HashSet, fs::remove_file};
+
+use env_defs::{CloudProvider, ExtraData};
+use env_utils::{
+    create_temp_dir, download_zip, get_extra_environment_variables_all, store_backend_file,
+    store_tf_vars_json, unzip_file,
+};
+
+use crate::current_region_handler;
+
+pub async fn handle_setup(deployment_id: &str, environment_id: &str) {
+    let (deployment, _) = current_region_handler()
+        .await
+        .get_deployment_and_dependents(deployment_id, environment_id, false)
+        .await
+        .unwrap();
+
+    if deployment.is_none() {
+        println!("Deployment not found");
+        std::process::exit(1);
+    }
+    let deployment = deployment.unwrap();
+
+    let is_stack = deployment.module_type == "stack";
+
+    println!(
+        "Setting up manual workspace for {} deployment {} in environment {}",
+        if is_stack { "stack" } else { "module" },
+        deployment_id,
+        environment_id
+    );
+
+    let module = if is_stack {
+        current_region_handler()
+            .await
+            .get_stack_version(
+                &deployment.module,
+                &deployment.module_track,
+                &deployment.module_version,
+            )
+            .await
+            .unwrap()
+    } else {
+        current_region_handler()
+            .await
+            .get_module_version(
+                &deployment.module,
+                &deployment.module_track,
+                &deployment.module_version,
+            )
+            .await
+            .unwrap()
+    };
+
+    if module.is_none() {
+        eprintln!(
+            "{} version not found",
+            if is_stack { "Stack" } else { "Module" }
+        );
+        std::process::exit(1);
+    }
+    let module = module.unwrap();
+
+    let handler = current_region_handler().await;
+    let url = match env_common::get_modules_download_url(&handler, &module.s3_key).await {
+        Ok(url) => url,
+        Err(e) => {
+            panic!("Error: {:?}", e);
+        }
+    };
+
+    let new_dir = create_temp_dir().unwrap();
+    let zip_path = new_dir.join("temp-module.zip");
+    download_zip(&url, &zip_path).await.unwrap();
+    unzip_file(&zip_path, &new_dir).unwrap();
+    remove_file(&zip_path).unwrap();
+
+    let tf_extra_environment_variables = module
+        .tf_providers
+        .iter()
+        .flat_map(|provider| provider.tf_extra_environment_variables.iter())
+        .collect::<Vec<&String>>();
+
+    let extra_vars_keys = tf_extra_environment_variables
+        .iter()
+        .filter(|k| !k.to_lowercase().contains("git"))
+        .map(|k| k.to_string())
+        .collect::<HashSet<String>>()
+        .into_iter()
+        .collect::<Vec<String>>();
+
+    let extra_vars_values = get_extra_environment_variables_all(
+        &deployment.deployment_id,
+        environment_id,
+        &deployment.reference,
+        &deployment.module_version,
+        &deployment.module_type,
+        &deployment.module_track,
+        &deployment.drift_detection,
+        &ExtraData::None,
+    );
+
+    let extra_vars: std::collections::HashMap<String, String> = extra_vars_keys
+        .iter()
+        .map(|k| {
+            (
+                k.to_string(),
+                extra_vars_values.get(k).cloned().unwrap_or_default(),
+            )
+        })
+        .collect();
+
+    let mut all_variables = deployment.variables.clone();
+    if let serde_json::Value::Object(ref mut map) = all_variables {
+        if let serde_json::Value::Object(extra_map) = serde_json::json!(extra_vars) {
+            map.extend(extra_map);
+        }
+    }
+
+    store_tf_vars_json(&all_variables, new_dir.to_str().unwrap());
+    store_backend_file(
+        &handler.get_backend_provider(),
+        new_dir.to_str().unwrap(),
+        &handler
+            .get_backend_provider_arguments(environment_id, deployment_id)
+            .await,
+    )
+    .await;
+
+    println!(
+        "Manual workspace setup complete. Downloaded and unzipped module to {}",
+        new_dir.display()
+    );
+
+    println!("\nStart by running \n\npushd {}\n", new_dir.display());
+    println!("Then run initialize the workspace with \n\ntofu init\n");
+    println!("Finally, to apply the changes run \n\ntofu apply\n");
+    println!("\nHint: Remember to `popd` when you're done to exit the workspace.");
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod claim;
 pub mod deployment;
+pub mod manual_intervention;
 pub mod module;
 pub mod policy;
 pub mod project;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,6 +102,11 @@ enum Commands {
         #[command(subcommand)]
         command: DeploymentCommands,
     },
+    /// Set up manual intervention directory for a deployment (Only for advanced users)
+    ManualIntervention {
+        #[command(subcommand)]
+        command: ManualInterventionCommands,
+    },
     /// Launch interactive TUI for exploring modules and deployments
     Ui,
     /// Generate markdown documentation (hidden)
@@ -307,6 +312,17 @@ enum DeploymentCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum ManualInterventionCommands {
+    /// Set up a manual-intervention workspace for a specific deployment
+    Setup {
+        /// Environment id of the deployment, e.g. cli/default
+        environment_id: String,
+        /// Deployment id to set up manual intervention for, e.g. s3bucket/s3bucket-my-s3-bucket-7FV
+        deployment_id: String,
+    },
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
@@ -455,6 +471,14 @@ async fn main() {
                 deployment_id,
             } => {
                 commands::deployment::handle_describe(&deployment_id, &environment_id).await;
+            }
+        },
+        Commands::ManualIntervention { command } => match command {
+            ManualInterventionCommands::Setup {
+                environment_id,
+                deployment_id,
+            } => {
+                commands::manual_intervention::handle_setup(&deployment_id, &environment_id).await;
             }
         },
         Commands::Ui => {

--- a/defs/src/cloudprovider.rs
+++ b/defs/src/cloudprovider.rs
@@ -43,6 +43,11 @@ pub trait CloudProvider: Send + Sync {
     fn get_cloud_provider(&self) -> &str;
     fn get_backend_provider(&self) -> &str;
     fn get_storage_basepath(&self) -> String;
+    async fn get_backend_provider_arguments(
+        &self,
+        environment: &str,
+        deployment_id: &str,
+    ) -> serde_json::Value;
     async fn set_backend(
         &self,
         exec: &mut tokio::process::Command,
@@ -175,4 +180,5 @@ pub trait CloudProvider: Send + Sync {
         environment: &str,
         version: &str,
     ) -> Result<PolicyResp, anyhow::Error>;
+    async fn get_environment_variables(&self) -> Result<serde_json::Value, anyhow::Error>;
 }

--- a/env_aws/src/api.rs
+++ b/env_aws/src/api.rs
@@ -337,6 +337,12 @@ pub fn get_job_status_query(job_id: &str) -> Value {
     })
 }
 
+pub fn get_environment_variables_query() -> Value {
+    json!({
+        "event": "get_environment_variables"
+    })
+}
+
 pub fn get_all_deployments_query(project_id: &str, region: &str, environment: &str) -> Value {
     json!({
         "IndexName": "DeletedIndex",

--- a/env_aws/src/lib.rs
+++ b/env_aws/src/lib.rs
@@ -24,6 +24,7 @@ pub use api::{
     get_deployment_query,
     get_deployments_to_driftcheck_query,
     get_deployments_using_module_query,
+    get_environment_variables_query,
     get_events_query,
     get_generate_presigned_url_query,
     get_job_status_query,

--- a/env_aws/src/provider.rs
+++ b/env_aws/src/provider.rs
@@ -9,7 +9,7 @@ use env_utils::{
     _get_deployments, _get_events, _get_module_optional, _get_modules, _get_policies, _get_policy,
     _get_provider_optional, _get_providers, get_projects,
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::{future::Future, pin::Pin, thread::sleep, time::Duration};
 
 #[derive(Clone)]
@@ -41,6 +41,19 @@ impl CloudProvider for AwsCloudProvider {
     }
     fn get_storage_basepath(&self) -> String {
         format!("{}/", self.project_id) // Shared storage bucket with all projects
+    }
+    async fn get_backend_provider_arguments(
+        &self,
+        environment: &str,
+        deployment_id: &str,
+    ) -> serde_json::Value {
+        let environment_variables = self.get_environment_variables().await.unwrap_or_default();
+        json!({
+            "bucket": environment_variables.get("TF_STATE_S3_BUCKET").unwrap(),
+            "dynamodb_table": environment_variables.get("DYNAMODB_TF_LOCKS_TABLE_ARN").unwrap(),
+            "key": format!("{}{}/{}/terraform.tfstate", self.get_storage_basepath(), environment, deployment_id),
+            "region": self.region,
+        })
     }
     async fn set_backend(
         &self,
@@ -422,5 +435,28 @@ impl CloudProvider for AwsCloudProvider {
         version: &str,
     ) -> Result<PolicyResp, anyhow::Error> {
         _get_policy(self, crate::get_policy_query(policy, environment, version)).await
+    }
+    async fn get_environment_variables(&self) -> Result<serde_json::Value, anyhow::Error> {
+        match crate::run_function(
+            &self.function_endpoint,
+            &crate::get_environment_variables_query(),
+            &self.project_id,
+            &self.region,
+        )
+        .await
+        {
+            Ok(response) => match response.payload.get("body") {
+                Some(variables) => Ok(variables.clone()),
+                None => Err(anyhow::anyhow!(
+                    "Environment variables not found in response"
+                )),
+            },
+            Err(e) => {
+                println!("Error getting environment variables: {:?}", e);
+                Err(anyhow::anyhow!(
+                    "Failed to get function environment variables"
+                ))
+            }
+        }
     }
 }

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -200,6 +200,12 @@ pub fn get_job_status_query(job_id: &str) -> Value {
     })
 }
 
+pub fn get_environment_variables_query() -> Value {
+    json!({
+        "event": "get_environment_variables"
+    })
+}
+
 pub fn get_all_latest_modules_query(track: &str) -> Value {
     _get_all_latest_modules_query("LATEST_MODULE", track)
 }

--- a/env_azure/src/lib.rs
+++ b/env_azure/src/lib.rs
@@ -24,6 +24,7 @@ pub use api::{
     get_deployment_query,
     get_deployments_to_driftcheck_query,
     get_deployments_using_module_query,
+    get_environment_variables_query,
     get_events_query,
     get_generate_presigned_url_query,
     get_job_status_query,

--- a/env_azure/src/provider.rs
+++ b/env_azure/src/provider.rs
@@ -41,6 +41,13 @@ impl CloudProvider for AzureCloudProvider {
     fn get_storage_basepath(&self) -> String {
         "".to_string() // Every subscription has its own storage blob container
     }
+    async fn get_backend_provider_arguments(
+        &self,
+        _environment: &str,
+        _deployment_id: &str,
+    ) -> serde_json::Value {
+        todo!("Implement Azure backend provider arguments")
+    }
     async fn set_backend(
         &self,
         exec: &mut tokio::process::Command,
@@ -397,5 +404,23 @@ impl CloudProvider for AzureCloudProvider {
         version: &str,
     ) -> Result<PolicyResp, anyhow::Error> {
         _get_policy(self, crate::get_policy_query(policy, environment, version)).await
+    }
+    async fn get_environment_variables(&self) -> Result<serde_json::Value, anyhow::Error> {
+        match crate::run_function(
+            &self.function_endpoint,
+            &crate::get_environment_variables_query(),
+            &self.project_id,
+            &self.region,
+        )
+        .await
+        {
+            Ok(response) => Ok(response.payload),
+            Err(e) => {
+                println!("Error getting environment variables: {:?}", e);
+                Err(anyhow::anyhow!(
+                    "Failed to get function environment variables"
+                ))
+            }
+        }
     }
 }

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -195,6 +195,15 @@ impl CloudProvider for GenericCloudHandler {
     fn get_storage_basepath(&self) -> String {
         self.provider.get_storage_basepath()
     }
+    async fn get_backend_provider_arguments(
+        &self,
+        environment: &str,
+        deployment_id: &str,
+    ) -> serde_json::Value {
+        self.provider
+            .get_backend_provider_arguments(environment, deployment_id)
+            .await
+    }
     async fn set_backend(
         &self,
         exec: &mut tokio::process::Command,
@@ -414,6 +423,9 @@ impl CloudProvider for GenericCloudHandler {
         version: &str,
     ) -> Result<PolicyResp, anyhow::Error> {
         self.provider.get_policy(policy, environment, version).await
+    }
+    async fn get_environment_variables(&self) -> Result<serde_json::Value, anyhow::Error> {
+        self.provider.get_environment_variables().await
     }
 }
 

--- a/env_common/src/interface/no_cloud_provider.rs
+++ b/env_common/src/interface/no_cloud_provider.rs
@@ -87,6 +87,14 @@ impl CloudProvider for NoCloudProvider {
         String::new()
     }
 
+    async fn get_backend_provider_arguments(
+        &self,
+        _environment: &str,
+        _deployment_id: &str,
+    ) -> serde_json::Value {
+        serde_json::Value::Null
+    }
+
     async fn set_backend(
         &self,
         _cmd: &mut tokio::process::Command,
@@ -316,5 +324,9 @@ impl CloudProvider for NoCloudProvider {
 
     async fn get_policy_download_url(&self, _key: &str) -> Result<String, anyhow::Error> {
         Ok(String::new())
+    }
+
+    async fn get_environment_variables(&self) -> Result<serde_json::Value, anyhow::Error> {
+        Ok(serde_json::Value::Null)
     }
 }

--- a/integration-tests/azure-function-code/function_app.py
+++ b/integration-tests/azure-function-code/function_app.py
@@ -66,6 +66,8 @@ def handler(req: func.HttpRequest) -> func.HttpResponse:
             return generate_presigned_url(req)
         elif event == 'get_job_status':
             return get_job_status(req)
+        elif event == 'get_environment_variables':
+            return get_environment_variables(req)
         elif event == 'transact_write':
             return transact_write(req)
         elif event == 'publish_notification':
@@ -171,6 +173,17 @@ def get_job_status(req: func.HttpRequest) -> func.HttpResponse:
     # - Otherwise, return is_running=False
     is_running = job_id.startswith('running-') if job_id else False
     return func.HttpResponse(json.dumps({'job_id': job_id, 'is_running': is_running}), status_code=200, mimetype="application/json")
+
+def get_environment_variables(req: func.HttpRequest) -> func.HttpResponse:
+    # Return mock environment variables for testing (matches real Azure function structure)
+    env_vars = {
+        "STORAGE_ACCOUNT_NAME": "test-storage-account",
+        "TF_STATE_CONTAINER": "test-tfstate",
+        "RESOURCE_GROUP_NAME": "test-rg",
+        "AZURE_SUBSCRIPTION_ID": "test-subscription-id",
+        "LOCATION": "westus2",
+    }
+    return func.HttpResponse(json.dumps(env_vars), status_code=200, mimetype="application/json")
 
 def start_runner(req: func.HttpRequest) -> func.HttpResponse:
     # TODO: Implement the ACI task start logic as another docker container

--- a/integration-tests/lambda-code/test-api.py
+++ b/integration-tests/lambda-code/test-api.py
@@ -208,6 +208,14 @@ def get_job_status(event):
     is_running = job_id.startswith('running-') if job_id else False
     return {'job_id': job_id, 'is_running': is_running}
 
+def get_environment_variables(event):
+    # Return mock environment variables for testing (matches real lambda.py structure)
+    return {
+            "DYNAMODB_TF_LOCKS_TABLE_ARN": "arn:aws:dynamodb:us-west-2:123456789012:table/test-tf-locks",
+            "TF_STATE_S3_BUCKET": "test-tf-state-bucket",
+            "REGION": "us-west-2",
+        }
+
 def start_runner(event):
     # ecs = boto3.client('ecs')
     payload = event.get('data')
@@ -224,6 +232,7 @@ processes = {
     'read_logs': read_logs,
     'generate_presigned_url': generate_presigned_url,
     'get_job_status': get_job_status,
+    'get_environment_variables': get_environment_variables,
     'publish_notification': lambda event: {'status': 'success', 'message': 'Notification published successfully'},
 }
 

--- a/terraform_runner/src/lib.rs
+++ b/terraform_runner/src/lib.rs
@@ -17,9 +17,9 @@ pub use opa::{
 pub use read::read_module_from_file;
 pub use runner::{run_terraform_runner, setup_misc};
 pub use terraform::{
-    run_terraform_command, set_up_provider_mirror, store_backend_file, store_tf_vars_json,
-    terraform_apply_destroy, terraform_init, terraform_output, terraform_plan, terraform_show,
-    terraform_show_after_apply, terraform_validate,
+    run_terraform_command, set_up_provider_mirror, terraform_apply_destroy, terraform_init,
+    terraform_output, terraform_plan, terraform_show, terraform_show_after_apply,
+    terraform_validate,
 };
 pub use utils::get_env_var;
 pub use webhook::post_webhook;

--- a/utils/src/dir.rs
+++ b/utils/src/dir.rs
@@ -1,0 +1,9 @@
+pub fn create_temp_dir() -> std::io::Result<std::path::PathBuf> {
+    let temp_dir = std::env::temp_dir();
+    let dir_name = format!("temp_dir_{}", uuid::Uuid::new_v4());
+    let temp_path = temp_dir.join(dir_name);
+
+    std::fs::create_dir_all(&temp_path)?;
+
+    Ok(temp_path)
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,4 +1,5 @@
 mod deployment;
+mod dir;
 mod file;
 mod general;
 mod json;
@@ -18,6 +19,7 @@ mod variables;
 mod versioning;
 
 pub use deployment::{generate_deployment_claim, generate_module_example_deployment};
+pub use dir::create_temp_dir;
 pub use file::{
     clean_root, copy_dir_recursive, download_zip, download_zip_to_vec, get_terraform_lockfile,
     get_terraform_tfvars, get_zip_file, get_zip_file_from_str, merge_zips, read_file_base64,
@@ -52,8 +54,9 @@ pub use stack::read_stack_directory;
 pub use string_utils::{to_camel_case, to_snake_case};
 pub use tar::{get_diff_id_from_zip, targz_to_zip_bytes, zip_bytes_to_targz};
 pub use terraform::{
-    get_provider_url_key, plan_get_destructive_changes, run_terraform_provider_lock,
-    DestructiveChange,
+    get_extra_environment_variables, get_extra_environment_variables_all, get_provider_url_key,
+    plan_get_destructive_changes, run_terraform_provider_lock, store_backend_file,
+    store_tf_vars_json, DestructiveChange,
 };
 pub use time::{epoch_to_timestamp, get_epoch, get_timestamp};
 pub use variables::{

--- a/utils/src/terraform.rs
+++ b/utils/src/terraform.rs
@@ -1,10 +1,11 @@
 use anyhow::{anyhow, Context, Result};
 use bollard::exec::StartExecResults;
 use bollard::image::CreateImageOptions;
-use env_defs::TfLockProvider;
+use env_defs::{ApiInfraPayload, ExtraData, TfLockProvider};
 use log::warn;
 use serde::Deserialize;
 use serde_json::Value;
+use std::fs::{write, File};
 use uuid::Uuid;
 
 #[derive(Deserialize, Debug)]
@@ -675,4 +676,164 @@ mod tests {
         let changes = plan_get_destructive_changes(&plan_json);
         assert_eq!(changes.len(), 0);
     }
+}
+pub fn store_tf_vars_json(tf_vars: &serde_json::Value, folder_path: &str) {
+    // Try to create a file
+    let tf_vars_file = match File::create(format!("{}/terraform.tfvars.json", folder_path)) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("Failed to create terraform.tfvars.json: {:?}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Write the JSON data to the file
+    if let Err(e) = serde_json::to_writer_pretty(tf_vars_file, &tf_vars) {
+        eprintln!("Failed to write JSON to terraform.tfvars.json: {:?}", e);
+        std::process::exit(1);
+    }
+}
+
+pub async fn store_backend_file(
+    backend_provider: &str,
+    folder_path: &str,
+    extras_map: &serde_json::Value,
+) {
+    // There are verifications when publishing a module to ensure that there
+    // is no existing already backend specified. This is to ensure that InfraWeave
+    // uses its backend storage
+    let backend_file_content = format!(
+        r#"
+terraform {{
+    backend "{}" {{{}}}
+}}"#,
+        backend_provider,
+        extras_map.as_object().map_or("".to_string(), |extras| {
+            extras
+                .iter()
+                .map(|(k, v)| format!("\n        {} = {}", k, v))
+                .collect::<Vec<String>>()
+                .join("")
+        }) + if !(extras_map == &serde_json::json!({})) {
+            "\n    "
+        } else {
+            ""
+        }
+    );
+
+    let path = format!("{}/backend.tf", folder_path);
+    let file_path = std::path::Path::new(path.as_str());
+    if let Err(e) = write(file_path, &backend_file_content) {
+        eprintln!("Failed to write to backend.tf: {:?}", e);
+        std::process::exit(1);
+    }
+}
+
+#[rustfmt::skip]
+pub fn get_extra_environment_variables(
+    payload: &ApiInfraPayload,
+) -> std::collections::HashMap<String, String> {
+    get_extra_environment_variables_all(
+        &payload.deployment_id,
+        &payload.environment,
+        &payload.reference,
+        &payload.module_version,
+        &payload.module_type,
+        &payload.module_track,
+        &payload.drift_detection,
+        &payload.extra_data,
+    )
+}
+
+pub fn get_extra_environment_variables_all(
+    deployment_id: &str,
+    environment: &str,
+    reference: &str,
+    module_version: &str,
+    module_type: &str,
+    module_track: &str,
+    drift_detection: &env_defs::DriftDetection,
+    extra_data: &ExtraData,
+) -> std::collections::HashMap<String, String> {
+    let mut env_vars = std::collections::HashMap::new();
+    env_vars.insert(
+        "INFRAWEAVE_DEPLOYMENT_ID".to_string(),
+        deployment_id.to_string(),
+    );
+    env_vars.insert(
+        "INFRAWEAVE_ENVIRONMENT".to_string(),
+        environment.to_string(),
+    );
+    env_vars.insert("INFRAWEAVE_REFERENCE".to_string(), reference.to_string());
+    env_vars.insert(
+        "INFRAWEAVE_MODULE_VERSION".to_string(),
+        module_version.to_string(),
+    );
+    env_vars.insert(
+        "INFRAWEAVE_MODULE_TYPE".to_string(),
+        module_type.to_string(),
+    );
+    env_vars.insert(
+        "INFRAWEAVE_MODULE_TRACK".to_string(),
+        module_track.to_string(),
+    );
+    env_vars.insert(
+        "INFRAWEAVE_DRIFT_DETECTION".to_string(),
+        (if drift_detection.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        })
+        .to_string(),
+    );
+    env_vars.insert(
+        "INFRAWEAVE_DRIFT_DETECTION_INTERVAL".to_string(),
+        if drift_detection.enabled {
+            drift_detection.interval.to_string()
+        } else {
+            "N/A".to_string()
+        },
+    );
+
+    match &extra_data {
+        ExtraData::GitHub(github_data) => {
+            env_vars.insert(
+                "INFRAWEAVE_GIT_COMMITTER_EMAIL".to_string(),
+                github_data.user.email.clone(),
+            );
+            env_vars.insert(
+                "INFRAWEAVE_GIT_COMMITTER_NAME".to_string(),
+                github_data.user.name.clone(),
+            );
+            env_vars.insert(
+                "INFRAWEAVE_GIT_ACTOR_USERNAME".to_string(),
+                github_data.user.username.clone(),
+            );
+            env_vars.insert(
+                "INFRAWEAVE_GIT_ACTOR_PROFILE_URL".to_string(),
+                github_data.user.profile_url.clone(),
+            );
+            env_vars.insert(
+                "INFRAWEAVE_GIT_REPOSITORY_NAME".to_string(),
+                github_data.repository.full_name.clone(),
+            );
+            env_vars.insert(
+                "INFRAWEAVE_GIT_REPOSITORY_PATH".to_string(),
+                github_data.job_details.file_path.clone(),
+            );
+            env_vars.insert(
+                "INFRAWEAVE_GIT_COMMIT_SHA".to_string(),
+                github_data.check_run.head_sha.clone(),
+            );
+        }
+        ExtraData::GitLab(gitlab_data) => {
+            // TODO: Add more here for GitLab
+            env_vars.insert(
+                "INFRAWEAVE_GIT_REPOSITORY_PATH".to_string(),
+                gitlab_data.job_details.file_path.clone(),
+            );
+        }
+        ExtraData::None => {}
+    };
+    env_vars
 }


### PR DESCRIPTION
* for advanced users only
* need to be added in the bootstrap step for access to state-file

This pull request introduces a new "manual intervention" feature to the CLI, allowing advanced users to set up a manual workspace for a deployment. It also adds a new interface for retrieving environment variables from cloud providers, and implements this for both AWS and Azure. The changes include new commands, trait extensions, backend argument handling, and updated integration tests to support and test these features.

Resolves https://github.com/infraweave-io/infraweave/issues/155

**Manual Intervention CLI Feature:**
- Added a new `ManualIntervention` command to the CLI, with a `setup` subcommand that allows users to create a manual workspace for a specific deployment. This involves downloading, unzipping the module, merging extra environment variables, and preparing Terraform backend configuration. (`cli/src/commands/manual_intervention.rs`, `cli/src/commands/mod.rs`, `cli/src/main.rs`)

**CloudProvider Trait Enhancements:**
- Extended the `CloudProvider` trait to include asynchronous methods for getting backend provider arguments and environment variables, enabling cloud-agnostic retrieval of necessary backend configuration and secrets. (`defs/src/provider.rs`)

**AWS and Azure Provider Implementations:**
- Implemented the new trait methods for AWS and Azure, including logic to fetch and return environment variables and backend arguments. For AWS, the backend arguments are constructed from fetched environment variables; for Azure, the method is stubbed as a TODO. (`env_aws/src/provider.rs`, `env_azure/src/provider.rs`, `env_aws/src/api.rs`, `env_azure/src/api.rs`, `env_aws/src/lib.rs`, `env_azure/src/lib.rs`)

**Common Handler and NoCloudProvider Support:**
- Updated the generic cloud handler and no-cloud provider implementations to support the new trait methods, ensuring compatibility and safe fallbacks. (`env_common/src/interface/cloud_handlers.rs`, `env_common/src/interface/no_cloud_provider.rs`)

**Integration Test and Utility Updates:**
- Enhanced integration test stubs for AWS Lambda and Azure Functions to provide mock environment variables for testing the new CLI features. Also refactored imports and utility usage for storing backend files and Terraform variables. (`integration-tests/azure-function-code/function_app.py`, `integration-tests/lambda-code/test-api.py`, `terraform_runner/src/lib.rs`, `terraform_runner/src/runner.rs`)