### PR TITLE
fix: only perform extra job-id verification on deploy

### DIFF
--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -448,9 +448,13 @@ async fn run_job(
     let deployment_result: Option<DeploymentResp>;
 
     loop {
-        let (in_progress, _, _status, deployment_job_result) =
-            is_deployment_in_progress(handler, &deployment.deployment_id, &deployment.namespace)
-                .await;
+        let (in_progress, _, _status, deployment_job_result) = is_deployment_in_progress(
+            handler,
+            &deployment.deployment_id,
+            &deployment.namespace,
+            false,
+        )
+        .await;
         if !in_progress {
             let status = if command == "destroy" {
                 "successful" // Since deployment not found is considered successful

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -819,7 +819,7 @@ async fn follow_job_until_finished(
     let mut update_time = "".to_string();
     loop {
         let (in_progress, n_job_id, depl_status, depl) =
-            is_deployment_in_progress(handler, deployment_id, environment).await;
+            is_deployment_in_progress(handler, deployment_id, environment, false).await;
         deployment_status = depl_status;
         let status = if in_progress {
             "in progress"


### PR DESCRIPTION
This pull request introduces a more robust mechanism for checking whether a deployment job is truly in progress by adding a `job_check` parameter to the `is_deployment_in_progress` function. This is for when checking before applying a claim, and preventing the deep-check when we are observing an already running job we just initiated.

**Deployment job status checking improvements:**

* Added a `job_check` boolean parameter to the `is_deployment_in_progress` function in `env_common/src/logic/api_infra.rs`, allowing callers to specify if the actual job status should be verified even when the deployment status is "in progress".
* Updated the logic inside `is_deployment_in_progress` to only perform the additional job status check if `job_check` is true, enhancing control over deployment job verification. [[1]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R577) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8R610)

**Integration with deployment workflows:**

* Modified `submit_claim_job` in `env_common/src/logic/api_infra.rs` to call `is_deployment_in_progress` with `job_check` set to true, ensuring stricter checks before submitting a claim job.
* Updated `run_job` in `infraweave_py/src/deployment.rs` and `follow_job_until_finished` in `operator/src/operator.rs` to call `is_deployment_in_progress` with `job_check` set to false, maintaining previous behavior where strict job status verification is not needed. [[1]](diffhunk://#diff-7c9aabcf0fade9c2286b4debcea28b59583ff8b4ce9231f471814f770a5872e5L451-R456) [[2]](diffhunk://#diff-46cf44a083bd5f031887f93d91d7577de42bf49b6bc7bc08c0bd70b1597f1bb6L822-R822)