### PR TITLE
fix: resolve incorrect successful python status during destroy

### DIFF
--- a/env_aws/src/api.rs
+++ b/env_aws/src/api.rs
@@ -342,23 +342,32 @@ pub fn get_deployment_and_dependents_query(
     })
 }
 
-// TODO: Add include_deleted to the query
 pub fn get_deployment_query(
     project_id: &str,
     region: &str,
     deployment_id: &str,
     environment: &str,
-    _include_deleted: bool,
+    include_deleted: bool,
 ) -> Value {
-    json!({
-        "KeyConditionExpression": "PK = :pk AND SK = :metadata",
-        "FilterExpression": "deleted = :deleted",
-        "ExpressionAttributeValues": {
-            ":pk": format!("DEPLOYMENT#{}", get_deployment_identifier(project_id, region, deployment_id, environment)),
-            ":metadata": "METADATA",
-            ":deleted": 0
-        }
-    })
+    if include_deleted {
+        json!({
+            "KeyConditionExpression": "PK = :pk AND SK = :metadata",
+            "ExpressionAttributeValues": {
+                ":pk": format!("DEPLOYMENT#{}", get_deployment_identifier(project_id, region, deployment_id, environment)),
+                ":metadata": "METADATA"
+            }
+        })
+    } else {
+        json!({
+            "KeyConditionExpression": "PK = :pk AND SK = :metadata",
+            "FilterExpression": "deleted = :deleted",
+            "ExpressionAttributeValues": {
+                ":pk": format!("DEPLOYMENT#{}", get_deployment_identifier(project_id, region, deployment_id, environment)),
+                ":metadata": "METADATA",
+                ":deleted": 0
+            }
+        })
+    }
 }
 
 // TODO: use environment_refiner

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -288,31 +288,33 @@ pub fn get_deployment_and_dependents_query(
     })
 }
 
-// TODO: Add include_deleted parameter to query
 pub fn get_deployment_query(
     project_id: &str,
     region: &str,
     deployment_id: &str,
     environment: &str,
-    _include_deleted: bool,
+    include_deleted: bool,
 ) -> Value {
-    json!({
-        "query": "SELECT * FROM c WHERE c.PK = @pk AND c.SK = @metadata AND c.deleted = @deleted",
-        "parameters": [
-            {
-                "name": "@pk",
-                "value": format!("DEPLOYMENT#{}", get_deployment_identifier(project_id, region, deployment_id, environment))
-            },
-            {
-                "name": "@metadata",
-                "value": "METADATA"
-            },
-            {
-                "name": "@deleted",
-                "value": 0
-            }
-        ]
-    })
+    let pk = format!("DEPLOYMENT#{}", get_deployment_identifier(project_id, region, deployment_id, environment));
+    
+    if include_deleted {
+        json!({
+            "query": "SELECT * FROM c WHERE c.PK = @pk AND c.SK = @metadata",
+            "parameters": [
+                { "name": "@pk", "value": pk },
+                { "name": "@metadata", "value": "METADATA" }
+            ]
+        })
+    } else {
+        json!({
+            "query": "SELECT * FROM c WHERE c.PK = @pk AND c.SK = @metadata AND c.deleted = @deleted",
+            "parameters": [
+                { "name": "@pk", "value": pk },
+                { "name": "@metadata", "value": "METADATA" },
+                { "name": "@deleted", "value": 0 }
+            ]
+        })
+    }
 }
 
 // TODO: Add environment_refiner parameter to query

--- a/env_common/src/logic/api_infra.rs
+++ b/env_common/src/logic/api_infra.rs
@@ -485,7 +485,7 @@ pub async fn submit_claim_job(
 ) -> Result<String, anyhow::Error> {
     let payload = &payload_with_variables.payload;
     let (in_progress, job_id, _, _) =
-        is_deployment_in_progress(handler, &payload.deployment_id, &payload.environment, true)
+        is_deployment_in_progress(handler, &payload.deployment_id, &payload.environment, true, false)
             .await;
     if in_progress {
         return Err(CloudHandlerError::JobAlreadyInProgress(job_id).into());
@@ -550,11 +550,12 @@ pub async fn is_deployment_in_progress(
     deployment_id: &str,
     environment: &str,
     job_check: bool, // Ensure that the job is actually running even if deployment status is in progress
+    include_deleted: bool,
 ) -> (bool, String, String, Option<DeploymentResp>) {
     let busy_statuses = ["requested", "initiated"]; // TODO: use enums
 
     let deployment = match handler
-        .get_deployment(deployment_id, environment, false)
+        .get_deployment(deployment_id, environment, include_deleted)
         .await
     {
         Ok(deployment_resp) => match deployment_resp {

--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -735,19 +735,16 @@ async fn run_job(
                 &deployment.deployment_id,
                 &deployment.namespace,
                 false,
+                true,
             )
             .await;
             (in_progress, deployment)
         };
 
         if !in_progress {
-            let status = if command == "destroy" {
-                "successful"
-            } else {
-                &match &deployment_job_result {
-                    Some(deployment_job_result) => deployment_job_result.status.clone(),
-                    None => "unknown".to_string(),
-                }
+            let status = match &deployment_job_result {
+                Some(deployment_job_result) => deployment_job_result.status.clone(),
+                None => "unknown".to_string(),
             };
             println!(
                 "Finished {} with status {}! (job_id: {})\n{}",

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -819,7 +819,7 @@ async fn follow_job_until_finished(
     let mut update_time = "".to_string();
     loop {
         let (in_progress, n_job_id, depl_status, depl) =
-            is_deployment_in_progress(handler, deployment_id, environment, false).await;
+            is_deployment_in_progress(handler, deployment_id, environment, false, true).await;
         deployment_status = depl_status;
         let status = if in_progress {
             "in progress"


### PR DESCRIPTION
This pull request updates how deployment queries handle deleted deployments across AWS and Azure environments, and ensures that logic functions consistently support querying deleted deployments. The main changes are the addition and propagation of an `include_deleted` parameter to relevant query and status-checking functions, enabling more flexible querying and job status tracking for deployments that may have been marked as deleted.

Resolves https://github.com/infraweave-io/infraweave/issues/161

**Deployment Query Enhancements:**

* Added an `include_deleted` parameter to `get_deployment_query` in both `env_aws/src/api.rs` and `env_azure/src/api.rs`, allowing queries to optionally include deleted deployments. The query logic now conditionally applies filters based on this parameter. 

**Job Status and Progress Checks:**

* Updated `is_deployment_in_progress` in `env_common/src/logic/api_infra.rs` to accept and pass through the `include_deleted` parameter, ensuring job status checks can consider deleted deployments when needed.
* Modified calls to `is_deployment_in_progress` in `submit_claim_job` and related async job logic to correctly supply the new `include_deleted` argument.

These updates improve consistency in querying and status tracking by supporting operations on deleted deployments throughout the codebase.