### PR TITLE
feat: add upgrade command to cli

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -68,11 +68,29 @@ jobs:
 
           BIN_OUTPUT="target/${{ matrix.target }}/release/${PROJECT_NAME}${BIN_SUFFIX}"
           BIN_RELEASE="cli-${{ matrix.name }}${BIN_SUFFIX}"
+          BIN_RELEASE_VERSIONED="cli-${{ matrix.name }}-${VERSION}${BIN_SUFFIX}"
 
           mkdir -p "./cli-releases"
 
           if [[ -f "$BIN_OUTPUT" ]]; then
-            mv "$BIN_OUTPUT" "./cli-releases/$BIN_RELEASE"
+            # Keep the raw binary for backward compatibility
+            cp "$BIN_OUTPUT" "./cli-releases/$BIN_RELEASE"
+            
+            # Also create versioned binary for archive
+            cp "$BIN_OUTPUT" "./cli-releases/$BIN_RELEASE_VERSIONED"
+            
+            # Create archives based on platform
+            if [[ "${{ matrix.runner }}" == "windows-latest" ]]; then
+              # Create ZIP for Windows
+              cd "./cli-releases"
+              7z a -tzip "$BIN_RELEASE.zip" "$BIN_RELEASE_VERSIONED"
+              rm "$BIN_RELEASE_VERSIONED"
+            else
+              # Create tar.gz for Unix-like systems (Linux/macOS)
+              cd "./cli-releases"
+              tar -czf "$BIN_RELEASE.tar.gz" "$BIN_RELEASE_VERSIONED"
+              rm "$BIN_RELEASE_VERSIONED"
+            fi
           else
             echo "Error: Built binary not found at $BIN_OUTPUT" && exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,7 +1116,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.90",
  "which 4.4.2",
@@ -1424,6 +1424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1579,8 @@ dependencies = [
  "ratatui",
  "reqwest 0.11.27",
  "ring",
+ "self_update",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -1644,6 +1652,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2918,9 +2939,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3457,6 +3480,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tower-service",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3753,6 +3777,19 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
  "serde",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
 ]
 
 [[package]]
