### PR TITLE
feat: add interactive cli choices for environment-id and deployment-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -36,7 +36,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -1369,7 +1369,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1424,9 +1424,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -1887,12 +1887,13 @@ dependencies = [
  "clap",
  "clap-markdown",
  "colored",
- "crossterm",
+ "crossterm 0.28.1",
  "dirs 5.0.1",
  "env_common",
  "env_defs",
  "env_utils",
  "hostname",
+ "inquire",
  "log",
  "openssl",
  "prettytable",
@@ -2047,6 +2048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,11 +2163,29 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
  "rustix 0.38.41",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.0.7",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2458,6 +2486,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -2556,7 +2585,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "objc2",
 ]
 
@@ -2580,6 +2609,15 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -3323,6 +3361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,7 +3502,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "ignore",
  "walkdir",
 ]
@@ -4300,6 +4347,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm 0.29.0",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4976,7 +5037,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.5.7",
 ]
@@ -5004,6 +5065,12 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-channel"
@@ -5414,7 +5481,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -5426,7 +5493,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "dispatch2",
  "objc2",
 ]
@@ -5437,7 +5504,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -5456,7 +5523,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5467,7 +5534,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5651,7 +5718,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -6122,7 +6189,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -6719,10 +6786,10 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "instability",
  "itertools 0.13.0",
  "lru",
@@ -6768,7 +6835,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -7199,7 +7266,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -7212,7 +7279,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -7532,7 +7599,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -7545,7 +7612,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -8237,7 +8304,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -8289,7 +8356,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8330,7 +8397,7 @@ name = "terraform_runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "convert_case",
+ "convert_case 0.6.0",
  "env_aws",
  "env_common",
  "env_defs",
@@ -8703,7 +8770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -9783,7 +9850,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ arboard = "3.4"
 self_update = "0.42"
 semver = "1.0"
 dirs = "5.0"
+inquire = "0.9"
 
 # MCP server dependencies
 rmcp-openapi = "0.20"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -8,4 +8,6 @@ mod utils;
 pub use defs::ClaimJobStruct;
 pub use plan::follow_plan;
 pub use run::run_claim_file;
-pub use utils::{current_region_handler, get_environment};
+pub use utils::{
+    current_region_handler, get_environment, resolve_deployment_id, resolve_environment_id,
+};

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,4 +1,7 @@
 use env_common::interface::GenericCloudHandler;
+use env_defs::CloudProvider;
+use inquire::Select;
+use std::collections::HashSet;
 
 pub fn get_environment(environment_arg: &str) -> String {
     if !environment_arg.contains('/') {
@@ -10,4 +13,87 @@ pub fn get_environment(environment_arg: &str) -> String {
 
 pub async fn current_region_handler() -> GenericCloudHandler {
     GenericCloudHandler::default().await
+}
+
+pub async fn get_available_environments() -> anyhow::Result<Vec<String>> {
+    let handler = current_region_handler().await;
+    let deployments = handler.get_all_deployments("").await?;
+
+    let mut environments: Vec<String> = deployments
+        .iter()
+        .map(|d| d.environment.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    environments.sort();
+    Ok(environments)
+}
+
+pub async fn get_available_deployments(environment: &str) -> anyhow::Result<Vec<String>> {
+    let handler = current_region_handler().await;
+    let deployments = handler.get_all_deployments("").await?;
+
+    let mut deployment_ids: Vec<String> = deployments
+        .iter()
+        .filter(|d| d.environment == environment)
+        .map(|d| d.deployment_id.clone())
+        .collect();
+
+    deployment_ids.sort();
+    Ok(deployment_ids)
+}
+
+pub async fn prompt_select_environment() -> anyhow::Result<String> {
+    let environments = get_available_environments().await?;
+
+    if environments.is_empty() {
+        anyhow::bail!("No environments found. Please specify environment in the command instead.");
+    }
+
+    let selected = Select::new("Select an environment:", environments)
+        .prompt()
+        .map_err(|e| anyhow::anyhow!("Failed to select environment: {}", e))?;
+
+    Ok(selected)
+}
+
+pub async fn prompt_select_deployment(environment: &str) -> anyhow::Result<String> {
+    let deployments = get_available_deployments(environment).await?;
+
+    if deployments.is_empty() {
+        anyhow::bail!("No deployments found in environment '{}'", environment);
+    }
+
+    let selected = Select::new("Select a deployment:", deployments)
+        .prompt()
+        .map_err(|e| anyhow::anyhow!("Failed to select deployment: {}", e))?;
+
+    Ok(selected)
+}
+
+pub async fn resolve_environment_id(environment_id: Option<String>) -> String {
+    match environment_id {
+        Some(id) => id,
+        None => match prompt_select_environment().await {
+            Ok(env) => env,
+            Err(e) => {
+                eprintln!("Error selecting environment: {}", e);
+                std::process::exit(1);
+            }
+        },
+    }
+}
+
+pub async fn resolve_deployment_id(deployment_id: Option<String>, environment: &str) -> String {
+    match deployment_id {
+        Some(id) => id,
+        None => match prompt_select_deployment(environment).await {
+            Ok(dep) => dep,
+            Err(e) => {
+                eprintln!("Error selecting deployment: {}", e);
+                std::process::exit(1);
+            }
+        },
+    }
 }


### PR DESCRIPTION
This pull request adds support for interactive selection of environment and deployment IDs in the CLI, making these arguments optional for many commands. If not provided, the user is prompted to select from available options, improving usability and reducing errors. The implementation includes new utility functions for listing environments/deployments and handling prompts, and updates all affected command argument definitions and handlers.

**Interactive selection and argument handling:**

* Made `environment_id` and `deployment_id` arguments optional for most CLI commands in `cli/src/main.rs`, so users are prompted to select them if not provided. 
* Updated command handlers to resolve missing IDs by prompting the user, using new utility functions `resolve_environment_id` and `resolve_deployment_id`. 

**Utility functions and dependencies:**

* Added `inquire` dependency in `cli/Cargo.toml` for interactive prompts.
* Added new utility functions in `cli/src/utils.rs` for listing available environments and deployments, and for prompting the user to select one if needed.
* Exported new utility functions for use throughout the CLI (`resolve_environment_id`, `resolve_deployment_id`).

These changes make the CLI more user-friendly by guiding users to select valid environments and deployments, reducing the need to remember or look up IDs.