### PR TITLE
docs: add python properties

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pip install --upgrade pip
-          pip install maturin==1.7.5 mkdocs-material
+          pip install maturin==1.7.5 mkdocs-material griffe
           pip install -e .
 
       - name: Build & install the extension

--- a/docs/plugins/python_docs_plugin.py
+++ b/docs/plugins/python_docs_plugin.py
@@ -27,6 +27,19 @@ class PythonDocsPlugin(BasePlugin):
         if cls.docstring:
             lines.append(f"{cls.docstring.value}\n\n")
         
+        # Get properties (getters/setters - attributes in PyO3)
+        properties = [
+            m for m in cls.members.values() 
+            if m.is_attribute and not m.name.startswith('_')
+        ]
+        
+        if properties:
+            lines.append(f"## Properties\n\n")
+            for prop in properties:
+                lines.append(f"### `{prop.name}`\n\n")
+                if prop.docstring:
+                    lines.append(f"{prop.docstring.value}\n\n")
+        
         # Get methods (excluding private and special methods except __init__, __enter__, __exit__)
         methods = [
             m for m in cls.members.values() 

--- a/infraweave_py/src/deployment.rs
+++ b/infraweave_py/src/deployment.rs
@@ -648,6 +648,8 @@ impl Deployment {
             Some(deployment) => match &deployment.output {
                 serde_json::Value::Object(map) => {
                     let types_mod = py.import("types")?;
+                    // Get SimpleNamespace class from Python's types module to create an object
+                    // that allows dot-notation access to Terraform outputs (e.g., outputs.bucket_arn)
                     let simple_ns = types_mod.getattr("SimpleNamespace")?;
                     let json_mod = py.import("json")?;
                     let kwargs = PyDict::new(py);


### PR DESCRIPTION
This pull request introduces improvements to documentation generation and enhances the developer experience. The main changes include adding a new dependency for documentation parsing, improving the Python docs plugin to include class properties in the generated markdown, and clarifying a comment in the Rust code for better readability.

**Documentation tooling and output improvements:**

* Added the `griffe` package to the documentation workflow dependencies in `.github/workflows/docs.yml` to enable advanced Python docstring parsing.
* Enhanced the `render_class_to_markdown` function in `docs/plugins/python_docs_plugin.py` to include a "Properties" section, listing public class attributes with their docstrings in the generated documentation.

**Code clarity:**

* Updated a comment in `infraweave_py/src/deployment.rs` to clarify the use of Python's `SimpleNamespace` for accessing Terraform outputs via dot notation.