### PR TITLE
Align versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,15 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +378,22 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -596,29 +603,25 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.11.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47bb8cc16b669d267eeccf585aea077d0882f4777b1c1f740217885d6e6e5a3"
+checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
 dependencies = [
  "aws-lc-sys",
- "paste",
  "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.23.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2101df3813227bbaaaa0b04cd61c534c7954b22bd68d399b440be937dc63ff7"
+checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
- "paste",
 ]
 
 [[package]]
@@ -1127,7 +1130,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
@@ -1254,21 +1257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,29 +1301,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.90",
- "which 4.4.2",
-]
 
 [[package]]
 name = "bit-set"
@@ -1412,13 +1377,17 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.17.1"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
+checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
 dependencies = [
+ "async-stream",
  "base64 0.22.1",
+ "bitflags 2.10.0",
+ "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
+ "chrono",
  "futures-core",
  "futures-util",
  "hex",
@@ -1431,9 +1400,11 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "log",
+ "num",
  "pin-project-lite",
- "rustls 0.23.19",
- "rustls-native-certs 0.7.3",
+ "rand 0.9.1",
+ "rustls 0.23.28",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -1441,21 +1412,42 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tonic",
  "tower-service",
  "url",
  "winapi",
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.45.0-rc.26.0.1"
+name = "bollard-buildkit-proto"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.49.1-rc.28.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "chrono",
+ "prost 0.14.1",
  "serde",
+ "serde_json",
  "serde_repr",
  "serde_with",
 ]
