### PR TITLE
feat: implement stack-level variable support

### DIFF
--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -11,7 +11,7 @@ pub fn get_module_identifier(module: &str, track: &str) -> String {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct TfVariable {
     pub name: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default = "default_tf_variable_type")]
     pub _type: serde_json::Value,
     #[serde(
         default,
@@ -19,9 +19,20 @@ pub struct TfVariable {
         skip_serializing_if = "Option::is_none"
     )]
     pub default: Option<serde_json::Value>, // Default: missing -> None, explicitly set null in terraform variable -> Some(Value::Null)
+    #[serde(default)]
     pub description: String,
+    #[serde(default = "default_nullable")]
     pub nullable: bool,
+    #[serde(default)]
     pub sensitive: bool,
+}
+
+fn default_tf_variable_type() -> serde_json::Value {
+    serde_json::Value::String("any".to_string())
+}
+
+fn default_nullable() -> bool {
+    true
 }
 
 // Custom deserializer to treat an explicit JSON null as Some(Value::Null), but missing field as None

--- a/defs/src/stack.rs
+++ b/defs/src/stack.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::ModuleExample;
+use crate::{ModuleExample, TfVariable};
 
 // These are only used to parse files, they will be stored as modules in DB
 
@@ -31,6 +31,8 @@ pub struct StackSpec {
     pub memory: Option<String>,
     pub locals: Option<serde_yaml::Mapping>,
     pub dependencies: Option<Vec<Dependency>>,
+    #[serde(rename = "stackVariableDefinitions", default)]
+    pub stack_variable_definitions: Option<Vec<TfVariable>>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/integration-tests/stacks/bucketcollection-stack-vars/bucket1a.yaml
+++ b/integration-tests/stacks/bucketcollection-stack-vars/bucket1a.yaml
@@ -1,0 +1,9 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: bucket1a
+spec:
+  moduleVersion: 0.1.2-dev+test.10
+  region: N/A
+  variables:
+    bucketName: "{{ Stack::variables::environment }}-bucket1a"

--- a/integration-tests/stacks/bucketcollection-stack-vars/bucket2.yaml
+++ b/integration-tests/stacks/bucketcollection-stack-vars/bucket2.yaml
@@ -1,0 +1,9 @@
+apiVersion: infraweave.io/v1
+kind: S3Bucket
+metadata:
+  name: bucket2
+spec:
+  moduleVersion: 0.1.3-dev+test.10
+  region: N/A
+  variables:
+    bucketName: "{{ Stack::variables::environment }}-bucket2"

--- a/integration-tests/stacks/bucketcollection-stack-vars/stack.yaml
+++ b/integration-tests/stacks/bucketcollection-stack-vars/stack.yaml
@@ -1,0 +1,28 @@
+apiVersion: infraweave.io/v1
+kind: Stack
+metadata:
+  name: bucketcollectionstackvars
+spec:
+  stackName: BucketCollectionStackVars
+  reference: https://github.com/infraweave-io/stacks/bucketcollection-stack-vars
+  description: |
+    This is a deployment stack consisting of two S3-buckets demonstrating stack-level variables.
+    
+    ## Details
+    Both buckets use a stack-level variable 'environment' to construct their names.
+    This allows setting a single value that's used across multiple modules in the stack.
+
+  stackVariableDefinitions:
+    - name: environment
+      description: Environment name used to prefix bucket names
+
+  examples:
+    - name: bucketcollection-stack-vars-example
+      description: |
+        # Stack variables example
+
+        This demonstrates using stack-level variables across multiple modules.
+        The 'environment' variable is set once at the stack level and used by both buckets.
+      variables:
+        stack:
+          environment: production

--- a/utils/src/variables.rs
+++ b/utils/src/variables.rs
@@ -77,6 +77,10 @@ pub fn verify_variable_existence_and_type(
 
                 let is_reference = variable_value.as_str().is_some_and(|s| re.is_match(s));
 
+                if module_variable_type == "any" {
+                    continue;
+                }
+
                 if variable_value_type != module_variable_type {
                     if is_reference {
                         log::warn!("


### PR DESCRIPTION
This pull request introduces support for stack-level variables in deployment stacks, allowing variables to be defined once at the stack level and referenced across multiple modules. The implementation includes updates to the core data structures, logic for variable collection and resolution, dependency validation, and new integration tests to verify the feature.

```
apiVersion: infraweave.io/v1
kind: Stack
metadata:
  name: ...
spec:
  ...
  stackVariableDefinitions:
    - name: environment
      description: Environment name used to prefix bucket names
```

to be used like

```
apiVersion: infraweave.io/v1
kind: S3Bucket
metadata:
  name: bucket1a
spec:
  moduleVersion: ...
  region: N/A
  variables:
    bucketName: "{{ Stack::variables::environment }}-bucket1a"
```

and in stack-claim like:

```
apiVersion: infraweave.io/v1
kind: MyStack
spec:
  ...
  stackVersion: ...
  variables:
    vpc:
      vpcName: my-vpc
    stack:
      environment: somevalue-here
```

**Stack-level variable support:**

* Added the `stackVariableDefinitions` field to the `StackSpec` struct, enabling definition of stack-level variables using the existing `TfVariable` type. Default values and serialization behaviors were updated to support this. (`defs/src/stack.rs`, `defs/src/module.rs`) (https://developer.hashicorp.com/terraform/language/block/variable)
* Updated the variable collection logic to merge stack-level variables into the variable map, using the `stack__<variable_name>` naming convention. (`env_common/src/logic/api_stack.rs`)

**Reference resolution and dependency handling:**

* Enhanced reference resolution to handle `Stack::variables::*` references, mapping them to stack-level variables and ensuring they are resolved correctly. (`env_common/src/logic/api_stack.rs`, `env_common/src/logic/tf_input_resolver.rs`) 
* Updated dependency validation to skip stack-level variable references, preventing incorrect validation errors and ensuring only module dependencies are checked. (`env_common/src/logic/api_stack.rs`)

**Integration tests:**

* Added new integration tests and example stack manifests to verify stack-level variable functionality, including correct variable resolution and example structure. (`integration-tests/stacks/bucketcollection-stack-vars/stack.yaml`, `integration-tests/stacks/bucketcollection-stack-vars/bucket1a.yaml`, `integration-tests/stacks/bucketcollection-stack-vars/bucket2.yaml`, `integration-tests/tests/stack.rs`) 