### PR TITLE
fix: use proper release in cli upgrade

### DIFF
--- a/cli/src/commands/upgrade.rs
+++ b/cli/src/commands/upgrade.rs
@@ -117,8 +117,6 @@ pub async fn handle_upgrade(check_only: bool, include_prerelease: bool) {
         } else {
             println!("Downloading and installing version {}...", latest_version);
 
-            let latest_version = semver::Version::parse("0.0.95-rc.6").unwrap();
-
             let target_name = get_target_name();
             let bin_name = if cfg!(windows) { "cli.exe" } else { "cli" };
             let bin_path = format!("cli-{}-v{}", target_name, latest_version);


### PR DESCRIPTION
This pull request makes a minor cleanup to the `handle_upgrade` function in `upgrade.rs` by removing an unnecessary re-parsing of the `latest_version` variable. This helps prevent confusion and ensures the code uses the correct version throughout.