### PR TITLE
fix: add variable name roundtrip verification and error handling

### DIFF
--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -73,6 +73,9 @@ pub enum ModuleError {
     #[error("No terraform required_providers defined in a '.tf' file for \"{0}\"")]
     NoRequiredProvidersDefined(String),
 
+    #[error("Invalid variable naming: {0}")]
+    InvalidVariableNaming(String),
+
     #[error("Reference \"{0}\" could not be resolved using key \"{1}\"")]
     UnresolvedReference(String, String),
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -61,7 +61,7 @@ pub use terraform::{
 pub use time::{epoch_to_timestamp, get_epoch, get_timestamp};
 pub use variables::{
     verify_required_variables_are_set, verify_variable_claim_casing,
-    verify_variable_existence_and_type,
+    verify_variable_existence_and_type, verify_variable_name_roundtrip,
 };
 pub use versioning::{
     get_version_track, semver_parse, semver_parse_without_build, zero_pad_semver,

--- a/utils/src/string_utils.rs
+++ b/utils/src/string_utils.rs
@@ -92,4 +92,68 @@ mod tests {
         let actual = to_snake_case(input);
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn test_roundtrip_edge_cases_pass() {
+        // Test cases that should pass roundtrip conversion
+        let passing_cases = vec![
+            ("http2_enabled", "number in middle of word"),
+            ("s3_bucket", "number at start of word"),
+            ("my_v2_api", "number between words"),
+            ("ipv4_address", "number in middle of first word"),
+            ("api_v1", "number at end"),
+            ("normal_name", "snake_case"),
+            ("bucket_name", "standard snake_case"),
+            ("enable_logging", "standard snake_case"),
+            ("port8080", "number at end of word"),
+        ];
+
+        for (original, description) in passing_cases {
+            let camel = to_camel_case(original);
+            let back = to_snake_case(&camel);
+
+            println!(
+                "PASS {}: '{}' -> '{}' -> '{}'",
+                description, original, camel, back
+            );
+
+            assert_eq!(
+                original, back,
+                "Expected '{}' ({}) to pass roundtrip",
+                original, description
+            );
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_edge_cases_fail() {
+        // Test cases that should fail roundtrip conversion
+        let failing_cases = vec![
+            ("port_8080", "number after underscore"),
+            ("x_123_test", "pure number segment"),
+            ("test_123", "ends with pure number"),
+            ("bucket__name", "double underscore"),
+            ("_private", "leading underscore"),
+            ("trailing_", "trailing underscore"),
+            ("normalName", "camelCase"),
+            ("NormalName", "PascalCase"),
+            ("a_b_c", "multiple single letters"),
+        ];
+
+        for (original, description) in failing_cases {
+            let camel = to_camel_case(original);
+            let back = to_snake_case(&camel);
+
+            println!(
+                "FAIL {}: '{}' -> '{}' -> '{}'",
+                description, original, camel, back
+            );
+
+            assert_ne!(
+                original, back,
+                "Expected '{}' ({}) to fail roundtrip, but it passed",
+                original, description
+            );
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces stricter validation for Terraform variable naming to ensure that all variable names can safely roundtrip between snake_case and camelCase without loss of information. This helps prevent subtle bugs when variable names are converted for API usage. The changes include a new verification function, integration into the module publishing workflow, expanded error handling, and comprehensive test coverage for edge cases.

**Variable Naming Validation**

* Added the `verify_variable_name_roundtrip` function in `utils/src/variables.rs` to check that Terraform variable names survive conversion from snake_case to camelCase and back, ensuring only safe naming patterns are used. Variables prefixed with `INFRAWEAVE_` are exempt from this check.
* Integrated the roundtrip variable name verification into the `publish_module_from_zip` workflow in `env_common/src/logic/api_module.rs`, causing publishing to fail if any variable names are invalid.
* Introduced a new error variant `InvalidVariableNaming` to `ModuleError` in `env_common/src/errors.rs` for reporting variable naming issues.

**Testing**

* Added extensive unit tests for `verify_variable_name_roundtrip` in `utils/src/variables.rs`, covering valid cases, expected failures (e.g., camelCase, double underscores, numbers after underscores), and mixed valid/invalid scenarios.
* Added roundtrip edge case tests for string conversion functions in `utils/src/string_utils.rs`, verifying correct handling of snake_case and camelCase conversions.

**Imports and Exports**

* Updated module imports/exports in `env_common/src/logic/api_module.rs` and `utils/src/lib.rs` to include the new verification function. 