### PR TITLE
ci: remove unit-tests in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,3 @@ repos:
         args: ["clippy"]
         language: system
         pass_filenames: false
-
-      - id: make-unit-tests
-        name: check unit tests
-        entry: make unit-tests
-        language: system
-        pass_filenames: false


### PR DESCRIPTION
This pull request makes a small change to the `.pre-commit-config.yaml` file, specifically removing the pre-commit hook that checked unit tests. This means unit tests will no longer be run automatically as part of the pre-commit process.