### PR TITLE
fix: hide sensitive output in terraform runner

### DIFF
--- a/terraform_runner/src/cmd.rs
+++ b/terraform_runner/src/cmd.rs
@@ -86,10 +86,10 @@ pub async fn run_generic_command(
         .fold(String::new(), |acc, line| acc + line.as_str() + "\n");
 
     if !exist_status.success() {
-        println!(
-            "cmd: {:?}, std: {}\nerr: {}",
-            exec, stdout_text, stderr_text
-        );
+        println!("Command failed with stderr:\n{}", stderr_text);
+        if !stdout_text.is_empty() {
+            println!("stdout:\n{}", stdout_text);
+        }
         return Err(anyhow!("{}", stderr_text));
     }
 

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -82,7 +82,7 @@ pub async fn run_terraform_command(
         exec.arg("-lock=false");
     }
 
-    println!("Running terraform command:\n{:?}", exec.as_std());
+    println!("Running terraform command: terraform {}", command);
 
     if init {
         GenericCloudHandler::default()
@@ -337,7 +337,6 @@ pub async fn terraform_show(
     {
         Ok(command_result) => {
             println!("Terraform {} successful", cmd);
-            println!("Output: {}", command_result.stdout);
 
             let tf_plan = "./tf_plan.json";
             let tf_plan_file_path = Path::new(tf_plan);
@@ -484,7 +483,6 @@ pub async fn terraform_show_after_apply(
     {
         Ok(command_result) => {
             println!("Terraform {} after apply successful", cmd);
-            println!("Output: {}", command_result.stdout);
 
             let plan_raw_json_key = format!(
                 "{}{}/{}/{}_{}_apply_output.json",
@@ -652,7 +650,6 @@ pub async fn terraform_output(
     {
         Ok(command_result) => {
             println!("Terraform {} successful", cmd);
-            println!("Output: {}", command_result.stdout);
 
             let output = match serde_json::from_str(command_result.stdout.as_str()) {
                 Ok(json) => json,


### PR DESCRIPTION
This pull request primarily improves code readability and output clarity in several modules related to deployment and Terraform command execution. The most significant changes include formatting improvements for function calls, enhanced error reporting, and cleaner logging of command execution results.

**Code readability and formatting:**
* Reformatted multi-argument function calls in `env_azure/src/api.rs` and `env_common/src/logic/api_infra.rs` to use multi-line formatting, improving readability and maintainability. 

**Terraform command output and logging:**
* Simplified error reporting in `terraform_runner/src/cmd.rs` by printing only stderr when a command fails and conditionally printing stdout, making error messages clearer.
* Improved logging in `terraform_runner/src/terraform.rs` by printing a concise command summary instead of the full command object, and removed redundant output logs after successful Terraform commands to reduce log noise. 