### PR TITLE
fix: add object to quick variable validation (shortened)

### DIFF
--- a/utils/src/variables.rs
+++ b/utils/src/variables.rs
@@ -60,7 +60,7 @@ pub fn verify_variable_existence_and_type(
                     serde_json::Value::Bool(_) => "bool",
                     serde_json::Value::Number(_) => "number",
                     serde_json::Value::String(val) => {
-                        if val.starts_with("map(") {
+                        if val.starts_with("map(") || val.starts_with("object(") {
                             // Covers map(string), map(number), etc.
                             "object"
                         } else if val.starts_with("list(") || val.starts_with("set(") {


### PR DESCRIPTION
This pull request makes a small update to the logic for variable type detection in the `verify_variable_existence_and_type` function. The change expands the check for object types to also recognize values starting with `object(`, in addition to the previous support for `map(`.

* Improved detection of object types by treating strings starting with `object(` as `"object"` types in `verify_variable_existence_and_type` in `utils/src/variables.rs`.