### PR TITLE
fix: allow destroy when empty tf resources

### DIFF
--- a/terraform_runner/src/runner.rs
+++ b/terraform_runner/src/runner.rs
@@ -176,14 +176,16 @@ async fn terraform_flow<'a>(
 
         // Always capture the current state resources, even if apply/destroy failed partway through
         // This ensures we have an accurate record of what resources actually exist
-        match terraform_state_list().await {
+        let captured_resources = match terraform_state_list().await {
             Ok(tf_resources) => {
-                status_handler.set_resources(tf_resources);
+                status_handler.set_resources(tf_resources.clone());
+                tf_resources
             }
             Err(e) => {
                 println!("Warning: Failed to capture resource list: {:?}", e);
+                None
             }
-        }
+        };
 
         // Extract output for subsequent operations
         let apply_output_str = apply_result.as_ref().map(|s| s.as_str()).unwrap_or("");
@@ -200,8 +202,28 @@ async fn terraform_flow<'a>(
             }
         }
 
-        // Re-propagate the error if apply/destroy failed, but only after capturing resources and change records
-        apply_result?;
+        // Handle apply/destroy errors after capturing resources and change records
+        if let Err(e) = apply_result {
+            let is_destroy = command == "destroy";
+            let has_no_resources = captured_resources
+                .as_ref()
+                .map(|r| r.is_empty())
+                .unwrap_or(false);
+
+            // Allow destroy to proceed if there are no resources in state
+            // This prevents users from getting stuck when trying to clean up deployments
+            // that have no actual infrastructure resources
+            if is_destroy && has_no_resources {
+                println!(
+                    "Destroy failed but no resources exist in state - proceeding with cleanup: {:?}",
+                    e
+                );
+                status_handler.set_deleted(true);
+            } else {
+                // Re-propagate error for apply failures or destroy with existing resources
+                return Err(e);
+            }
+        }
 
         // Only get outputs for apply command (destroy has no outputs since resources are gone)
         if command == "apply" {


### PR DESCRIPTION
This pull request refines the error handling logic in the `terraform_flow` function, specifically for the Terraform destroy operation. The changes ensure that destroy errors do not block cleanup when no resources exist, improving user experience during teardown scenarios.

Resolves https://github.com/infraweave-io/infraweave/issues/177

**Error handling improvements:**

* Updated the resource capture logic to store the result of `terraform_state_list` in a variable, allowing subsequent error checks and resource existence validation. (`terraform_runner/src/runner.rs`)
* Enhanced error propagation after apply/destroy by allowing destroy operations to proceed without error if no resources exist in state, preventing users from getting stuck during cleanup. The error is only re-propagated if resources remain or if the command is apply. (`terraform_runner/src/runner.rs`)