### PR TITLE
fix: add module stack yaml validation

### DIFF
--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -609,6 +609,12 @@ fn validate_module_name(module_manifest: &ModuleManifest) -> anyhow::Result<(), 
             module_name
         )));
     }
+    if !module_name.chars().all(|c| c.is_alphanumeric()) {
+        return Err(ModuleError::ValidationError(format!(
+            "The moduleName {} must only contain alphanumeric characters (no hyphens, underscores, or special characters).",
+            module_name
+        )));
+    }
     if module_name.to_lowercase() != name {
         return Err(ModuleError::ValidationError(format!(
             "The name {} must exactly match lowercase of the moduleName specified under spec {}.",
@@ -1344,6 +1350,46 @@ bucketName: some-bucket-name
             name: s3bucket
         spec:
             moduleName: s3Bucket
+            version: 0.2.1
+            providers: []
+            reference: https://github.com/your-org/s3bucket
+            description: "S3Bucket description here..."
+        "#;
+        let module_manifest: ModuleManifest = serde_yaml::from_str(yaml_manifest).unwrap();
+
+        let result = validate_module_name(&module_manifest);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_validate_module_name_must_be_alphanumeric() {
+        let yaml_manifest = r#"
+        apiVersion: infraweave.io/v1
+        kind: Module
+        metadata:
+            name: s3bucket
+        spec:
+            moduleName: S3-Bucket
+            version: 0.2.1
+            providers: []
+            reference: https://github.com/your-org/s3bucket
+            description: "S3Bucket description here..."
+        "#;
+        let module_manifest: ModuleManifest = serde_yaml::from_str(yaml_manifest).unwrap();
+
+        let result = validate_module_name(&module_manifest);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_validate_module_name_must_be_alphanumeric_no_underscore() {
+        let yaml_manifest = r#"
+        apiVersion: infraweave.io/v1
+        kind: Module
+        metadata:
+            name: s3_bucket
+        spec:
+            moduleName: S3_Bucket
             version: 0.2.1
             providers: []
             reference: https://github.com/your-org/s3bucket

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -697,6 +697,12 @@ fn validate_stack_name(stack_manifest: &StackManifest) -> anyhow::Result<(), Mod
             stack_name
         )));
     }
+    if !stack_name.chars().all(|c| c.is_alphanumeric()) {
+        return Err(ModuleError::ValidationError(format!(
+            "The stackName {} must only contain alphanumeric characters (no hyphens, underscores, or special characters).",
+            stack_name
+        )));
+    }
     if stack_name.to_lowercase() != name {
         return Err(ModuleError::ValidationError(format!(
             "The name {} must exactly match lowercase of the stackName specified under spec {}.",
@@ -2579,6 +2585,44 @@ output "bucket2__list_of_strings" {
             name: webpagerunner
         spec:
             stackName: webpageRunner
+            version: 0.2.1
+            reference: https://github.com/your-org/webpage-runner
+            description: "Webpage runner description here..."
+        "#;
+        let stack_manifest: StackManifest = serde_yaml::from_str(yaml_manifest).unwrap();
+
+        let result = validate_stack_name(&stack_manifest);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_validate_stack_name_must_be_alphanumeric() {
+        let yaml_manifest = r#"
+        apiVersion: infraweave.io/v1
+        kind: Stack
+        metadata:
+            name: webpage-runner
+        spec:
+            stackName: Webpage-Runner
+            version: 0.2.1
+            reference: https://github.com/your-org/webpage-runner
+            description: "Webpage runner description here..."
+        "#;
+        let stack_manifest: StackManifest = serde_yaml::from_str(yaml_manifest).unwrap();
+
+        let result = validate_stack_name(&stack_manifest);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_validate_stack_name_must_be_alphanumeric_no_underscore() {
+        let yaml_manifest = r#"
+        apiVersion: infraweave.io/v1
+        kind: Stack
+        metadata:
+            name: webpage_runner
+        spec:
+            stackName: Webpage_Runner
             version: 0.2.1
             reference: https://github.com/your-org/webpage-runner
             description: "Webpage runner description here..."


### PR DESCRIPTION
This pull request adds stricter validation for both module and stack manifests, ensuring that their names and kinds conform to specific requirements. It also introduces comprehensive unit tests to verify these new validation rules.

Validation improvements:

* Added `validate_module_kind` and `validate_stack_kind` functions to enforce that the `kind` field in module and stack manifests must be `"Module"` and `"Stack"` respectively. These checks are now called during publishing. 
* Enhanced `validate_module_name` and `validate_stack_name` to require that names start with an uppercase character and contain only alphanumeric characters (no hyphens, underscores, or special characters). 

Testing:

* Added unit tests for the new `kind` and name validation logic in both module and stack manifests, covering valid and invalid cases for uppercase and alphanumeric constraints. 