### PR TITLE
feat: add output name roundtrip verification and error handling

### DIFF
--- a/env_common/src/errors.rs
+++ b/env_common/src/errors.rs
@@ -76,6 +76,9 @@ pub enum ModuleError {
     #[error("Invalid variable naming: {0}")]
     InvalidVariableNaming(String),
 
+    #[error("Invalid output naming: {0}")]
+    InvalidOutputNaming(String),
+
     #[error("Reference \"{0}\" could not be resolved using key \"{1}\"")]
     UnresolvedReference(String, String),
 

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -12,7 +12,8 @@ use env_utils::{
     get_terraform_lockfile, get_tf_required_providers_from_tf_files, get_timestamp,
     get_variables_from_tf_files, merge_json_dicts, read_tf_from_zip, run_terraform_provider_lock,
     semver_parse, tempdir, validate_module_schema, validate_tf_backend_not_set,
-    validate_tf_extra_environment_variables, verify_variable_name_roundtrip, zero_pad_semver,
+    validate_tf_extra_environment_variables, verify_output_name_roundtrip,
+    verify_variable_name_roundtrip, zero_pad_semver,
 };
 use futures::stream::{self, StreamExt};
 
@@ -332,6 +333,12 @@ pub async fn publish_module_from_zip(
     // (snake_case -> camelCase -> snake_case)
     verify_variable_name_roundtrip(&tf_variables).map_err(|e| {
         ModuleError::InvalidVariableNaming(format!("Module '{}': {}", module_yaml.metadata.name, e))
+    })?;
+
+    // Verify that all output names can survive roundtrip case conversion
+    // (snake_case -> camelCase -> snake_case)
+    verify_output_name_roundtrip(&tf_outputs).map_err(|e| {
+        ModuleError::InvalidOutputNaming(format!("Module '{}': {}", module_yaml.metadata.name, e))
     })?;
 
     let module = module_yaml.metadata.name.clone();

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -60,7 +60,7 @@ pub use terraform::{
 };
 pub use time::{epoch_to_timestamp, get_epoch, get_timestamp};
 pub use variables::{
-    verify_required_variables_are_set, verify_variable_claim_casing,
+    verify_output_name_roundtrip, verify_required_variables_are_set, verify_variable_claim_casing,
     verify_variable_existence_and_type, verify_variable_name_roundtrip,
 };
 pub use versioning::{


### PR DESCRIPTION
This pull request introduces a new validation step for Terraform module outputs to ensure their names use proper snake_case formatting and can survive roundtrip case conversion (snake_case → camelCase → snake_case). This helps prevent naming issues when outputs are exposed via APIs and enforces consistency. The changes include the implementation of the validation logic, integration into the module publishing workflow, error handling, and comprehensive tests.

### Output naming validation

* Added a new function `verify_output_name_roundtrip` in `utils/src/variables.rs` to check that all Terraform output names survive roundtrip case conversion between snake_case and camelCase. It reports errors for names that do not roundtrip properly, such as camelCase, PascalCase, double underscores, or numbers immediately after underscores.
* Added extensive unit tests for `verify_output_name_roundtrip` to cover valid and invalid cases, including edge cases like numbers, double underscores, camelCase, PascalCase, and mixed valid/invalid lists.

### Integration and error handling

* Integrated `verify_output_name_roundtrip` into the module publishing workflow in `env_common/src/logic/api_module.rs`, so modules with invalid output names are rejected during publishing.
* Added a new error variant `InvalidOutputNaming` to the `ModuleError` enum in `env_common/src/errors.rs` for reporting output naming issues.

### Utility exports

* Exported `verify_output_name_roundtrip` in `utils/src/lib.rs` and updated imports in `env_common/src/logic/api_module.rs` to make the function available for use in module logic.