### PR TITLE
feat: add optional include_deleted parameter to deployment endpoints

### DIFF
--- a/cli/src/commands/deployment.rs
+++ b/cli/src/commands/deployment.rs
@@ -23,7 +23,7 @@ pub async fn handle_describe(deployment_id: &str, environment: &str) {
 pub async fn handle_list() {
     let deployments = current_region_handler()
         .await
-        .get_all_deployments("")
+        .get_all_deployments("", false)
         .await
         .unwrap();
     println!(

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -805,7 +805,7 @@ impl App {
     pub async fn load_deployments(&mut self) -> Result<()> {
         let deployments = current_region_handler()
             .await
-            .get_all_deployments("")
+            .get_all_deployments("", false)
             .await?;
 
         let mut deployments_vec: Vec<Deployment> = deployments

--- a/defs/src/cloudprovider.rs
+++ b/defs/src/cloudprovider.rs
@@ -114,6 +114,7 @@ pub trait CloudProvider: Send + Sync {
     async fn get_all_deployments(
         &self,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error>;
     async fn get_deployment_and_dependents(
         &self,
@@ -132,6 +133,7 @@ pub trait CloudProvider: Send + Sync {
         &self,
         module: &str,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error>;
     async fn get_plan_deployment(
         &self,

--- a/env_aws/src/provider.rs
+++ b/env_aws/src/provider.rs
@@ -250,10 +250,16 @@ impl CloudProvider for AwsCloudProvider {
     async fn get_all_deployments(
         &self,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
         _get_deployments(
             self,
-            crate::get_all_deployments_query(&self.project_id, &self.region, environment),
+            crate::get_all_deployments_query(
+                &self.project_id,
+                &self.region,
+                environment,
+                include_deleted,
+            ),
         )
         .await
     }
@@ -297,6 +303,7 @@ impl CloudProvider for AwsCloudProvider {
         &self,
         module: &str,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
         _get_deployments(
             self,
@@ -305,6 +312,7 @@ impl CloudProvider for AwsCloudProvider {
                 &self.region,
                 module,
                 environment,
+                include_deleted,
             ),
         )
         .await

--- a/env_azure/src/provider.rs
+++ b/env_azure/src/provider.rs
@@ -219,10 +219,16 @@ impl CloudProvider for AzureCloudProvider {
     async fn get_all_deployments(
         &self,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
         _get_deployments(
             self,
-            crate::get_all_deployments_query(&self.project_id, &self.region, environment),
+            crate::get_all_deployments_query(
+                &self.project_id,
+                &self.region,
+                environment,
+                include_deleted,
+            ),
         )
         .await
     }
@@ -266,6 +272,7 @@ impl CloudProvider for AzureCloudProvider {
         &self,
         module: &str,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
         _get_deployments(
             self,
@@ -274,6 +281,7 @@ impl CloudProvider for AzureCloudProvider {
                 &self.region,
                 module,
                 environment,
+                include_deleted,
             ),
         )
         .await

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -308,8 +308,11 @@ impl CloudProvider for GenericCloudHandler {
     async fn get_all_deployments(
         &self,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
-        self.provider.get_all_deployments(environment).await
+        self.provider
+            .get_all_deployments(environment, include_deleted)
+            .await
     }
     async fn get_deployment_and_dependents(
         &self,
@@ -338,9 +341,10 @@ impl CloudProvider for GenericCloudHandler {
         &self,
         module: &str,
         environment: &str,
+        include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
         self.provider
-            .get_deployments_using_module(module, environment)
+            .get_deployments_using_module(module, environment, include_deleted)
             .await
     }
     async fn get_plan_deployment(

--- a/env_common/src/interface/no_cloud_provider.rs
+++ b/env_common/src/interface/no_cloud_provider.rs
@@ -216,6 +216,7 @@ impl CloudProvider for NoCloudProvider {
     async fn get_all_deployments(
         &self,
         _environment: &str,
+        _include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
         Ok(vec![])
     }
@@ -242,6 +243,7 @@ impl CloudProvider for NoCloudProvider {
         &self,
         _module: &str,
         _environment: &str,
+        _include_deleted: bool,
     ) -> Result<Vec<DeploymentResp>, anyhow::Error> {
         Ok(vec![])
     }

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -148,7 +148,7 @@ spec:
             let lambda_endpoint_url = "http://127.0.0.1:8081";
             let handler2 = GenericCloudHandler::custom(lambda_endpoint_url).await;
 
-            let all_deployments = handler2.get_all_deployments(&environment).await.unwrap();
+            let all_deployments = handler2.get_all_deployments(&environment, false).await.unwrap();
             println!("All deployments: {:?}", all_deployments);
             let deployment = all_deployments.first();
             assert_eq!(deployment.is_some(), true);

--- a/operator/src/operator.rs
+++ b/operator/src/operator.rs
@@ -1335,7 +1335,7 @@ async fn fetch_and_apply_exising_deployments(
 ) -> Result<(), anyhow::Error> {
     let cluster_name = "my-k8s-cluster-1";
     let deployments = match handler
-        .get_deployments_using_module(&module.module, cluster_name)
+        .get_deployments_using_module(&module.module, cluster_name, false)
         .await
     {
         Ok(modules) => modules,

--- a/webserver-openapi/src/main.rs
+++ b/webserver-openapi/src/main.rs
@@ -593,7 +593,7 @@ async fn get_deployments_for_module(
     let environment = ""; // this can be used to filter out specific environments
     let deployments = match GenericCloudHandler::workload(&project, &region)
         .await
-        .get_deployments_using_module(&module, environment)
+        .get_deployments_using_module(&module, environment, false)
         .await
     {
         Ok(modules) => modules,
@@ -621,7 +621,7 @@ async fn get_deployments_for_module(
 async fn get_deployments(Path((project, region)): Path<(String, String)>) -> impl IntoResponse {
     let deployments = match GenericCloudHandler::workload(&project, &region)
         .await
-        .get_all_deployments("")
+        .get_all_deployments("", false)
         .await
     {
         Ok(deployments) => deployments,


### PR DESCRIPTION
This pull request introduces support for filtering deployments by their deletion status across the codebase. The main change is the addition of an `include_deleted` parameter to deployment queries and related APIs, enabling clients and internal logic to specify whether deleted deployments should be included in results. This affects trait definitions, cloud provider implementations, query construction for AWS and Azure, and the CLI/TUI interfaces.

### API and Query Improvements

* Added an `include_deleted` boolean parameter to deployment-related queries in both AWS and Azure implementations, allowing selective retrieval of deleted deployments. This includes changes to `get_all_deployments_query`, `get_deployment_and_dependents_query`, and `get_deployments_using_module_query` functions in `env_aws/src/api.rs` and `env_azure/src/api.rs`. 

* Updated the `CloudProvider` trait in `defs/src/cloudprovider.rs` to include the `include_deleted` parameter for relevant methods. 

### Cloud Provider Implementations

* Modified AWS, Azure, and generic cloud provider implementations to propagate the new `include_deleted` parameter and utilize the updated query functions. This includes changes in `env_aws/src/provider.rs`, `env_azure/src/provider.rs`, and `env_common/src/interface/cloud_handlers.rs`.

### CLI and TUI Integration

* Updated CLI and TUI commands to pass the `include_deleted` parameter when listing deployments, ensuring the interface reflects the new filtering capability. 

### Operator and Integration Tests

* Updated operator logic and integration tests to use the new `include_deleted` parameter in deployment queries, maintaining compatibility and test coverage. 

### Webserver API Changes

* Added a new query struct `IncludeDeletedQuery` to the webserver API handlers, enabling clients to specify the `include_deleted` parameter in HTTP requests. 