### PR TITLE
feat: add variables to change record

### DIFF
--- a/defs/src/infra_change_record.rs
+++ b/defs/src/infra_change_record.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::resource_change::SanitizedResourceChange;
 
@@ -24,7 +25,6 @@ pub struct InfraChangeRecord {
     pub environment: String,
     pub change_type: String, // plan or apply
     pub module_version: String,
-    // TODO: add variables since it might be interesting here
     pub epoch: u128,
     pub timestamp: String,
     /// Human-readable terraform output (plan/apply/destroy stdout)
@@ -37,4 +37,5 @@ pub struct InfraChangeRecord {
     /// Optional for backward compatibility.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub resource_changes: Vec<SanitizedResourceChange>,
+    pub variables: Value,
 }

--- a/env_common/src/interface/deployment_status_handler.rs
+++ b/env_common/src/interface/deployment_status_handler.rs
@@ -153,6 +153,10 @@ impl<'a> DeploymentStatusHandler<'a> {
         self.tf_resources = tf_resources
     }
 
+    pub fn get_variables(&self) -> Value {
+        self.variables.clone()
+    }
+
     pub async fn send_event(&self, handler: &GenericCloudHandler) {
         let epoch = get_epoch();
         let event = EventData {

--- a/terraform_runner/src/runner.rs
+++ b/terraform_runner/src/runner.rs
@@ -47,7 +47,7 @@ pub async fn run_terraform_runner(
     // To reduce clutter, a DeploymentStatusHandler is used to handle the status updates
     // since we will be updating the status multiple times and only a few fields change each time
     let mut status_handler =
-        initiate_deployment_status_handler(initial_deployment, &payload_with_variables);
+        initiate_deployment_status_handler(&initial_deployment, &payload_with_variables);
     let job_id = get_current_job_id(&handler, &mut status_handler).await;
 
     ensure_valid_job_id(
@@ -189,8 +189,15 @@ async fn terraform_flow<'a>(
         let apply_output_str = apply_result.as_ref().map(|s| s.as_str()).unwrap_or("");
 
         // Record the apply/destroy operation in the change history
-        match record_apply_destroy_changes(payload, job_id, &module, apply_output_str, handler)
-            .await
+        match record_apply_destroy_changes(
+            payload,
+            job_id,
+            &module,
+            apply_output_str,
+            handler,
+            status_handler,
+        )
+        .await
         {
             Ok(_) => {
                 println!("Successfully recorded apply/destroy changes");
@@ -391,10 +398,10 @@ async fn get_current_job_id(
     }
 }
 
-fn initiate_deployment_status_handler(
-    initial_deployment: Option<DeploymentResp>,
-    payload_with_variables: &ApiInfraPayloadWithVariables,
-) -> DeploymentStatusHandler<'_> {
+fn initiate_deployment_status_handler<'a>(
+    initial_deployment: &Option<DeploymentResp>,
+    payload_with_variables: &'a ApiInfraPayloadWithVariables,
+) -> DeploymentStatusHandler<'a> {
     let payload = &payload_with_variables.payload;
     let command = &payload.command;
     let environment = &payload.environment;
@@ -430,7 +437,7 @@ fn initiate_deployment_status_handler(
             Value::Null
         },
         if let Some(deployment) = initial_deployment {
-            deployment.policy_results
+            deployment.policy_results.clone()
         } else {
             vec![]
         },

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -377,6 +377,7 @@ pub async fn terraform_show(
                     environment: environment.clone(),
                     change_type: command.to_string(),
                     resource_changes,
+                    variables: status_handler.get_variables(),
                 };
                 match insert_infra_change_record(
                     handler,
@@ -417,6 +418,7 @@ pub async fn record_apply_destroy_changes(
     module: &env_defs::ModuleResp,
     apply_output: &str,
     handler: &GenericCloudHandler,
+    status_handler: &DeploymentStatusHandler<'_>,
 ) -> Result<(), anyhow::Error> {
     // Extract resource changes from the plan JSON (what was approved before execution)
     let (resource_changes, raw_plan_json) = match tokio::fs::read_to_string("./tf_plan.json").await
@@ -458,6 +460,7 @@ pub async fn record_apply_destroy_changes(
         environment: payload.environment.clone(),
         change_type: payload.command.clone(),
         resource_changes,
+        variables: status_handler.get_variables(),
     };
 
     let _record_id = insert_infra_change_record(handler, infra_change_record, &raw_plan_json)


### PR DESCRIPTION
This pull request introduces support for tracking deployment variables in infrastructure change records, ensuring that variable data is captured and stored alongside resource changes during Terraform operations. The changes span multiple modules and update core data structures and function signatures to enable this new functionality.

**Infrastructure change record enhancements:**

* Added a new `variables` field of type `Value` to the `InfraChangeRecord` struct in `defs/src/infra_change_record.rs`, enabling storage of deployment variables with each change record. 

**Deployment status handler updates:**

* Implemented a `get_variables` method in `DeploymentStatusHandler` to retrieve the current deployment variables, supporting their inclusion in change records.

**Terraform runner and flow adjustments:**

* Updated the `initiate_deployment_status_handler` function signature to take references, improving lifetime management and ensuring correct variable handling. 
* Modified the `record_apply_destroy_changes` function and its callers to accept a `DeploymentStatusHandler` reference, allowing variables to be passed and recorded during apply/destroy operations. 
* Ensured that the `variables` field is populated in all relevant places where `InfraChangeRecord` is created, including during `terraform_show` and apply/destroy recording. 