### PR TITLE
feat: enhance python set_variables to merge with existing variables

### DIFF
--- a/defs/src/infra_change_record.rs
+++ b/defs/src/infra_change_record.rs
@@ -37,5 +37,8 @@ pub struct InfraChangeRecord {
     /// Optional for backward compatibility.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub resource_changes: Vec<SanitizedResourceChange>,
+    /// Variables used for the deployment.
+    /// Optional for backward compatibility with older change records.
+    #[serde(default)]
     pub variables: Value,
 }

--- a/infraweave_py/test.py
+++ b/infraweave_py/test.py
@@ -39,10 +39,8 @@ with bucket1:
     print(res)
     print(res.get_output())
 
-    bucket1.set_variables(
-        bucket_name="my-bucket12347ydfs4",
-        enable_acl=False,
-    )
+    # Only change the bucket name, keep other settings same
+    bucket1.set_variables(bucket_name="my-bucket12347ydfs4")
     res = bucket1.plan()
     print(res)
     print(f"is destructive: {res.has_destructive_changes()}")


### PR DESCRIPTION
This pull request updates the logic for setting deployment variables in the `Deployment` struct, making it more flexible and less destructive. Instead of overwriting all existing variables when new ones are set, the method now merges new variables into the existing set, allowing incremental updates.

Improvements to variable management:

* The `set_variables` method now merges provided Python keyword arguments into the existing `variables` field, rather than replacing it entirely. This enables setting or updating individual variables without removing previously set values.
* The merging logic checks if both the new and existing variables are JSON objects, and if so, updates the existing map with new key-value pairs; otherwise, it replaces the entire variable set.