### PR TITLE
fix: add name conflict validation between modules and stacks

### DIFF
--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -383,6 +383,13 @@ pub async fn publish_module_from_zip(
             }
         };
 
+    if let Ok(Some(_existing_stack)) = handler.get_latest_stack_version(&module, "").await {
+        return Err(ModuleError::ValidationError(format!(
+            "A stack with the name '{}' already exists. Modules and stacks cannot share the same name.",
+            module
+        )));
+    }
+
     let version_diff = match latest_version {
         // TODO break out to function
         Some(previous_existing_module) => {

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -582,6 +582,14 @@ pub async fn publish_stack(
         }
     }
 
+    if let Ok(Some(_existing_module)) = handler.get_latest_module_version(&module.module, "").await
+    {
+        return Err(ModuleError::ValidationError(format!(
+            "A module with the name '{}' already exists. Modules and stacks cannot share the same name.",
+            &module.module
+        )));
+    }
+
     let all_regions = handler.get_all_regions().await?;
 
     // Check if TEST_MODE is enabled to determine concurrency limit


### PR DESCRIPTION
This pull request adds validation to prevent naming conflicts between modules and stacks. Specifically, it ensures that a module and a stack cannot share the same name, improving data integrity and preventing ambiguous resource references.

Validation improvements:

* Added a check in `publish_module_from_zip` to return a validation error if a stack with the same name as the module already exists, preventing modules and stacks from sharing names.
* Added a check in `publish_stack` to return a validation error if a module with the same name as the stack already exists, enforcing unique naming between modules and stacks.