### PR TITLE
fix: streamline deployment status handling in terraform flow and apply/destroy commands

### DIFF
--- a/terraform_runner/src/runner.rs
+++ b/terraform_runner/src/runner.rs
@@ -182,13 +182,14 @@ async fn terraform_flow<'a>(
         if command == "apply" {
             terraform_output(payload, handler, status_handler).await?;
         }
-    } else if command == "plan" {
-        status_handler.set_status("successful".to_string());
-        status_handler.set_event_duration();
-        status_handler.set_last_event_epoch(); // Reset the event duration timer for the next event
-        status_handler.send_event(handler).await;
-        status_handler.send_deployment(handler).await?;
     }
+
+    // Set deployment status to successful after all operations complete
+    status_handler.set_status("successful".to_string());
+    status_handler.set_event_duration();
+    status_handler.set_last_event_epoch();
+    status_handler.send_event(handler).await;
+    status_handler.send_deployment(handler).await?;
 
     // if !dependents.is_empty() {
     //     _trigger_dependent_deployments(&dependents).await; // TODO: WIP: needs to launch with replaced variables

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -601,15 +601,9 @@ pub async fn terraform_apply_destroy<'a>(
         Ok(command_result) => {
             println!("Terraform {} successful", cmd);
 
-            let status = "successful".to_string();
-            status_handler.set_status(status);
-            status_handler.set_event_duration();
-            status_handler.set_last_event_epoch(); // Reset the event duration timer for the next event
             if cmd == "destroy" {
                 status_handler.set_deleted(true);
             }
-            status_handler.send_event(handler).await;
-            status_handler.send_deployment(handler).await?;
 
             Ok(command_result.stdout)
         }


### PR DESCRIPTION
This pull request refactors how deployment status updates are handled after Terraform operations. The main change is to centralize the status update logic, ensuring deployment status is set only once after all operations complete, rather than in multiple places. This helps avoid redundant status updates and streamlines the workflow.

Deployment status handling improvements:

* Moved the deployment status update out of `terraform_apply_destroy` and into the main flow in `terraform_flow`, so status is set only after all operations complete. 

Redundant code removal:

* Removed duplicate status update code from `terraform_apply_destroy`, reducing unnecessary repeated calls and simplifying the function.