### PR TITLE
fix: add resource_changes to track sanitized changes in a structured format

### DIFF
--- a/defs/src/infra_change_record.rs
+++ b/defs/src/infra_change_record.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::resource_change::SanitizedResourceChange;
+
 pub fn get_change_record_identifier(
     project_id: &str,
     region: &str,
@@ -25,14 +27,14 @@ pub struct InfraChangeRecord {
     // TODO: add variables since it might be interesting here
     pub epoch: u128,
     pub timestamp: String,
-    /// Human-readable text output from terraform command.
-    /// For plan commands: contains `terraform plan` stdout showing planned changes.
-    /// For apply/destroy commands: contains `terraform apply/destroy` stdout showing
-    /// what actually happened (including "Apply complete! Resources: 2 added, 0 changed, 0 destroyed").
+    /// Human-readable terraform output (plan/apply/destroy stdout)
     pub plan_std_output: String,
-    /// Storage key/path to the raw JSON output from terraform show.
-    /// For plan commands: points to `{command}_{job_id}_plan_output.json`
-    /// For apply commands: points to `{command}_{job_id}_apply_output.json`
-    /// The actual file path distinguishes between planned vs applied changes.
+    /// Storage key for raw Terraform plan JSON (from `terraform show -json planfile`).
+    /// Always contains the plan, even for apply/destroy. Stored in blob storage for compliance.
+    /// Use `resource_changes` for non-sensitive audit trails.
     pub plan_raw_json_key: String,
+    /// Sanitized resource changes (addresses and actions only, no sensitive values).
+    /// Optional for backward compatibility.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resource_changes: Vec<SanitizedResourceChange>,
 }

--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -13,6 +13,7 @@ mod notification;
 mod oci;
 mod policy;
 mod resource;
+mod resource_change;
 mod stack;
 mod tfprovider;
 
@@ -47,5 +48,9 @@ pub use policy::{
     deserialize_policy_manifest, get_policy_identifier, PolicyManifest, PolicyResp, PolicyResult,
 };
 pub use resource::ResourceResp;
+pub use resource_change::{
+    sanitize_resource_changes, sanitize_resource_changes_from_plan, ResourceAction, ResourceMode,
+    SanitizedResourceChange,
+};
 pub use stack::StackManifest;
 pub use tfprovider::{Metadata as ProviderMetaData, ProviderManifest, ProviderResp, ProviderSpec};

--- a/terraform_runner/src/lib.rs
+++ b/terraform_runner/src/lib.rs
@@ -17,8 +17,8 @@ pub use opa::{
 pub use read::read_module_from_file;
 pub use runner::{run_terraform_runner, setup_misc};
 pub use terraform::{
-    run_terraform_command, set_up_provider_mirror, terraform_apply_destroy, terraform_init,
-    terraform_output, terraform_plan, terraform_show, terraform_show_after_apply,
+    record_apply_destroy_changes, run_terraform_command, set_up_provider_mirror,
+    terraform_apply_destroy, terraform_init, terraform_output, terraform_plan, terraform_show,
     terraform_validate,
 };
 pub use utils::get_env_var;


### PR DESCRIPTION
This pull request introduces improvements to the way infrastructure change records are captured and stored during Terraform operations, with a focus on better auditability and compliance. The main changes include adding a sanitized summary of resource changes to `InfraChangeRecord`, refactoring how apply/destroy operations are recorded, and updating imports and exports to support these features.

### Infrastructure Change Record Enhancements

* Added a new `resource_changes` field to the `InfraChangeRecord` struct, which stores a sanitized summary of resource changes (addresses and actions only, no sensitive values). This field is optional and designed for non-sensitive audit trails.

### Recording Apply/Destroy Operations

* Refactored the logic for capturing apply/destroy operations: replaced the previous `terraform_show_after_apply` function with `record_apply_destroy_changes`, which now reads the plan file and extracts sanitized resource changes for compliance and audit tracking. [[1]](diffhunk://#diff-df0568d93755a170be598c2f1ed4459ec500e7e073503946f8c4cc1b71a60f3aL177-R178) [[2]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07L408-L493)

### Resource Change Sanitization Integration

* Integrated resource change sanitization by calling `sanitize_resource_changes_from_plan` when creating change records, ensuring only non-sensitive data is captured. [[1]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07R364-R365) [[2]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07L371-R379)

### Imports and Exports Updates

* Updated imports and public exports in `defs/src/lib.rs` and `terraform_runner/src/lib.rs` to include new resource change sanitization utilities and types. [[1]](diffhunk://#diff-dce60921cb288dcb0912a027091cc4fb5fd26c31685984760735db157e08ef08R16) [[2]](diffhunk://#diff-dce60921cb288dcb0912a027091cc4fb5fd26c31685984760735db157e08ef08R51-R54) [[3]](diffhunk://#diff-04b487c8215f20a2726287d98fce7a42c35744d2bcc74c80e5e6bbea620db500L20-R21) [[4]](diffhunk://#diff-de4d2b280de55401076180ef5bb4ccad8726ec5c8145ccd328ce72df5a17eb07L4-R7) [[5]](diffhunk://#diff-df0568d93755a170be598c2f1ed4459ec500e7e073503946f8c4cc1b71a60f3aL19-R21)

These changes collectively improve the compliance, auditability, and maintainability of infrastructure change tracking in the codebase.