### PR TITLE
feat: add more python module/stack properties

### DIFF
--- a/infraweave_py/src/module.rs
+++ b/infraweave_py/src/module.rs
@@ -2,6 +2,7 @@ use env_common::interface::{initialize_project_id_and_region, GenericCloudHandle
 use env_defs::CloudProvider;
 use env_defs::ModuleResp;
 use pyo3::prelude::*;
+use pyo3::types::PyType;
 use tokio::runtime::Runtime;
 
 /// A Python-exposed wrapper for a module version.
@@ -58,12 +59,78 @@ impl Module {
         Ok(module)
     }
 
-    /// Retrieves the logical name of this module.
-    ///
-    /// This method prints a debug log to stdout and returns the stored name.
-    pub fn get_name(&self) -> &str {
-        println!("get_name called {}", &self.name);
+    /// Gets the module name.
+    #[getter]
+    pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Gets the module version.
+    #[getter]
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Gets the module track.
+    #[getter]
+    pub fn track(&self) -> &str {
+        &self.track
+    }
+
+    /// Gets the latest version of this module for a given track.
+    ///
+    /// Fetches the most recent version of the module from the
+    /// configured cloud provider. If no track is specified, defaults to "stable".
+    ///
+    /// # Arguments
+    /// * `track` - Optional release track (e.g., "stable", "beta", "dev").
+    ///             Defaults to "stable" if not provided.
+    ///
+    /// # Returns
+    /// A new `Module` instance with the latest version for the specified track.
+    ///
+    /// # Errors
+    /// Panics if the module is not found or if there's an error communicating
+    /// with the cloud provider.
+    ///
+    /// # Example
+    /// ```python
+    /// from infraweave import S3Bucket
+    ///
+    /// # Get latest stable version
+    /// latest_module = S3Bucket.get_latest_version()
+    ///
+    /// # Get latest dev version
+    /// latest_dev = S3Bucket.get_latest_version(track="dev")
+    /// ```
+    #[classmethod]
+    #[pyo3(signature = (track=None))]
+    fn get_latest_version(_cls: &Bound<'_, PyType>, track: Option<&str>) -> PyResult<Self> {
+        let class_name_str = _cls.name()?.to_string();
+
+        // Prevent calling get_latest_version directly on the Module base class
+        if class_name_str == "Module" {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                "Cannot call get_latest_version() on Module base class. Use a specific module class like S3Bucket instead."
+            ));
+        }
+
+        let track = track.unwrap_or("stable");
+        let rt = Runtime::new().unwrap();
+        let module = rt.block_on(Module::async_get_latest(&class_name_str, track))?;
+        Ok(module)
+    }
+
+    /// Static method to get the latest version by module name.
+    ///
+    /// This is used internally by dynamic wrapper classes.
+    #[staticmethod]
+    #[pyo3(signature = (name, track=None))]
+    fn get_latest_version_by_name(name: &str, track: Option<&str>) -> PyResult<Self> {
+        let track = track.unwrap_or("stable");
+        let rt = Runtime::new().unwrap();
+        let module = rt.block_on(Module::async_get_latest(name, track))?;
+        Ok(module)
     }
 }
 
@@ -96,6 +163,40 @@ impl Module {
         Ok(Module {
             name: name.to_string(),
             version: version.to_string(),
+            track: track.to_string(),
+            module,
+        })
+    }
+
+    /// Internal async method to fetch the latest version of a module.
+    ///
+    /// - Initializes the project ID and region from environment.
+    /// - Creates a `GenericCloudHandler` to query the latest module version.
+    /// - Panics if the module is not found or on API errors.
+    async fn async_get_latest(name: &str, track: &str) -> PyResult<Self> {
+        // Ensure environment is set up for API calls
+        initialize_project_id_and_region().await;
+        let handler = GenericCloudHandler::default().await;
+
+        // Fetch the latest module version from the cloud provider
+        let module = match handler
+            .get_latest_module_version(&name.to_lowercase(), track)
+            .await
+        {
+            Ok(resp) => match resp {
+                Some(module) => module,
+                None => {
+                    panic!("No version of module {} found in track {}", name, track);
+                }
+            },
+            Err(e) => {
+                panic!("Error trying to get latest module version: {}", e);
+            }
+        };
+
+        Ok(Module {
+            name: name.to_string(),
+            version: module.version.clone(),
             track: track.to_string(),
             module,
         })

--- a/infraweave_py/test.py
+++ b/infraweave_py/test.py
@@ -10,8 +10,8 @@ s3bucket = S3Bucket(
 #     track='dev'
 # )
 
-print(s3bucket.get_name())
-# print(bc.get_name())
+print(s3bucket)
+# print(bc)
 
 # bucketcollection1 = Deployment(
 #     name="bucketcollection1",


### PR DESCRIPTION
This pull request refactors and enhances the Python bindings for both `Module` and `Stack` classes with adding new properties and implementing class and static methods to fetch the latest version of modules and stacks. The dynamic Python wrapper generation is also updated to expose these improvements.

### Python API improvements for `Module` and `Stack` classes

* Replaced the old `get_name` method with Python property getters for `name`, `version`, and `track` in both `Module` (`infraweave_py/src/module.rs`) and `Stack` (`infraweave_py/src/stack.rs`). This makes these attributes accessible as properties in Python, following Python conventions. 
* Added new class and static methods: `get_latest_version` (classmethod) and `get_latest_version_by_name` (staticmethod) to both `Module` and `Stack`. These methods fetch the latest version from the cloud provider for a given track, with error handling for base class misuse and API errors. 
* Implemented internal asynchronous methods (`async_get_latest`) for both `Module` and `Stack` to encapsulate the logic of fetching the latest version from the cloud provider, ensuring environment setup and robust error handling. 

### Dynamic Python wrapper generation enhancements

* Updated the dynamic wrapper generation in `infraweave_py/src/python.rs` to expose `name`, `version`, and `track` as Python properties, and to add the new `get_latest_version` classmethod. Also improved the `__repr__` for better debugging output.

### Dependency and import updates

* Added necessary imports (`PyType`) to support the new property and classmethod implementations in both `module.rs` and `stack.rs`. 