### PR TITLE
fix: add get-logs command for a specific job-id

### DIFF
--- a/cli/src/commands/deployment.rs
+++ b/cli/src/commands/deployment.rs
@@ -1,7 +1,9 @@
 use log::error;
 
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+use env_defs::{CloudProvider, CloudProviderCommon};
+use std::fs::File;
+use std::io::Write;
 
 pub async fn handle_describe(deployment_id: &str, environment: &str) {
     let (deployment, _) = current_region_handler()
@@ -78,6 +80,43 @@ pub async fn handle_get_claim(deployment_id: &str, environment: &str) {
         }
         Err(e) => {
             error!("Failed to get claim: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub async fn handle_get_logs(job_id: &str, output_path: Option<&str>) {
+    match current_region_handler().await.read_logs(job_id).await {
+        Ok(logs) => {
+            let log_content = logs
+                .iter()
+                .map(|log| log.message.as_str())
+                .collect::<Vec<&str>>()
+                .join("\n");
+
+            match output_path {
+                Some(path) => match File::create(path) {
+                    Ok(mut file) => match file.write_all(log_content.as_bytes()) {
+                        Ok(_) => {
+                            println!("Logs successfully written to: {}", path);
+                        }
+                        Err(e) => {
+                            error!("Failed to write logs to file: {}", e);
+                            std::process::exit(1);
+                        }
+                    },
+                    Err(e) => {
+                        error!("Failed to create file {}: {}", path, e);
+                        std::process::exit(1);
+                    }
+                },
+                None => {
+                    println!("{}", log_content);
+                }
+            }
+        }
+        Err(e) => {
+            error!("Failed to get logs for job {}: {}", job_id, e);
             std::process::exit(1);
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -84,6 +84,14 @@ enum Commands {
         /// Deployment id to get claim for, e.g. s3bucket/my-s3-bucket
         deployment_id: String,
     },
+    /// Download logs for a specific job ID
+    GetLogs {
+        /// Job ID to download logs for
+        job_id: String,
+        /// Optional output file path (prints to stdout if not specified)
+        #[arg(short, long)]
+        output: Option<String>,
+    },
     /// Work with deployments
     Deployments {
         #[command(subcommand)]
@@ -329,6 +337,9 @@ async fn main() {
         } => {
             let env = get_environment(&environment_id);
             commands::deployment::handle_get_claim(&deployment_id, &env).await;
+        }
+        Commands::GetLogs { job_id, output } => {
+            commands::deployment::handle_get_logs(&job_id, output.as_deref()).await;
         }
         Commands::Plan {
             environment_id,


### PR DESCRIPTION
This pull request adds a new CLI command to download logs for a specific job ID, along with supporting code to handle log retrieval and output. The main changes introduce a user-facing feature for accessing job logs, either printing them to the console or saving them to a file.

* This can be useful e.g. in python test to inspect logs further

**New CLI feature for job log retrieval:**

* Added a new `GetLogs` command to the CLI, enabling users to download logs for a specified job ID, with an optional output file path to save the logs. (`cli/src/main.rs`, [cli/src/main.rsR87-R94](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR87-R94))
* Implemented the `handle_get_logs` async function to fetch logs, concatenate log messages, and either print them to stdout or write them to a file, with error handling for file operations. (`cli/src/commands/deployment.rs`, [cli/src/commands/deployment.rsR87-R123](diffhunk://#diff-6dfd94cb337249d425b64565035b96957530e79396e05329f8bf746f110f448cR87-R123))
* Integrated the new command into the CLI's main execution flow, invoking `handle_get_logs` when the `GetLogs` command is used. (`cli/src/main.rs`, [cli/src/main.rsR341-R343](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR341-R343))

**Codebase support for new functionality:**

* Updated imports in `deployment.rs` to include `CloudProviderCommon`, `File`, and `Write`, supporting the new log retrieval and file writing logic. (`cli/src/commands/deployment.rs`, [cli/src/commands/deployment.rsL4-R6](diffhunk://#diff-6dfd94cb337249d425b64565035b96957530e79396e05329f8bf746f110f448cL4-R6))