### PR TITLE
fix: allow multiline string in tf_input_resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ unit-tests: build-check
 
 integration-tests: aws-integration-tests azure-integration-tests
 
+# For all tests:     make aws-integration-tests
+# For specific test: make aws-integration-tests test=stack_tests::test_stack_multiline_policy_with_reference
 aws-integration-tests:
 	@echo "Running AWS integration tests..."
 	PROVIDER=aws \

--- a/integration-tests/modules/iam-role-with-policy/main.tf
+++ b/integration-tests/modules/iam-role-with-policy/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_iam_role" "main" {
+  name               = var.role_name
+  assume_role_policy = var.assume_role_policy
+}
+
+resource "aws_iam_role_policy" "inline" {
+  name   = "${var.role_name}-policy"
+  role   = aws_iam_role.main.id
+  policy = var.inline_policy
+}

--- a/integration-tests/modules/iam-role-with-policy/module.yaml
+++ b/integration-tests/modules/iam-role-with-policy/module.yaml
@@ -1,0 +1,45 @@
+apiVersion: infraweave.io/v1
+kind: Module
+metadata:
+  name: iamrole
+spec:
+  moduleName: IAMRole
+  reference: https://github.com/infraweave-io/modules/iamrole
+  cpu: "1024"
+  memory: "4096"
+  providers:
+    - name: aws-5
+  description: |
+    An IAM role with an inline policy for testing multiline JSON policies with references.
+  examples:
+    - name: role-with-policy
+      description: |
+        # IAM Role with Policy
+
+        This example creates an IAM role with an inline policy that references an S3 bucket's ARN.
+      variables:
+        role_name: test-iam-role
+        assume_role_policy: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "lambda.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+              }
+            ]
+          }
+        inline_policy: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::example-bucket"
+              }
+            ]
+          }

--- a/integration-tests/modules/iam-role-with-policy/outputs.tf
+++ b/integration-tests/modules/iam-role-with-policy/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  value       = aws_iam_role.main.arn
+  description = "ARN of the IAM role"
+}
+
+output "role_name" {
+  value       = aws_iam_role.main.name
+  description = "Name of the IAM role"
+}

--- a/integration-tests/modules/iam-role-with-policy/variables.tf
+++ b/integration-tests/modules/iam-role-with-policy/variables.tf
@@ -1,0 +1,14 @@
+variable "role_name" {
+  type        = string
+  description = "Name of the IAM role"
+}
+
+variable "assume_role_policy" {
+  type        = string
+  description = "Assume role policy JSON"
+}
+
+variable "inline_policy" {
+  type        = string
+  description = "Inline policy JSON"
+}

--- a/integration-tests/modules/s3bucket-with-policy/main.tf
+++ b/integration-tests/modules/s3bucket-with-policy/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "main" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_policy" "main" {
+  bucket = aws_s3_bucket.main.id
+  policy = var.policy
+}

--- a/integration-tests/modules/s3bucket-with-policy/module.yaml
+++ b/integration-tests/modules/s3bucket-with-policy/module.yaml
@@ -1,0 +1,32 @@
+apiVersion: infraweave.io/v1
+kind: Module
+metadata:
+  name: s3bucketwithpolicy
+spec:
+  moduleName: S3BucketWithPolicy
+  reference: https://github.com/infraweave-io/modules/s3bucketwithpolicy
+  cpu: "1024"
+  memory: "4096"
+  providers:
+    - name: aws-5
+  description: |
+    An S3 bucket with a bucket policy for testing multiline JSON policies with references.
+  examples:
+    - name: bucket-with-policy
+      description: |
+        # Bucket with Policy
+
+        This example creates an S3 bucket with a policy that references another bucket's ARN.
+      variables:
+        bucket_name: test-bucket-with-policy
+        policy: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::example-bucket"
+              }
+            ]
+          }

--- a/integration-tests/modules/s3bucket-with-policy/outputs.tf
+++ b/integration-tests/modules/s3bucket-with-policy/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_arn" {
+  value       = aws_s3_bucket.main.arn
+  description = "ARN of the S3 bucket"
+}
+
+output "bucket_name" {
+  value       = aws_s3_bucket.main.bucket
+  description = "Name of the S3 bucket"
+}