@@ -1663,10 +1655,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -1677,15 +1670,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -1766,17 +1750,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1877,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -2809,7 +2782,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "reqwest 0.12.24",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -2922,13 +2895,12 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3044,6 +3016,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferroid"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce161062fb044bd629c2393590efd47cab8d0241faf15704ffb0d47b7b4e4a35"
+dependencies = [
+ "portable-atomic",
+ "rand 0.9.1",
+ "web-time",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3063,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fixedbitset"
@@ -3391,12 +3380,6 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gitops"
@@ -3910,7 +3893,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "log",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -4342,7 +4325,7 @@ dependencies = [
  "operator",
  "pretty_assertions",
  "rand 0.8.5",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -4415,18 +4398,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4717,7 +4700,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
@@ -4870,12 +4853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lexical"
 version = "7.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4955,16 +4932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,7 +4945,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -5064,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -5473,15 +5440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "oci-client"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5721,7 +5679,7 @@ dependencies = [
  "log",
  "openssl",
  "pretty_assertions",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "schemars 0.8.21",
  "serde",
@@ -5812,7 +5770,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -6326,7 +6284,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -6342,8 +6310,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "regex",
  "syn 2.0.90",
  "tempfile",
@@ -6363,6 +6331,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "prost-reflect"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6370,9 +6351,9 @@ checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
 dependencies = [
  "base64 0.22.1",
  "once_cell",
- "prost",
+ "prost 0.13.5",
  "prost-reflect-derive 0.14.0",
- "prost-types",
+ "prost-types 0.13.5",
  "serde",
  "serde-value",
 ]
@@ -6383,9 +6364,9 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "prost-reflect-derive 0.15.1",
- "prost-types",
+ "prost-types 0.13.5",
 ]
 
 [[package]]
@@ -6426,7 +6407,16 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -6568,8 +6558,8 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls 0.23.19",
+ "rustc-hash",
+ "rustls 0.23.28",
  "socket2 0.6.1",
  "thiserror 2.0.6",
  "tokio",
@@ -6588,8 +6578,8 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring",
- "rustc-hash 2.1.1",
- "rustls 0.23.19",
+ "rustc-hash",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.6",
@@ -6765,15 +6755,6 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6972,7 +6953,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -7177,18 +7158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7243,16 +7212,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -7329,18 +7298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -7942,15 +7899,15 @@ checksum = "23738cfc7e052e3a00a71853804b5f3da030b801e58e0fbde9b0fbf06e7cda58"
 dependencies = [
  "anyhow",
  "glob",
- "prost",
+ "prost 0.13.5",
  "prost-build",
  "prost-reflect 0.14.7",
  "prost-reflect-build",
- "prost-types",
+ "prost-types 0.13.5",
  "serde",
  "serde_json",
  "sigstore-protobuf-specs-derive",
- "which 7.0.3",
+ "which",
 ]
 
 [[package]]
@@ -8359,18 +8316,20 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.23.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f40cc2bd72e17f328faf8ca7687fe337e61bccd8acf9674fa78dd3792b045e1"
+checksum = "1483605f58b2fff80d786eb56a0b6b4e8b1e5423fbc9ec2e3e562fa2040d6f27"
 dependencies = [
+ "astral-tokio-tar",
  "async-trait",
  "bollard",
- "bollard-stubs",
  "bytes",
  "docker_credential",
  "either",
  "etcetera",
+ "ferroid",
  "futures",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -8378,19 +8337,18 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.11.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064a2677e164cad39ef3c1abddb044d5a25c49d27005804563d8c4227aac8bd0"
+checksum = "5e75e78ff453128a2c7da9a5d5a3325ea34ea214d4bf51eab3417de23a4e5147"
 dependencies = [
  "testcontainers",
 ]
@@ -8541,27 +8499,26 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8594,7 +8551,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -8610,21 +8567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8636,6 +8578,46 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.7",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+dependencies = [
+ "bytes",
+ "prost 0.14.1",
+ "tonic",
 ]
 
 [[package]]
@@ -8659,7 +8641,7 @@ dependencies = [
  "pem",
  "percent-encoding",
  "reqwest 0.12.24",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "serde",
  "serde_json",
  "serde_plain",
@@ -8696,7 +8678,9 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.7.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
@@ -8973,6 +8957,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8989,6 +9001,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -9341,7 +9359,7 @@ dependencies = [
  "log",
  "openssl",
  "reqwest 0.12.24",
- "rustls 0.23.19",
+ "rustls 0.23.28",
  "serde",
  "serde_json",
  "tokio",
@@ -9357,18 +9375,6 @@ name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.41",
-]
 
 [[package]]
 name = "which"
@@ -9516,6 +9522,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,9 +3521,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c115d4f30f52c67202f079c5f9d8b49db4691f460fdb0b4c2e838261b2ba5"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,43 +1050,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "tokio",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "axum-core 0.5.0",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1096,7 +1064,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1112,23 +1080,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -2807,7 +2758,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.5",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -2830,7 +2781,7 @@ dependencies = [
  "env_defs",
  "env_utils",
  "log",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -2857,7 +2808,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "rustls 0.23.19",
  "serde",
  "serde_json",
@@ -2931,7 +2882,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "regorus",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "semver",
  "serde",
  "serde_json",
@@ -3469,7 +3420,7 @@ dependencies = [
  "openssl",
  "pretty_assertions",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3983,19 +3934,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.31",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -4330,7 +4268,7 @@ dependencies = [
  "openssl",
  "pretty_assertions",
  "pyo3",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -4388,7 +4326,7 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.8.1",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "dirs 4.0.0",
@@ -5156,12 +5094,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -5772,7 +5704,7 @@ name = "operator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.8.1",
+ "axum",
  "axum-server",
  "base64 0.22.1",
  "chrono",
@@ -6371,7 +6303,7 @@ name = "prometheus_exporter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.6.20",
+ "axum",
  "env_common",
  "env_defs",
  "env_utils",
@@ -6380,7 +6312,7 @@ dependencies = [
  "log",
  "openssl",
  "prometheus",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -6814,7 +6746,7 @@ dependencies = [
  "lambda_runtime",
  "log",
  "openssl",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -6977,23 +6909,19 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
- "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
- "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7020,7 +6948,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-rustls 0.27.3",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -8407,7 +8335,7 @@ dependencies = [
  "log",
  "nanoid",
  "openssl",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -8741,7 +8669,6 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9103,7 +9030,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6427547f6db7ec006cbbef95f7565952a16f362e298b416d2d497d9706fef72d"
 dependencies = [
- "axum 0.8.1",
+ "axum",
  "serde",
  "serde_json",
  "utoipa",
@@ -9115,7 +9042,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161166ec520c50144922a625d8bc4925cc801b2dda958ab69878527c0e5c5d61"
 dependencies = [
- "axum 0.8.1",
+ "axum",
  "base64 0.22.1",
  "mime_guess",
  "regex",
@@ -9387,7 +9314,7 @@ dependencies = [
 name = "webserver-openapi"
 version = "0.1.0"
 dependencies = [
- "axum 0.8.1",
+ "axum",
  "axum-macros",
  "base64 0.22.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6285,9 +6285,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -6295,7 +6295,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -6431,9 +6431,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "pxfm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,51 @@ members = [
     "integration-tests",
 ]
 
+[workspace.lints.rust]
+warnings = "deny"
+
+[workspace.lints.clippy]
+redundant-closure = { level = "allow", priority = 1 }
+needless_return = { level = "allow", priority = 1 }
+match_ref_pats = { level = "allow", priority = 1 }
+let_and_return = { level = "allow", priority = 1 }
+io_other_error = { level = "allow", priority = 1 }
+needless_borrows_for_generic_args = { level = "allow", priority = 1 }
+expect_fun_call = { level = "allow", priority = 1 }
+double_ended_iterator_last = { level = "allow", priority = 1 }
+let_unit_value = { level = "allow", priority = 1 }
+needless_borrow = { level = "allow", priority = 1 }
+useless_conversion = { level = "allow", priority = 1 }
+too_many_arguments = { level = "allow", priority = 1 }
+bool_comparison = { level = "allow", priority = 1 }
+partialeq_to_none = { level = "allow", priority = 1 }
+manual_map = { level = "allow", priority = 1 }
+useless_format = { level = "allow", priority = 1 }
+format_in_format_args = { level = "allow", priority = 1 }
+type_complexity = { level = "allow", priority = 1 }
+map_entry = { level = "allow", priority = 1 }
+ptr_arg = { level = "allow", priority = 1 }
+unnecessary_unwrap = { level = "allow", priority = 1 }
+manual_ok_err = { level = "allow", priority = 1 }
+redundant_field_names = { level = "allow", priority = 1 }
+cloned_ref_to_slice_refs = { level = "allow", priority = 1 }
+collapsible_else_if = { level = "allow", priority = 1 }
+option_as_ref_deref = { level = "allow", priority = 1 }
+redundant_pattern_matching = { level = "allow", priority = 1 }
+single_component_path_imports = { level = "allow", priority = 1 }
+empty_line_after_outer_attr = { level = "allow", priority = 1 }
+explicit_counter_loop = { level = "allow", priority = 1 }
+println_empty_string = { level = "allow", priority = 1 }
+nonminimal_bool = { level = "allow", priority = 1 }
+print_literal = { level = "allow", priority = 1 }
+new_without_default = { level = "allow", priority = 1 }
+unwrap_or_default = { level = "allow", priority = 1 }
+large_enum_variant = { level = "allow", priority = 1 }
+if_same_then_else = { level = "allow", priority = 1 }
+collapsible_if = { level = "allow", priority = 1 }
+question_mark = { level = "allow", priority = 1 }
+useless_vec = { level = "allow", priority = 1 }
+
 [workspace.dependencies]
 # Core serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,67 @@ members = [
     "webserver-openapi",
     "integration-tests",
 ]
+
+[workspace.dependencies]
+# Core serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.8"
+
+# Async runtime
+tokio = { version = "1.48", features = ["full"] }
+futures = "0.3.31"
+async-trait = "0.1.50"
+
+# Error handling
+anyhow = "1.0"
+thiserror = "1.0.68"
+
+# Logging
+log = "0.4"
+fern = "0.6"
+
+# HTTP client
+reqwest = { version = "0.12", features = ["json"] }
+
+# Cryptography and encoding
+openssl = { version = "0.10.72", features = ["vendored"] }
+rustls = "0.23.18"
+base64 = "0.22"
+sha2 = "0.10"
+
+# Time and date
+chrono = "0.4"
+
+# Utilities
+regex = "1.11.0"
+rand = "0.8.5"
+semver = "1.0"
+url = "2.5"
+zip = "0.6.6"
+walkdir = "2.3"
+tempfile = "3.22.0"
+hcl-rs = "0.18.4"
+
+# AWS
+aws-config = { version = "1.5", features = ["behavior-version-latest"] }
+
+# Lambda
+lambda_runtime = "0.13.0"
+
+# Web framework
+axum = "0.8.1"
+
+# OpenAPI
+utoipa = "5.3.1"
+jsonwebtoken = "9.3.1"
+
+# MCP
+rmcp = "0.8"
+rmcp-openapi = "0.20"
+
+# Templating
+tera = "1.15.0"
+
+# Testing
+pretty_assertions = "1.4.1"

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,7 @@ generate-cli-docs:
 build-operator:
 	DOCKER_BUILDKIT=1 docker build -t infraweave-operator -f operator/Dockerfile .
 
-build-check:
-	@echo "Building with warnings as errors..."
-	RUSTFLAGS="-D warnings" cargo build --all-targets
-
-unit-tests: build-check
+unit-tests:
 	cargo test --workspace --exclude integration-tests
 
 integration-tests: aws-integration-tests azure-integration-tests

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license-file = "../LICENSE"
 build = "build.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 clap-markdown = "0.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,33 +8,33 @@ build = "build.rs"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 clap-markdown = "0.1"
-reqwest = { version = "0.12", features = ["json"] }
-tokio = { version = "1", features = ["full"] }
+reqwest = { workspace = true }
+tokio = { workspace = true }
 colored = "2.0"
 prettytable = "0.10"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-chrono = "0.4"
-anyhow = "1.0"
-serde_yaml = "0.8"
-log = "0.4"
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+anyhow = { workspace = true }
+serde_yaml = { workspace = true }
+log = { workspace = true }
 ring = "0.17.12"
-openssl = { version = "0.10", features = ["vendored"] }
+openssl = { workspace = true }
 hostname = "0.4"
 ratatui = "0.28"
 crossterm = "0.28"
 arboard = "3.4"
 self_update = "0.42"
-semver = "1.0"
+semver = { workspace = true }
 dirs = "5.0"
 inquire = "0.9"
 
 # MCP server dependencies
-rmcp-openapi = "0.20"
-rmcp = "0.8"
-url = "2.5"
-utoipa = "5.3.1"
-rand = "0.8"
+rmcp-openapi = { workspace = true }
+rmcp = { workspace = true }
+url = { workspace = true }
+utoipa = { workspace = true }
+rand = { workspace = true }
 
 env_common = { path = "../env_common" }
 env_defs = { path = "../defs" }

--- a/crd-templator/Cargo.toml
+++ b/crd-templator/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crd-templator/Cargo.toml
+++ b/crd-templator/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
-tera = "1.15.0"
-tokio = { version = "1", features = ["full"] }
-serde_json = "*"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+tera = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
 
 env_defs = { path = "../defs" }
 

--- a/defs/Cargo.toml
+++ b/defs/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/defs/Cargo.toml
+++ b/defs/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1.50"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml = "0.8"
-tokio = { version = "1", features = ["full"] }
-walkdir = "2.3"
-thiserror = "1.0.68"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
+walkdir = { workspace = true }
+thiserror = { workspace = true }
 utoipa = { version = "5.2.0", features = ["axum_extras"], optional = true }
 
 [features]

--- a/env_aws/Cargo.toml
+++ b/env_aws/Cargo.toml
@@ -5,29 +5,29 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-async-trait = "0.1.50"
-aws-config = { version = "1.5", features = ["behavior-version-latest"] }
+async-trait = { workspace = true }
+aws-config = { workspace = true }
 aws-sdk-lambda = "1.60.0"
 aws-sdk-ssm = "1.56.0"
 aws-sdk-sts = "1.51.0"
 aws-sdk-s3 = "1.65.0"
-serde_json = "1.0"
-serde_yaml = "0.8"
-chrono = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-log = "0.4"
-tokio = { version = "1", features = ["full"] }
-anyhow = "1.0"
-zip = "0.6.6"
-reqwest = "0.11"
-tempfile = "3.10.1"
-rand = "0.8.5"
-base64 = "0.22"
-regex = "1.11.0"
-hcl-rs = "0.18.4"
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+zip = { workspace = true }
+reqwest = { workspace = true }
+tempfile = { workspace = true }
+rand = { workspace = true }
+base64 = { workspace = true }
+regex = { workspace = true }
+hcl-rs = { workspace = true }
 
 env_defs = { path = "../defs" }
 env_utils = { path = "../utils" }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
+pretty_assertions = { workspace = true }

--- a/env_aws/Cargo.toml
+++ b/env_aws/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait = { workspace = true }
 aws-config = { workspace = true }

--- a/env_azure/Cargo.toml
+++ b/env_azure/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-async-trait = "0.1.50"
+async-trait = { workspace = true }
 azure_identity = "0.21"
 azure_core = "0.21"
 azure_storage = "0.21"
 azure_storage_blobs = "0.21"
-serde_json = "1.0"
-serde_yaml = "0.8"
-chrono = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-log = "0.4"
-tokio = { version = "1", features = ["full"] }
-anyhow = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+reqwest = { workspace = true }
 
 env_defs = { path = "../defs" }
 env_utils = { path = "../utils" }

--- a/env_azure/Cargo.toml
+++ b/env_azure/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait = { workspace = true }
 azure_identity = "0.21"

--- a/env_common/Cargo.toml
+++ b/env_common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/env_common/Cargo.toml
+++ b/env_common/Cargo.toml
@@ -5,24 +5,24 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1.50"
-futures = "0.3"
-serde_json = "1.0"
-serde_yaml = "0.8"
-tokio = { version = "1" }
-serde = { version = "1.0", features = ["derive"] }
-log = "0.4"
-base64 = "0.22"
-hcl-rs = "0.18.4"
-regex = "1.11.0"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+log = { workspace = true }
+base64 = { workspace = true }
+hcl-rs = { workspace = true }
+regex = { workspace = true }
 once_cell = "1.20.2"
 humantime = "2.1"
-thiserror = "1.0.68"
-rustls = "0.23.18"
+thiserror = { workspace = true }
+rustls = { workspace = true }
 indexmap = "2.7.0"
 oci-client = "0.15.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { workspace = true }
 
 env_aws = { path = "../env_aws" }
 env_azure = { path = "../env_azure" }
@@ -30,4 +30,4 @@ env_defs = { path = "../defs" }
 env_utils = { path = "../utils" }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
+pretty_assertions = { workspace = true }

--- a/gitops/Cargo.toml
+++ b/gitops/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/gitops/Cargo.toml
+++ b/gitops/Cargo.toml
@@ -5,35 +5,35 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
-tokio = { version = "1", features = ["full"] }
-serde_json = "*"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
 env_common = { path = "../env_common" }
 env_defs = { path = "../defs" }
 env_utils = { path = "../utils" }
-anyhow = "1.0"
-log = "0.4"
-reqwest = { version = "0.11", features = ["json"] }
-openssl = { version = "0.10", features = ["vendored"] }
-lambda_runtime = "0.13.0"
+anyhow = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+openssl = { workspace = true }
+lambda_runtime = { workspace = true }
 aws_lambda_events = "0.16"
-futures = "0.3.31"
-base64 = "0.22"
-jsonwebtoken = "9.3.1"
+futures = { workspace = true }
+base64 = { workspace = true }
+jsonwebtoken = { workspace = true }
 hmac = "0.12"
-sha2 = "0.10"
+sha2 = { workspace = true }
 subtle = "2.4"
 hex = "0.4"
-chrono = "0.4"
-regex = "1.5"
+chrono = { workspace = true }
+regex = { workspace = true }
 
 # AWS SDK
 aws-sdk-ssm = "1.67.0"
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-config = { workspace = true }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
+pretty_assertions = { workspace = true }
 
 [lib]
 name = "gitops"

--- a/infraweave-mcp/Cargo.toml
+++ b/infraweave-mcp/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rmcp-openapi = "0.20"
-rmcp = "0.8"
-tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json"] }
-serde_json = "1.0"
-url = "2.5"
-utoipa = "5.3.1"
+rmcp-openapi = { workspace = true }
+rmcp = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }
+utoipa = { workspace = true }
 webserver-openapi = { path = "../webserver-openapi", default-features = false }
-rand = "0.8"
+rand = { workspace = true }

--- a/infraweave-mcp/Cargo.toml
+++ b/infraweave-mcp/Cargo.toml
@@ -3,6 +3,9 @@ name = "infraweave-mcp"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 rmcp-openapi = { workspace = true }
 rmcp = { workspace = true }

--- a/infraweave_py/Cargo.toml
+++ b/infraweave_py/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "Apache-2.0"
 build = "build.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/infraweave_py/Cargo.toml
+++ b/infraweave_py/Cargo.toml
@@ -6,15 +6,15 @@ license = "Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
-tokio = { version = "1", features = ["full"] }
-serde_json = "*"
-anyhow = "1.0"
-log = "0.4"
-reqwest = { version = "0.11", features = ["json"] }
-openssl = { version = "0.10", features = ["vendored"] }
-futures = "0.3.31"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+openssl = { workspace = true }
+futures = { workspace = true }
 pyo3 = { version = "0.24.1", features = ["extension-module"] }
 
 env_common = { path = "../env_common" }
@@ -22,7 +22,7 @@ env_defs = { path = "../defs" }
 env_utils = { path = "../utils" }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
+pretty_assertions = { workspace = true }
 
 [lib]
 name = "infraweave"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -22,8 +22,8 @@ terraform_runner = { path = "../terraform_runner" }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 rand = { workspace = true }
-testcontainers = { version = "0.23.1",  features = ["blocking"] }
-testcontainers-modules = { version = "0.11.4", features = ["dynamodb", "k3s"] }
+testcontainers = { version = "0.26.2",  features = ["blocking"] }
+testcontainers-modules = { version = "0.14.0", features = ["dynamodb", "k3s"] }
 env_utils = { path = "../utils" }
 kube = { version = "0.96.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "=0.23.0", features = ["v1_31"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.43", features = ["macros", "rt-multi-thread"] }
-serde_json = "1.0"
-serde_yaml = "0.8"
-hcl-rs = "0.18.4"
-anyhow = "1.0"
-chrono = "0.4"
-log = "0.4"
+serde = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+hcl-rs = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+log = { workspace = true }
 
 env_defs = { path = "../defs" }
 env_aws = { path = "../env_aws" }
@@ -20,17 +20,17 @@ env_common = { path = "../env_common" }
 terraform_runner = { path = "../terraform_runner" }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
-rand = "0.8"
+pretty_assertions = { workspace = true }
+rand = { workspace = true }
 testcontainers = { version = "0.23.1",  features = ["blocking"] }
 testcontainers-modules = { version = "0.11.4", features = ["dynamodb", "k3s"] }
 env_utils = { path = "../utils" }
 kube = { version = "0.96.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "=0.23.0", features = ["v1_31"] }
 kube-runtime = "0.96.0"
-rustls = "0.23.18"
+rustls = { workspace = true }
 dirs = "4.0"
 operator = { path = "../operator" }
-base64 = "0.22"
-axum = "0.8.1"
+base64 = { workspace = true }
+axum = { workspace = true }
 tower = "0.5"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -11,23 +11,23 @@ passthrough = ["K8S_OPENAPI_ENABLED_VERSION"]
 kube = { version = "0.96.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "=0.23.0", features = ["v1_31"] }
 kube-runtime = "0.96.0"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml = "0.8"
-futures = "0.3"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+futures = { workspace = true }
 schemars = "0.8"
-log = "0.4"
-fern = "0.6"
-anyhow = "1.0"
-chrono = "0.4.31"
-base64 = "0.22"
-openssl = { version = "0.10.72", features = ["vendored"] }
-rustls = { version = "0.23", features = ["ring"] }
+log = { workspace = true }
+fern = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+base64 = { workspace = true }
+openssl = { workspace = true }
+rustls = { workspace = true, features = ["ring"] }
 rustls-pemfile = "2.0"
 tokio-rustls = "0.26"
 kube-leader-election = "0.37.0"
-axum = "0.8.1"
+axum = { workspace = true }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 
 crd_templator = { path = "../crd-templator" }
@@ -36,5 +36,5 @@ env_utils = { path = "../utils" }
 env_defs = { path = "../defs" }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
+pretty_assertions = { workspace = true }
 tower = "0.5"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -7,6 +7,9 @@ license-file = "../LICENSE"
 [package.metadata.cross.build.env]
 passthrough = ["K8S_OPENAPI_ENABLED_VERSION"]
 
+[lints]
+workspace = true
+
 [dependencies]
 kube = { version = "0.96.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "=0.23.0", features = ["v1_31"] }

--- a/prometheus_exporter/Cargo.toml
+++ b/prometheus_exporter/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/prometheus_exporter/Cargo.toml
+++ b/prometheus_exporter/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { workspace = true }
 openssl = { workspace = true }
 lambda_runtime = { workspace = true }
 futures = { workspace = true }
-prometheus = "0.13"
+prometheus = "0.14"
 axum = { workspace = true }
 
 env_common = { path = "../env_common" }

--- a/prometheus_exporter/Cargo.toml
+++ b/prometheus_exporter/Cargo.toml
@@ -5,18 +5,18 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
-tokio = { version = "1", features = ["full"] }
-serde_json = "*"
-anyhow = "1.0"
-log = "0.4"
-reqwest = { version = "0.11", features = ["json"] }
-openssl = { version = "0.10", features = ["vendored"] }
-lambda_runtime = "0.13.0"
-futures = "0.3.31"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+openssl = { workspace = true }
+lambda_runtime = { workspace = true }
+futures = { workspace = true }
 prometheus = "0.13"
-axum = "0.6"
+axum = { workspace = true }
 
 env_common = { path = "../env_common" }
 env_defs = { path = "../defs" }

--- a/prometheus_exporter/src/endpoint.rs
+++ b/prometheus_exporter/src/endpoint.rs
@@ -35,7 +35,7 @@ pub async fn metrics_handler(
         for &status in &AVAILABLE_STATUSES {
             metrics
                 .event_counter
-                .with_label_values(&[module, status])
+                .with_label_values(&[module.as_str(), status])
                 .set(0);
         }
         // metrics.running_jobs.with_label_values(&[module]).set(0);
@@ -58,7 +58,7 @@ pub async fn metrics_handler(
                 for &status in &AVAILABLE_STATUSES {
                     metrics
                         .event_counter
-                        .with_label_values(&[&event.module, status])
+                        .with_label_values(&[event.module.as_str(), status])
                         .set(0);
                 }
                 // metrics.running_jobs.with_label_values(&[&event.module]).set(0);
@@ -69,7 +69,7 @@ pub async fn metrics_handler(
         // metrics.observe_event(event.status.as_str());
         metrics
             .event_counter
-            .with_label_values(&[&event.module, event.status.as_str()])
+            .with_label_values(&[event.module.as_str(), event.status.as_str()])
             .inc();
 
         // Handle specific statuses with additional metrics

--- a/prometheus_exporter/src/main.rs
+++ b/prometheus_exporter/src/main.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use axum::routing::get;
 use axum::Router;
+use tokio::net::TcpListener;
 use endpoint::metrics_handler;
 use env_common::interface::{initialize_project_id_and_region, GenericCloudHandler};
 use env_defs::CloudProvider;
@@ -33,10 +34,8 @@ async fn main() {
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3001));
     println!("Listening on {}", addr);
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn get_available_modules_stacks() -> (HashSet<String>, HashSet<String>) {

--- a/reconciler/Cargo.toml
+++ b/reconciler/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/reconciler/Cargo.toml
+++ b/reconciler/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
-tokio = { version = "1", features = ["full"] }
-serde_json = "*"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
 env_common = { path = "../env_common" }
 env_defs = { path = "../defs" }
 env_utils = { path = "../utils" }
-anyhow = "1.0"
-log = "0.4"
-reqwest = { version = "0.11", features = ["json"] }
-openssl = { version = "0.10", features = ["vendored"] }
-lambda_runtime = "0.13.0"
-futures = "0.3.31"
+anyhow = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+openssl = { workspace = true }
+lambda_runtime = { workspace = true }
+futures = { workspace = true }
 
 [lib]
 name = "reconciler"

--- a/terraform_runner/Cargo.toml
+++ b/terraform_runner/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/terraform_runner/Cargo.toml
+++ b/terraform_runner/Cargo.toml
@@ -5,18 +5,18 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
-tera = "1.15.0"
-tokio = { version = "1", features = ["full"] }
-serde_json = "*"
-anyhow = "1.0"
-log = "0.4"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+tera = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
 nanoid = "0.4.0"
 convert_case = "0.6.0"
-reqwest = { version = "0.11", features = ["json"] }
-openssl = { version = "0.10", features = ["vendored"] }
-futures = "0.3.31"
+reqwest = { workspace = true }
+openssl = { workspace = true }
+futures = { workspace = true }
 
 env_common = { path = "../env_common" }
 env_aws = { path = "../env_aws" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [dependencies]
 zip = { workspace = true }
 walkdir = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -28,7 +28,7 @@ sigstore = "0.12.0"
 base64 = { workspace = true }
 regorus = "0.4.0"
 tempfile = { workspace = true }
-bollard = "0.17.1"
+bollard = "0.19.4"
 uuid = "1.17"
 futures-util = "0"
 tokio = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -5,38 +5,38 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-zip = "0.6.6"
-walkdir = "2.3"
-hcl-rs = "0.18.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
-anyhow = "1.0"
+zip = { workspace = true }
+walkdir = { workspace = true }
+hcl-rs = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+anyhow = { workspace = true }
 jsonschema = "0.16"
-serde_yaml = "0.8"
-semver = "1.0"
-chrono = "0.4"
-regex = "1.11.0"
+serde_yaml = { workspace = true }
+semver = { workspace = true }
+chrono = { workspace = true }
+regex = { workspace = true }
 heck = "0.5"
-fern = "0.6"
-log = "0.4"
+fern = { workspace = true }
+log = { workspace = true }
 flate2 = "1.1"
 tar = "0.4"
-sha2 = "0.10"
+sha2 = { workspace = true }
 oci-distribution = "0.11.0"
 sigstore = "0.12.0"
-base64 = "0.22"
+base64 = { workspace = true }
 regorus = "0.4.0"
-tempfile = "3.22.0"
+tempfile = { workspace = true }
 bollard = "0.17.1"
 uuid = "1.17"
 futures-util = "0"
-tokio = "1"
+tokio = { workspace = true }
 tokio-util = "0.7.16"
 bytes = "1.10.1"
 
 env_defs = { path = "../defs" }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
+pretty_assertions = { workspace = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/webserver-openapi/Cargo.toml
+++ b/webserver-openapi/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license-file = "../LICENSE"
 
+[lints]
+workspace = true
+
 [lib]
 name = "webserver_openapi"
 path = "src/lib.rs"

--- a/webserver-openapi/Cargo.toml
+++ b/webserver-openapi/Cargo.toml
@@ -9,25 +9,25 @@ name = "webserver_openapi"
 path = "src/lib.rs"
 
 [dependencies]
-axum = "0.8.1"
+axum = { workspace = true }
 axum-macros = "0.5.0"
 hyper = { version = "1.0.1", features = ["full"] }
-tokio = { version = "1.43", features = ["full"] }
+tokio = { workspace = true }
 tower = "0.4"
-utoipa = { version = "5.3.1", features = ["axum_extras"] }
+utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"], optional = true }
 utoipa-redoc = { version = "6.0.0", features = ["axum"], optional = true }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 env_logger = "0.11"
-log = "0.4"
-openssl = { version = "0.10", features = ["vendored"] }
-rustls = "0.23.18"
-jsonwebtoken = "9.0"
-base64 = "0.22"
-reqwest = { version = "0.12", features = ["json"] }
+log = { workspace = true }
+openssl = { workspace = true }
+rustls = { workspace = true }
+jsonwebtoken = { workspace = true }
+base64 = { workspace = true }
+reqwest = { workspace = true }
 tower-http = { version = "0.6", features = ["trace"] }
-chrono = "0.4"
+chrono = { workspace = true }
 
 env_defs = { path = "../defs", features = ["openapi"] }
 env_common = { path = "../env_common" }


### PR DESCRIPTION
Move dependencies from member crate to workspace to keep versions aligned.

* fix RUSTSEC-2024-0437 protobuf
* fix RUSTSEC-2025-0111 tokio-tar
* bumped half to non yanked version 2.7.1

* Setting warnings to deny, in Cargo.toml to make it true for cargo check and not only the build check in make.