@@ -4509,6 +4546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4767,6 +4810,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oauth2"
@@ -5618,7 +5667,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "term",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -5927,6 +5976,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.19",
+ "socket2",
+ "thiserror 2.0.6",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.19",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.6",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6059,7 +6172,7 @@ dependencies = [
  "strum_macros 0.26.4",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6277,7 +6390,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.19",
  "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6285,6 +6401,7 @@ dependencies = [
  "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -6292,6 +6409,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -6395,6 +6513,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -6520,6 +6644,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -6745,6 +6870,36 @@ checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand 2.3.0",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "self_update"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
+dependencies = [
+ "hyper 1.5.1",
+ "indicatif",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest 0.12.9",
+ "self-replace",
+ "semver",
+ "serde_json",
+ "tempfile",
+ "urlencoding",
 ]
 
 [[package]]
@@ -8036,7 +8191,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -8044,6 +8199,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -8416,6 +8577,24 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,8 @@ hostname = "0.4"
 ratatui = "0.28"
 crossterm = "0.28"
 arboard = "3.4"
+self_update = "0.42"
+semver = "1.0"
 
 env_common = { path = "../env_common" }
 env_defs = { path = "../defs" }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod module;
 pub mod policy;
 pub mod project;
 pub mod stack;
+pub mod upgrade;

--- a/cli/src/commands/upgrade.rs
+++ b/cli/src/commands/upgrade.rs
@@ -1,0 +1,144 @@
+use self_update::update::Release;
+
+fn get_target_name() -> &'static str {
+    match std::env::consts::OS {
+        "linux" => match std::env::consts::ARCH {
+            "x86_64" => "linux-amd64",
+            "aarch64" => "linux-arm64",
+            _ => panic!("Unsupported architecture"),
+        },
+        "macos" => match std::env::consts::ARCH {
+            "x86_64" => "macos-amd64",
+            "aarch64" => "macos-arm64",
+            _ => panic!("Unsupported architecture"),
+        },
+        "windows" => match std::env::consts::ARCH {
+            "x86_64" => "windows-amd64",
+            _ => panic!("Unsupported architecture"),
+        },
+        _ => panic!("Unsupported operating system"),
+    }
+}
+
+fn get_current_version() -> semver::Version {
+    let version_str = env!("APP_VERSION");
+    // Strip the 'v' prefix if present
+    let version_str = version_str.strip_prefix('v').unwrap_or(version_str);
+    semver::Version::parse(version_str).unwrap_or_else(|e| {
+        eprintln!("Failed to parse current version '{}': {}", version_str, e);
+        std::process::exit(1);
+    })
+}
+
+fn get_latest_stable_version(releases: &[Release]) -> Option<semver::Version> {
+    releases
+        .iter()
+        .filter_map(|release| {
+            // Strip the 'v' prefix if present
+            let version_str = release
+                .version
+                .strip_prefix('v')
+                .unwrap_or(&release.version);
+            let version = semver::Version::parse(version_str).ok()?;
+            // Only include stable versions (no pre-release, beta etc..)
+            if version.pre.is_empty() {
+                Some(version)
+            } else {
+                None
+            }
+        })
+        .max()
+}
+
+fn needs_upgrade(current: &semver::Version, latest: &semver::Version) -> bool {
+    latest > current
+}
+
+pub async fn handle_upgrade(check_only: bool) {
+    let current_version = get_current_version();
+    println!("Current version: {}", current_version);
+
+    // self_update is blocking and creates its own runtime, so we need to spawn it in a blocking task
+    let result = tokio::task::spawn_blocking(|| {
+        self_update::backends::github::ReleaseList::configure()
+            .repo_owner("infraweave-io")
+            .repo_name("infraweave")
+            .build()
+            .unwrap()
+            .fetch()
+    })
+    .await;
+
+    let releases = match result {
+        Ok(Ok(releases)) => releases,
+        Ok(Err(e)) => {
+            println!("error: {}", e);
+            std::process::exit(1);
+        }
+        Err(e) => {
+            println!("error spawning task: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let latest_version = match get_latest_stable_version(&releases) {
+        Some(version) => version,
+        None => {
+            println!("No stable releases found");
+            std::process::exit(1);
+        }
+    };
+    println!("Latest stable version: {}", latest_version);
+
+    if needs_upgrade(&current_version, &latest_version) {
+        println!(
+            "An upgrade is available: {} -> {}",
+            current_version, latest_version
+        );
+
+        if check_only {
+            println!("Run 'infraweave upgrade' without --check to install the update.");
+        } else {
+            println!("Downloading and installing version {}...", latest_version);
+
+            let latest_version = semver::Version::parse("0.0.95-rc.6").unwrap();
+
+            let target_name = get_target_name();
+            let bin_name = if cfg!(windows) { "cli.exe" } else { "cli" };
+            let bin_path = format!("cli-{}-v{}", target_name, latest_version);
+
+            let status = tokio::task::spawn_blocking(move || {
+                self_update::backends::github::Update::configure()
+                    .repo_owner("infraweave-io")
+                    .repo_name("infraweave")
+                    .bin_name(bin_name)
+                    .target(&target_name)
+                    .bin_path_in_archive(&bin_path)
+                    .target_version_tag(&format!("v{}", latest_version))
+                    .show_download_progress(true)
+                    .current_version(&current_version.to_string())
+                    .no_confirm(true)
+                    .build()
+                    .and_then(|updater| updater.update())
+            })
+            .await;
+
+            match status {
+                Ok(Ok(status)) => {
+                    println!("✓ Successfully upgraded to version {}", status.version());
+                    println!("Please restart the CLI to use the new version.");
+                }
+                Ok(Err(e)) => {
+                    eprintln!("Failed to upgrade: {}", e);
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Error during upgrade: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+    } else {
+        println!("You are already on the latest version!");
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,6 +102,12 @@ enum Commands {
     /// Generate markdown documentation (hidden)
     #[command(hide = true)]
     GenerateDocs,
+    /// Upgrade to the latest released version of InfraWeave
+    Upgrade {
+        /// Only check for available upgrades without installing
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -277,7 +283,10 @@ async fn main() {
     let cli = Cli::parse();
 
     // Skip initialization for documentation generation
-    if !matches!(cli.command, Commands::GenerateDocs) {
+    if !matches!(
+        cli.command,
+        Commands::GenerateDocs | Commands::Upgrade { .. }
+    ) {
         setup_logging().unwrap();
         initialize_project_id_and_region().await;
     }
@@ -448,6 +457,9 @@ async fn main() {
                 );
 
             println!("{}", output);
+        }
+        Commands::Upgrade { check } => {
+            commands::upgrade::handle_upgrade(check).await;
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new self-upgrade feature to the InfraWeave CLI, allowing users to check for and install the latest released version directly from the command line. The implementation leverages the `self_update` and `semver` crates, adds a new subcommand, and ensures the upgrade logic is integrated smoothly with the CLI's async runtime and initialization flow.

**Upgrade feature implementation:**

* Added `self_update` and `semver` dependencies to `Cargo.toml` to support version management and self-updating capabilities.
* Created a new `upgrade` command module (`cli/src/commands/upgrade.rs`) that checks the current version, fetches the latest stable release from GitHub, and performs the upgrade if requested. The logic includes robust error handling and user messaging.

**CLI command integration:**

* Registered the new `Upgrade` subcommand in the CLI, with a `--check` flag to only check for updates without installing.
* Updated the CLI initialization logic to skip project setup for both documentation generation and upgrade commands, ensuring correct behavior for these special cases.
* Integrated the upgrade handler into the main command dispatch, invoking the upgrade logic asynchronously when the subcommand is used.