--- a/integration-tests/modules/s3bucket-with-policy/variables.tf
+++ b/integration-tests/modules/s3bucket-with-policy/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket"
+}
+
+variable "policy" {
+  type        = string
+  description = "Bucket policy JSON"
+}

--- a/integration-tests/stacks/bucket-with-policy-reference/bucket1.yaml
+++ b/integration-tests/stacks/bucket-with-policy-reference/bucket1.yaml
@@ -1,0 +1,9 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: s3bucket
+spec:
+  moduleVersion: 0.1.2-dev+test.10
+  region: N/A
+  variables:
+    bucketName: test-source-bucket

--- a/integration-tests/stacks/bucket-with-policy-reference/bucket2.yaml
+++ b/integration-tests/stacks/bucket-with-policy-reference/bucket2.yaml
@@ -1,0 +1,9 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: s3bucket2
+spec:
+  moduleVersion: 0.1.2-dev+test.10
+  region: N/A
+  variables:
+    bucketName: test-target-bucket

--- a/integration-tests/stacks/bucket-with-policy-reference/iamrole.yaml
+++ b/integration-tests/stacks/bucket-with-policy-reference/iamrole.yaml
@@ -1,0 +1,38 @@
+apiVersion: infraweave.io/v1
+kind: IAMRole
+metadata:
+  name: iamrole
+spec:
+  moduleVersion: 0.1.0-dev+test.1
+  region: N/A
+  variables:
+    roleName: test-iam-role
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
+    inlinePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "{{ S3Bucket::s3bucket::bucketArn }}"
+          },
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "{{ S3Bucket::s3bucket2::bucketArn }}"
+          }
+        ]
+      }

--- a/integration-tests/stacks/bucket-with-policy-reference/stack.yaml
+++ b/integration-tests/stacks/bucket-with-policy-reference/stack.yaml
@@ -1,0 +1,28 @@
+apiVersion: infraweave.io/v1
+kind: Stack
+metadata:
+  name: bucketwithiampolicy
+spec:
+  stackName: BucketWithIAMPolicy
+  reference: https://github.com/infraweave-io/stacks/bucketwithiampolicy
+  description: |
+    This stack tests multiline JSON policies with references to other modules.
+    
+    It creates:
+    - s3bucket: A simple S3 bucket
+    - s3bucket2: Another S3 bucket
+    - iamrole: An IAM role with an inline policy that references both S3 buckets' ARNs
+  examples:
+    - name: bucket-with-iam-policy
+      description: |
+        # S3 Buckets with IAM Role Policy Reference
+
+        This example demonstrates multiline JSON policies with module references.
+        The IAM role has a policy that grants permissions on both S3 buckets.
+      variables:
+        s3bucket:
+          bucketName: test-bucket-1
+        s3bucket2:
+          bucketName: test-bucket-2
+        iamrole:
+          roleName: test-iam-role


### PR DESCRIPTION
This pull request introduces support for resolving multiline string inputs containing references as Terraform heredocs, ensuring correct formatting and reference substitution in generated Terraform code. It also adds comprehensive integration tests and test modules to validate this behavior, particularly for IAM role policies and S3 bucket policies that reference other modules' outputs.

### Multiline String Reference Handling

* Updated `TfInputResolver` logic to detect multiline strings with references and output them as heredocs (`TemplateExpr::Heredoc`) instead of quoted strings, preventing Terraform errors with multiline policies. 
* Added a unit test to verify that multiline strings with references are resolved as heredocs and that references are correctly substituted.

### Integration Test Modules and Stacks

* Added new Terraform modules for `IAMRole` with inline policy and `S3BucketWithPolicy`, including their respective variable and output definitions, to facilitate testing of multiline policy scenarios. 
* Created corresponding module YAML files and stack YAML definitions to demonstrate and test multiline JSON policies with references between modules.

### Integration Test Coverage

* Added an integration test (`test_stack_multiline_policy_with_reference`) that publishes modules and a stack, then verifies that the generated Terraform code for IAM role policies uses heredoc formatting and correctly substitutes references to S3 bucket ARNs.

### Documentation and Usability

* Improved Makefile documentation for running AWS integration tests, clarifying usage for all tests and specific test cases.