### PR TITLE
fix: include 'include_deleted' parameter in get_all_deployments calls

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -17,7 +17,7 @@ pub async fn current_region_handler() -> GenericCloudHandler {
 
 pub async fn get_available_environments() -> anyhow::Result<Vec<String>> {
     let handler = current_region_handler().await;
-    let deployments = handler.get_all_deployments("").await?;
+    let deployments = handler.get_all_deployments("", false).await?;
 
     let mut environments: Vec<String> = deployments
         .iter()
@@ -32,7 +32,7 @@ pub async fn get_available_environments() -> anyhow::Result<Vec<String>> {
 
 pub async fn get_available_deployments(environment: &str) -> anyhow::Result<Vec<String>> {
     let handler = current_region_handler().await;
-    let deployments = handler.get_all_deployments("").await?;
+    let deployments = handler.get_all_deployments("", false).await?;
 
     let mut deployment_ids: Vec<String> = deployments
         .iter()


### PR DESCRIPTION
This pull request updates the way deployments are fetched in the `cli/src/utils.rs` utility functions by adding an extra argument to the `get_all_deployments` method. This change ensures that deployments are retrieved with the correct parameters in both the environment and deployment listing functions.

Deployment retrieval logic update:

* Changed calls to `handler.get_all_deployments("")` to include an additional `false` argument in both `get_available_environments` and `get_available_deployments`, aligning with the updated method signature. 