### PR TITLE
fix: show tf_resources in deployment in tui

### DIFF
--- a/cli/src/tui/renderers/detail_renderer.rs
+++ b/cli/src/tui/renderers/detail_renderer.rs
@@ -615,6 +615,45 @@ fn build_deployment_detail_content(
             lines.push(Line::from(""));
         }
 
+        // TF Resources subsection
+        if let Some(ref resources) = deployment.tf_resources {
+            if !resources.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "Terraform Resources",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )));
+                lines.push(Line::from(Span::styled(
+                    "─".repeat(40),
+                    Style::default().fg(Color::DarkGray),
+                )));
+
+                lines.push(Line::from(vec![
+                    Span::styled("Total: ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        resources.len().to_string(),
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ]));
+                lines.push(Line::from(""));
+
+                for (idx, resource) in resources.iter().enumerate() {
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            format!("  {}. ", idx + 1),
+                            Style::default().fg(Color::DarkGray),
+                        ),
+                        Span::styled(resource.clone(), Style::default().fg(Color::Green)),
+                    ]));
+                }
+
+                lines.push(Line::from(""));
+            }
+        }
+
         return lines;
     }
     current_idx += 1;


### PR DESCRIPTION
This pull request adds a new section to the deployment detail view in the TUI renderer to display information about Terraform resources. The section is only rendered when there are resources available, and includes a styled header, a count of resources, and a formatted list of resource names.

Terraform resources display:

* Added a "Terraform Resources" subsection to `build_deployment_detail_content` in `cli/src/tui/renderers/detail_renderer.rs`, showing the total count and a styled list of resources when present.