### PR TITLE
feat: make operator stateless

### DIFF
--- a/crd-templator/templates/module_crd_template.yaml
+++ b/crd-templator/templates/module_crd_template.yaml
@@ -71,6 +71,14 @@ spec:
                   type: string
                 lastGeneration:
                   type: integer
+                jobId:
+                  type: string
+                deploymentId:
+                  type: string
+                retryCount:
+                  type: integer
+                lastFailureEpoch:
+                  type: integer
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -86,7 +94,3 @@ spec:
           type: string
           jsonPath: .status.lastCheck
           description: The time of the last check of status update
-        - name: ResourceId
-          type: string
-          jsonPath: .metadata.annotations.deploymentId
-          description: The unique identifier of the resource deployment

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -13,7 +13,7 @@ mod operator_tests {
         config::{KubeConfigOptions, Kubeconfig},
         Client, Config,
     };
-    use operator::operator::{list_and_apply_modules, start_infraweave_watcher};
+    use operator::operator::{list_and_apply_modules, start_infraweave_controllers};
     use pretty_assertions::assert_eq;
     use rustls::crypto::CryptoProvider;
     use std::{env, fs, time::Duration};
@@ -76,8 +76,8 @@ mod operator_tests {
                 Err(e) => eprintln!("Failed to list and apply modules: {:?}", e),
             }
 
-            // Start the watcher
-            start_infraweave_watcher(&handler, client.clone());
+            // Start the controllers
+            start_infraweave_controllers(&handler, client.clone());
 
             sleep(Duration::from_secs(3)).await;
 
@@ -141,7 +141,7 @@ spec:
 
             assert_eq!(
                 resource_status,
-                "Apply - in progress"
+                "Apply - initiated"
             );
 
             // Set deployment status to successful in database to simulate successful deployment (since start_runner is mocked)
@@ -174,7 +174,7 @@ spec:
 
             assert_eq!(
                 resource_status,
-                "Apply - completed"
+                "Apply - successful"
             );
 
             // TODO: Use real runner in test_api.py so change records can be fetched


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the operator, integration tests, CRD templates, and Dockerfile to enhance maintainability and deployment efficiency. The most significant changes include a switch to controller-based architecture in the operator, updates to deployment status terminology in tests, and a multi-stage Dockerfile refactor using `cargo-chef` for optimized Rust builds.

**Operator architecture and integration tests:**
* Replaced the watcher pattern with controller-based logic by renaming and updating `start_infraweave_watcher` to `start_infraweave_controllers` in both imports and usage within `integration-tests/tests/operator.rs`. This reflects a move towards a more scalable and idiomatic Kubernetes operator design. [[1]](diffhunk://#diff-4f20a509c6071257a527cce18281fe30fc5fc611d6a413bcaa4a56261b081944L16-R16) [[2]](diffhunk://#diff-4f20a509c6071257a527cce18281fe30fc5fc611d6a413bcaa4a56261b081944L67-R68)
* Updated deployment status assertions in integration tests to use new terminology: "Apply - in progress" → "Apply - initiated" and "Apply - completed" → "Apply - successful", aligning test expectations with revised status semantics. [[1]](diffhunk://#diff-4f20a509c6071257a527cce18281fe30fc5fc611d6a413bcaa4a56261b081944L132-R132) [[2]](diffhunk://#diff-4f20a509c6071257a527cce18281fe30fc5fc611d6a413bcaa4a56261b081944L165-R165)

**CRD schema and printer columns:**
* Added new fields (`jobId`, `deploymentId`, `retryCount`, `lastFailureEpoch`) to the CRD schema in `module_crd_template.yaml`, enabling richer status tracking for deployments.
* Removed the `ResourceId` printer column from the CRD template, streamlining the displayed resource information.

**Build and deployment optimizations:**
* Refactored the `operator/Dockerfile` to use a multi-stage build with `cargo-chef`, significantly improving build caching and efficiency for Rust dependencies and application code.

**Minor code improvements:**
* Reformatted long lines for readability in Rust API and logic files (`env_azure/src/api.rs` and `env_common/src/logic/api_infra.rs`). [[1]](diffhunk://#diff-4ac929c084c81cc1478eba6a96ba8cc0d7ec66003c88b094012e68d20cb7d3aaL298-R301) [[2]](diffhunk://#diff-6486743bc180c0b33b2da638a4afd27076bebfc2bb2ff82c1fd1fa325aa1fea8L487-R493)