### PR TITLE
fix: add --prerelease flag to upgrade command for including pre-release versions

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -168,6 +168,9 @@ enum Commands {
         /// Only check for available upgrades without installing
         #[arg(long)]
         check: bool,
+        /// Include pre-release versions (e.g. beta, rc)
+        #[arg(long)]
+        prerelease: bool,
     },
 }
 
@@ -819,8 +822,8 @@ async fn main() {
 
             println!("{}", output);
         }
-        Commands::Upgrade { check } => {
-            commands::upgrade::handle_upgrade(check).await;
+        Commands::Upgrade { check, prerelease } => {
+            commands::upgrade::handle_upgrade(check, prerelease).await;
         }
     }
 }


### PR DESCRIPTION
This pull request updates the upgrade command in the CLI to support checking for and installing pre-release versions (such as beta or release candidates), in addition to stable releases. The implementation introduces a new command-line flag to include pre-releases, refactors the logic to handle both stable and pre-release versions, and improves user messaging to clarify which type of release is being considered.

**Upgrade command enhancements:**

* Added a `--prerelease` flag to the `upgrade` command, allowing users to include pre-release versions when checking for or installing upgrades.
* Refactored `get_latest_stable_version` into `get_latest_version`, which now accepts an `include_prerelease` parameter to determine whether to include pre-release versions in the search.
* Updated `handle_upgrade` to accept the new `include_prerelease` argument and use the refactored logic for determining the latest version. 

**User messaging improvements:**

* Enhanced output messages to clearly indicate whether the latest version found is stable or a pre-release, and to display appropriate messages when no releases are found.