### PR TITLE
fix: remove manifest in extradata

### DIFF
--- a/defs/src/gitprovider.rs
+++ b/defs/src/gitprovider.rs
@@ -62,7 +62,6 @@ pub struct JobDetails {
     pub job_id: String,
     pub change_type: String,
     pub file_path: String,
-    pub manifest_yaml: String,
     pub status: String,
     pub error_text: String,
 }

--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -20,9 +20,9 @@ mod tfprovider;
 pub use api::GenericFunctionResponse;
 pub use cloudprovider::{CloudProvider, CloudProviderCommon};
 pub use deployment::{
-    get_deployment_identifier, Dependency, Dependent, DeploymentManifest, DeploymentResp,
-    DeploymentSpec, DriftDetection, JobStatus, Metadata as DeploymentMetadata, ProjectData,
-    Webhook, DEFAULT_DRIFT_DETECTION_INTERVAL,
+    get_deployment_identifier, Dependency, DependencySpec, Dependent, DeploymentManifest,
+    DeploymentResp, DeploymentSpec, DriftDetection, JobStatus, Metadata as DeploymentMetadata,
+    ProjectData, Webhook, DEFAULT_DRIFT_DETECTION_INTERVAL,
 };
 pub use environment::EnvironmentResp;
 pub use errors::CloudHandlerError;

--- a/gitops/src/github.rs
+++ b/gitops/src/github.rs
@@ -705,7 +705,6 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                         job_id: "OVERRIDE".to_string(),
                         change_type: "OVERRIDE".to_string(),
                         file_path: "OVERRIDE".to_string(),
-                        manifest_yaml: "OVERRIDE".to_string(),
                         error_text: "OVERRIDE".to_string(),
                         status: "OVERRIDE".to_string(),
                     },
@@ -736,8 +735,6 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                     };
                     if let ExtraData::GitHub(ref mut github_check_run) = extra_data {
                         github_check_run.job_details.file_path = active.path.clone();
-                        github_check_run.job_details.manifest_yaml =
-                            canonical.clone().trim_start_matches("---").to_string();
                         let region = if let Some(region) = yaml["spec"]["region"].as_str() {
                             region.to_string()
                         } else {
@@ -864,8 +861,6 @@ pub async fn handle_process_push_event(event: &Value) -> Result<Value, anyhow::E
                     };
                     if let ExtraData::GitHub(ref mut github_check_run) = extra_data {
                         github_check_run.job_details.file_path = deleted.path.clone();
-                        github_check_run.job_details.manifest_yaml =
-                            canonical.clone().trim_start_matches("---").to_string();
                         let region = if let Some(region) = yaml["spec"]["region"].as_str() {
                             region.to_string()
                         } else {

--- a/gitops/src/main.rs
+++ b/gitops/src/main.rs
@@ -184,12 +184,6 @@ File: **{}**
 Deployment ID: **{}**
 Environment: **{}**
 
-## Claim
-
-```yaml
-{}
-```
-
 ## Information
 
 ```diff
@@ -199,7 +193,6 @@ Environment: **{}**
                     github_event.job_details.file_path,
                     github_event.job_details.deployment_id,
                     github_event.job_details.environment,
-                    github_event.job_details.manifest_yaml,
                     information
                 )),
                 annotations: None,

--- a/terraform_runner/src/runner.rs
+++ b/terraform_runner/src/runner.rs
@@ -88,7 +88,6 @@ pub async fn run_terraform_runner(
                 job_id: job_id.clone(),
                 change_type: command.to_uppercase(),
                 file_path: github_data.job_details.file_path.clone(),
-                manifest_yaml: github_data.job_details.manifest_yaml.clone(),
                 error_text,
                 status: result.to_string(),
             };
@@ -101,7 +100,6 @@ pub async fn run_terraform_runner(
                 job_id: job_id.clone(),
                 change_type: command.to_uppercase(),
                 file_path: gitlab_data.job_details.file_path.clone(),
-                manifest_yaml: gitlab_data.job_details.manifest_yaml.clone(),
                 error_text,
                 status: result.to_string(),
             };


### PR DESCRIPTION
This pull request removes the unused `manifest_yaml` field from the `JobDetails` struct and cleans up all related code that referenced this field. This simplifies the data structures and reduces unnecessary data handling across the codebase and reduces risk of bumping into envvar size limit of payload when launching runner.

**Data structure simplification:**

* Removed the `manifest_yaml` field from the `JobDetails` struct in `gitprovider.rs`, and updated all instances where this field was set or used in `github.rs`, `runner.rs`, and `main.rs`. 

**Output formatting cleanup:**

* Removed the "Claim" section, which previously displayed the manifest YAML, from the output template in `main.rs`.

**Public API update:**

* Updated the public exports in `lib.rs` to reflect the removal of `manifest_yaml` and the addition of `DependencySpec`.