### PR TITLE
fix: add TfVariable required impl

### DIFF
--- a/cli/src/tui/renderers/detail_renderer.rs
+++ b/cli/src/tui/renderers/detail_renderer.rs
@@ -10,7 +10,7 @@ use ratatui::{
 };
 
 use crate::tui::app::{App, PendingAction, View};
-use crate::tui::utils::{is_variable_required, to_camel_case, NavItem};
+use crate::tui::utils::{to_camel_case, NavItem};
 
 /// Render detail view (module/stack/deployment details)
 pub fn render_detail(frame: &mut Frame, area: Rect, app: &mut App) {
@@ -1333,7 +1333,7 @@ fn render_all_variables(stack: &env_defs::ModuleResp, lines: &mut Vec<Line<'stat
             lines.push(Line::from(""));
         }
 
-        let is_required = is_variable_required(variable);
+        let is_required = variable.required();
         let bullet = if is_required {
             Span::styled("⚠ ", Style::default().fg(Color::Red))
         } else {
@@ -1449,7 +1449,7 @@ fn render_variable_detail(
 ) {
     // Find the variable by name
     if let Some(variable) = stack.tf_variables.iter().find(|v| v.name == var_name) {
-        let is_required = is_variable_required(variable);
+        let is_required = variable.required();
         let icon = if is_required { "⚠ " } else { "🔧 " };
 
         let parts: Vec<&str> = variable.name.split("__").collect();
@@ -1751,13 +1751,13 @@ fn render_module_detail(
         // Sort variables: required first, then optional
         let mut sorted_vars: Vec<_> = module.tf_variables.iter().collect();
         sorted_vars.sort_by_key(|var| {
-            let is_required = is_variable_required(var);
+            let is_required = var.required();
             (!is_required, var.name.clone()) // Sort by required (reversed), then by name
         });
 
         for var in sorted_vars {
             let camel_case = to_camel_case(&var.name);
-            let is_required = is_variable_required(var);
+            let is_required = var.required();
             let icon = if is_required { "* " } else { "" };
             nav_items.push(format!("  └─ {}{}", icon, camel_case));
         }
@@ -1998,7 +1998,7 @@ fn build_detail_content(app: &App, module: &env_defs::ModuleResp) -> Vec<Line<'s
         // Sort variables: required first, then optional
         let mut sorted_vars: Vec<_> = module.tf_variables.iter().collect();
         sorted_vars.sort_by_key(|var| {
-            let is_required = is_variable_required(var);
+            let is_required = var.required();
             (!is_required, var.name.clone()) // Sort by required (reversed), then by name
         });
 
@@ -2021,7 +2021,7 @@ fn build_detail_content(app: &App, module: &env_defs::ModuleResp) -> Vec<Line<'s
                     serde_json::Value::String(s) => s.clone(),
                     other => format!("{}", other),
                 };
-                let is_required = is_variable_required(var);
+                let is_required = var.required();
                 let camel_case = to_camel_case(&var.name);
 
                 // Highlight required variables with red bullet and bold name
@@ -2089,7 +2089,7 @@ fn build_detail_content(app: &App, module: &env_defs::ModuleResp) -> Vec<Line<'s
                     serde_json::Value::String(s) => s.clone(),
                     other => format!("{}", other),
                 };
-                let is_required = is_variable_required(var);
+                let is_required = var.required();
                 let camel_case = to_camel_case(&var.name);
 
                 let icon = if is_required { "⚠ " } else { "🔧 " };

--- a/cli/src/tui/utils.rs
+++ b/cli/src/tui/utils.rs
@@ -214,18 +214,6 @@ pub fn to_camel_case(snake_case: &str) -> String {
     result
 }
 
-pub fn is_variable_required(var: &env_defs::TfVariable) -> bool {
-    if var.default.is_none() {
-        return true;
-    }
-
-    if !var.nullable && var.default == Some(serde_json::Value::Null) {
-        return true;
-    }
-
-    false
-}
-
 pub fn build_stack_nav_items(stack: &env_defs::ModuleResp) -> Vec<NavItem> {
     let mut items = vec![NavItem::General];
 
@@ -246,7 +234,7 @@ pub fn build_stack_nav_items(stack: &env_defs::ModuleResp) -> Vec<NavItem> {
                     items.push(NavItem::Variable {
                         module_name: None,
                         name: var.name.clone(),
-                        is_required: is_variable_required(var),
+                        is_required: var.required(),
                     });
                 }
             } else {
@@ -257,7 +245,7 @@ pub fn build_stack_nav_items(stack: &env_defs::ModuleResp) -> Vec<NavItem> {
                     items.push(NavItem::Variable {
                         module_name: Some(module_name.clone()),
                         name: var.name.clone(),
-                        is_required: is_variable_required(var),
+                        is_required: var.required(),
                     });
                 }
             }
@@ -303,7 +291,7 @@ pub fn build_module_nav_items(module: &env_defs::ModuleResp) -> Vec<NavItem> {
             items.push(NavItem::Variable {
                 module_name: None,
                 name: var.name.clone(),
-                is_required: is_variable_required(var),
+                is_required: var.required(),
             });
         }
     }

--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -46,6 +46,21 @@ where
     Ok(Some(v))
 }
 
+impl TfVariable {
+    /// Returns true if this variable is required (i.e. must be provided by the user)
+    pub fn required(&self) -> bool {
+        if self.default.is_none() {
+            return true;
+        }
+
+        if !self.nullable && self.default == Some(serde_json::Value::Null) {
+            return true;
+        }
+
+        false
+    }
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct TfValidation {
     pub expression: String,


### PR DESCRIPTION
This pull request refactors how the code determines whether a Terraform variable is required. The logic for checking if a variable is required has been moved from a standalone utility function to a method on the `TfVariable` struct, improving code organization and making the check more idiomatic. All usages of the old utility function have been updated to use the new method.

Refactoring and code organization:

* Added a `required()` method to the `TfVariable` struct in `defs/src/module.rs`, encapsulating the logic for determining if a variable is required.
* Removed the `is_variable_required` utility function from `cli/src/tui/utils.rs` and replaced all its usages with the new `TfVariable::required()` method.

Code updates for variable requirement checks:

* Updated all variable requirement checks in `cli/src/tui/renderers/detail_renderer.rs` to use `variable.required()` instead of `is_variable_required`.

Navigation item updates:

* Updated the construction of navigation items in `cli/src/tui/utils.rs` to use `var.required()` for the `is_required` field. 