### PR TITLE
feat: automap locals to output

### DIFF
--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -141,55 +141,15 @@ pub async fn publish_module(
             }
         });
 
-    //TODO: Split into multiple files, instead of a single file
-    let tf_root_providers = hcl::format::to_string(&tf_provider_mgmt.build()).unwrap();
-
-    let deployment = DeploymentManifest {
-        api_version: "infraweave.io/v1".to_string(),
-        metadata: DeploymentMetadata {
-            name: module_yaml.metadata.name.clone(),
-            namespace: None,
-            annotations: None,
-            labels: None,
-        },
-        kind: module_yaml.spec.module_name.clone(),
-        spec: DeploymentSpec {
-            module_version: module_yaml.spec.version.clone(),
-            stack_version: None,
-            region: "N/A".to_string(),
-            reference: Some(module_yaml.spec.reference.clone()),
-            variables: serde_yaml::Mapping::with_capacity(0),
-            dependencies: None,
-            drift_detection: None,
-        },
-    };
-    let module_call_builder = Body::builder()
-        .add_block(module_block(
-            &deployment,
-            &variables(
-                &module_inputs
-                    .iter()
-                    .map(|block| {
-                        let name = block.labels().first().unwrap().as_str().to_string();
-                        return (name.clone(), name.clone());
-                    })
-                    .collect(),
-                &deployment,
-                &TfInputResolver::new(Vec::new(), Vec::new()),
-            ),
-            &providers(&tf_providers),
-            &Vec::with_capacity(0),
-        ))
-        .build();
-    let tf_root_main = hcl::format::to_string(&module_call_builder).unwrap();
-
-    info!("Root module setup:\n{}", &tf_root_providers);
-    std::fs::write(temp_dir.join("providers.tf"), tf_root_providers)
-        .expect("Unable to write root providers.tf");
-
-    info!("Root module call:\n{}", &tf_root_main);
-    std::fs::write(temp_dir.join("main.tf"), tf_root_main)
-        .expect("Unable to write root providers.tf");
+    write_root_module(temp_dir, &tf_provider_mgmt, &module_inputs);
+    write_root_module_call(
+        temp_dir,
+        module_yaml.metadata.name.clone(),
+        module_yaml.spec.module_name.clone(),
+        module_yaml.spec.version.clone(),
+        &module_inputs,
+        &providers(&tf_providers),
+    );
 
     let tf_lock_file_content = run_terraform_provider_lock(&temp_dir).await.unwrap(); // runs docker
 
@@ -219,6 +179,145 @@ pub async fn publish_module(
         ),
     )
     .await
+}
+
+fn write_root_module(
+    root_dir: &Path,
+    tf_provider_mgmt: &TfProviderMgmt,
+    module_inputs: &[hcl::Block],
+) {
+    let data = tf_provider_mgmt.data();
+    if !data.is_empty() {
+        let tf_root_data =
+            hcl::format::to_string(&hcl::Body::builder().add_blocks(data).build()).unwrap();
+        info!("Root data:\n{}", &tf_root_data);
+        std::fs::write(root_dir.join("data.tf"), tf_root_data)
+            .expect("Unable to write root data.tf");
+    }
+
+    let mut mapped_locals: Vec<String> = vec![];
+    if let Some(mut locals) = tf_provider_mgmt.locals().iter().next().cloned() {
+        let outputs = tf_provider_mgmt.output();
+        for attr in locals.body.attributes_mut() {
+            if let Some(out) = outputs.iter().find(|b| {
+                b.identifier() == "output" && b.labels.iter().any(|bl| bl.as_str() == attr.key())
+            }) {
+                if let Some(val) = out.body().attributes().find(|attr| attr.key() == "value") {
+                    attr.expr = val.expr.clone();
+                    mapped_locals.push(attr.key().to_string());
+                }
+            }
+        }
+        let tf_root_locals =
+            hcl::format::to_string(&hcl::Body::builder().add_block(locals.clone()).build())
+                .unwrap();
+        info!("Root locals:\n{}", &tf_root_locals);
+        std::fs::write(root_dir.join("locals.tf"), tf_root_locals)
+            .expect("Unable to write root locals.tf");
+    }
+
+    let output = tf_provider_mgmt.output();
+    if !output.is_empty() {
+        let tf_root_output =
+            hcl::format::to_string(&hcl::Body::builder().add_blocks(output).build()).unwrap();
+        info!("Root outputs:\n{}", &tf_root_output);
+        std::fs::write(root_dir.join("outputs.tf"), tf_root_output)
+            .expect("Unable to write root outputs.tf");
+    }
+
+    let providers = tf_provider_mgmt.provider_configuration();
+    if !providers.is_empty() {
+        let tf_root_providers =
+            hcl::format::to_string(&hcl::Body::builder().add_blocks(providers).build()).unwrap();
+        info!("Root providers:\n{}", &tf_root_providers);
+        std::fs::write(root_dir.join("providers.tf"), tf_root_providers)
+            .expect("Unable to write root providers.tf");
+    }
+
+    let variables = tf_provider_mgmt.variables();
+    if !variables.is_empty() {
+        let tf_root_variables = hcl::format::to_string(
+            &hcl::Body::builder()
+                .add_blocks(
+                    variables
+                        .iter()
+                        .filter(|v| {
+                            let name = v.labels[0].as_str();
+                            module_inputs.iter().any(|b| b.labels() == v.labels())
+                                || mapped_locals.contains(&name.to_string()) == false
+                        })
+                        .cloned()
+                        .collect::<Vec<hcl::Block>>(),
+                )
+                .build(),
+        )
+        .unwrap();
+        info!("Root variables:\n{}", &tf_root_variables);
+        std::fs::write(root_dir.join("variables.tf"), tf_root_variables)
+            .expect("Unable to write root variables.tf");
+    }
+
+    if let Some(terraform) = tf_provider_mgmt.terraform().iter().next().cloned() {
+        let tf_root_version =
+            hcl::format::to_string(&hcl::Body::builder().add_block(terraform).build()).unwrap();
+        info!("Root version:\n{}", &tf_root_version);
+        std::fs::write(root_dir.join("version.tf"), tf_root_version)
+            .expect("Unable to write root version.tf");
+    }
+}
+
+fn write_root_module_call(
+    root_dir: &Path,
+    name: String,
+    kind: String,
+    version: Option<String>,
+    module_inputs: &[hcl::Block],
+    providers: &Vec<(hcl::ObjectKey, hcl::Expression)>,
+) {
+    let deployment = DeploymentManifest {
+        api_version: "infraweave.io/v1".to_string(),
+        metadata: DeploymentMetadata {
+            name,
+            namespace: None,
+            annotations: None,
+            labels: None,
+        },
+        kind,
+        spec: DeploymentSpec {
+            module_version: version,
+            stack_version: None,
+            region: "N/A".to_string(),
+            reference: None,
+            variables: serde_yaml::Mapping::with_capacity(0),
+            dependencies: None,
+            drift_detection: None,
+        },
+    };
+
+    let module_call_builder = Body::builder()
+        .add_block(module_block(
+            &deployment,
+            &variables(
+                &module_inputs
+                    .iter()
+                    .map(|block| {
+                        let name = block.labels().first().unwrap().as_str().to_string();
+                        return (name.clone(), name.clone());
+                    })
+                    .collect(),
+                &deployment,
+                &TfInputResolver::new(Vec::new(), Vec::new()),
+            ),
+            providers,
+            &Vec::with_capacity(0),
+        ))
+        .build();
+
+    let tf_root_main = hcl::format::to_string(&module_call_builder).unwrap();
+
+    info!("Root module call:\n{}", &tf_root_main);
+    std::fs::write(root_dir.join("main.tf"), tf_root_main)
+        .expect("Unable to write root providers.tf");
 }
 
 fn validate_providers(tf_providers: &Vec<ProviderResp>) {
@@ -1104,6 +1203,377 @@ mod tests {
     use super::*;
     use env_defs::{ProviderManifest, ProviderMetaData, ProviderSpec};
     use pretty_assertions::assert_eq;
+
+    #[cfg(test)]
+    mod write_root_module {
+        use super::super::write_root_module;
+        use crate::logic::tf_provider_mgmt::TfProviderMgmt;
+        use env_utils::read_tf_directory;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn write_root_no_mapping() {
+            let module_inputs: Vec<hcl::Block> = vec![hcl::Block::builder("variable")
+                .add_label("other_variable")
+                .add_attribute(hcl::Attribute::new(
+                    "type",
+                    hcl::to_expression("string").unwrap(),
+                ))
+                .build()];
+
+            assert_eq!(
+                execute_write_root_module(
+                    r#"
+                    output "first_output" {
+                        value = module.a.field
+                    }
+
+                    locals {
+                        some_variable = var.some_variable
+                        other_variable = var.other_variable
+                    }
+
+                    variable "some_variable" {
+                        type = string
+                    }
+
+                    variable "other_variable" {
+                        type = string
+                    }
+                    "#,
+                    &module_inputs
+                ),
+                hcl::parse(
+                    r#"
+                    output "first_output" {
+                        value = module.a.field
+                    }
+
+                    locals {
+                        some_variable = var.some_variable
+                        other_variable = var.other_variable
+                    }
+
+                    variable "some_variable" {
+                        type = string
+                    }
+
+                    variable "other_variable" {
+                        type = string
+                    }
+
+                    "#
+                )
+                .unwrap()
+            );
+        }
+
+        #[test]
+        fn write_root_map_and_remove_variable() {
+            let module_inputs: Vec<hcl::Block> = vec![hcl::Block::builder("variable")
+                .add_label("other_variable")
+                .add_attribute(hcl::Attribute::new(
+                    "type",
+                    hcl::to_expression("string").unwrap(),
+                ))
+                .build()];
+
+            assert_eq!(
+                execute_write_root_module(
+                    r#"
+                    output "some_variable" {
+                        value = module.a.field
+                    }
+
+                    locals {
+                        some_variable = var.some_variable
+                        other_variable = var.other_variable
+                    }
+
+                    variable "some_variable" {
+                        type = string
+                    }
+
+                    variable "other_variable" {
+                        type = string
+                    }
+                    "#,
+                    &module_inputs
+                ),
+                hcl::parse(
+                    r#"
+                    output "some_variable" {
+                        value = module.a.field
+                    }
+
+                    locals {
+                        some_variable = module.a.field
+                        other_variable = var.other_variable
+                    }
+
+                    variable "other_variable" {
+                        type = string
+                    }
+
+                    "#
+                )
+                .unwrap()
+            );
+        }
+
+        #[test]
+        fn write_root_map_and_retain_variable_its_used_by_module() {
+            let module_inputs: Vec<hcl::Block> = vec![hcl::Block::builder("variable")
+                .add_label("other_variable")
+                .add_attribute(hcl::Attribute::new(
+                    "type",
+                    hcl::to_expression("string").unwrap(),
+                ))
+                .build()];
+
+            assert_eq!(
+                execute_write_root_module(
+                    r#"
+                    output "some_variable" {
+                        value = module.a.field
+                    }
+
+                    output "other_variable" {
+                        value = module.b.field
+                    }
+
+                    locals {
+                        some_variable = var.some_variable
+                        other_variable = var.other_variable
+                    }
+
+                    variable "some_variable" {
+                        type = string
+                    }
+
+                    variable "other_variable" {
+                        type = string
+                    }
+                    "#,
+                    &module_inputs
+                ),
+                hcl::parse(
+                    r#"
+                    output "some_variable" {
+                        value = module.a.field
+                    }
+
+                    output "other_variable" {
+                        value = module.b.field
+                    }
+
+                    locals {
+                        some_variable = module.a.field
+                        other_variable = module.b.field
+                    }
+
+                    variable "other_variable" {
+                        type = string
+                    }
+
+                    "#
+                )
+                .unwrap()
+            );
+        }
+
+        fn execute_write_root_module(
+            tf_content_in: &str,
+            module_inputs: &[hcl::Block],
+        ) -> hcl::Body {
+            let mut tf_provider_mgmt = TfProviderMgmt::new();
+            hcl::parse(tf_content_in)
+                .unwrap()
+                .blocks()
+                .for_each(|new_block| tf_provider_mgmt.add_block(new_block));
+            let temp_dir = env_utils::tempdir().unwrap();
+            let root_dir = temp_dir.path();
+            write_root_module(root_dir, &tf_provider_mgmt, module_inputs);
+            hcl::parse(&read_tf_directory(root_dir).unwrap()).unwrap()
+        }
+    }
+
+    #[cfg(test)]
+    mod write_root_module_call {
+        use env_utils::read_tf_directory;
+        use pretty_assertions::assert_eq;
+
+        use crate::logic::api_module::write_root_module_call;
+
+        #[test]
+        fn validate_source() {
+            assert_eq!(
+                execute_write_root_module_call(
+                    "a".to_string(),
+                    "SomeKind".to_string(),
+                    Some("1.0.2-dev+abc123".to_string()),
+                    &Vec::with_capacity(0),
+                    &Vec::with_capacity(0),
+                ),
+                hcl::parse(
+                    r#"
+                    module "a" {
+                        source = "./SomeKind-1.0.2-dev+abc123"
+                    }
+                    "#
+                )
+                .unwrap()
+            )
+        }
+
+        #[test]
+        fn multiple_providers_and_alias() {
+            assert_eq!(
+                execute_write_root_module_call(
+                    "a".to_string(),
+                    "SomeKind".to_string(),
+                    Some("1.0.2-dev+abc123".to_string()),
+                    &Vec::with_capacity(0),
+                    &vec![
+                        (
+                            hcl::ObjectKey::Identifier(hcl::Identifier::sanitized(
+                                "aws".to_string()
+                            )),
+                            to_expression("aws")
+                        ),
+                        (
+                            hcl::ObjectKey::Expression(to_expression("aws.other")),
+                            to_expression("aws.other")
+                        ),
+                        (
+                            hcl::ObjectKey::Identifier(hcl::Identifier::sanitized(
+                                "helm".to_string()
+                            )),
+                            to_expression("helm")
+                        ),
+                    ],
+                ),
+                hcl::parse(
+                    r#"
+                    module "a" {
+                        source = "./SomeKind-1.0.2-dev+abc123"
+                        providers = {
+                            aws = aws
+                            aws.other = aws.other
+                            helm = helm
+                        }
+                    }
+                    "#
+                )
+                .unwrap()
+            )
+        }
+
+        #[test]
+        fn map_variables() {
+            assert_eq!(
+                execute_write_root_module_call(
+                    "a".to_string(),
+                    "SomeKind".to_string(),
+                    Some("1.0.2-dev+abc123".to_string()),
+                    &vec![
+                        hcl::Block::builder("variable")
+                            .add_label("var1")
+                            .add_attribute(hcl::Attribute::new("type", to_expression("string")))
+                            .build(),
+                        hcl::Block::builder("variable")
+                            .add_label("var2")
+                            .add_attribute(hcl::Attribute::new("type", to_expression("string")))
+                            .build(),
+                    ],
+                    &Vec::with_capacity(0),
+                ),
+                hcl::parse(
+                    r#"
+                    module "a" {
+                        source = "./SomeKind-1.0.2-dev+abc123"
+                        var1 = var.var1
+                        var2 = var.var2
+                    }
+                    "#
+                )
+                .unwrap()
+            )
+        }
+
+        #[test]
+        fn source_provider_variable() {
+            assert_eq!(
+                execute_write_root_module_call(
+                    "a".to_string(),
+                    "SomeKind".to_string(),
+                    Some("1.0.2-dev+abc123".to_string()),
+                    &vec![
+                        hcl::Block::builder("variable")
+                            .add_label("var1")
+                            .add_attribute(hcl::Attribute::new("type", to_expression("string")))
+                            .build(),
+                        hcl::Block::builder("variable")
+                            .add_label("var2")
+                            .add_attribute(hcl::Attribute::new("type", to_expression("string")))
+                            .build(),
+                    ],
+                    &vec![
+                        (
+                            hcl::ObjectKey::Identifier(hcl::Identifier::sanitized(
+                                "aws".to_string()
+                            )),
+                            to_expression("aws")
+                        ),
+                        (
+                            hcl::ObjectKey::Expression(to_expression("aws.other")),
+                            to_expression("aws.other")
+                        ),
+                        (
+                            hcl::ObjectKey::Identifier(hcl::Identifier::sanitized(
+                                "helm".to_string()
+                            )),
+                            to_expression("helm")
+                        ),
+                    ],
+                ),
+                hcl::parse(
+                    r#"
+                    module "a" {
+                        source = "./SomeKind-1.0.2-dev+abc123"
+                        var1 = var.var1
+                        var2 = var.var2
+                        providers = {
+                            aws = aws
+                            aws.other = aws.other
+                            helm = helm
+                        }
+                    }
+                    "#
+                )
+                .unwrap()
+            )
+        }
+
+        //TODO: replace when we bump HCL version
+        fn to_expression(input: &str) -> hcl::Expression {
+            let expr: hcl::edit::expr::Expression = hcl::edit::parser::parse_expr(input).unwrap();
+            expr.into()
+        }
+
+        fn execute_write_root_module_call(
+            name: String,
+            kind: String,
+            version: Option<String>,
+            module_inputs: &[hcl::Block],
+            providers: &Vec<(hcl::ObjectKey, hcl::Expression)>,
+        ) -> hcl::Body {
+            let temp_dir = env_utils::tempdir().unwrap();
+            let root_dir = temp_dir.path();
+            write_root_module_call(root_dir, name, kind, version, module_inputs, providers);
+            hcl::parse(&read_tf_directory(root_dir).unwrap()).unwrap()
+        }
+    }
 
     #[test]
     fn test_is_example_variables_valid() {

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -1245,13 +1245,13 @@ mod tests {
                 ),
                 hcl::parse(
                     r#"
-                    output "first_output" {
-                        value = module.a.field
-                    }
-
                     locals {
                         some_variable = var.some_variable
                         other_variable = var.other_variable
+                    }
+
+                    output "first_output" {
+                        value = module.a.field
                     }
 
                     variable "some_variable" {
@@ -1261,7 +1261,6 @@ mod tests {
                     variable "other_variable" {
                         type = string
                     }
-
                     "#
                 )
                 .unwrap()
@@ -1281,13 +1280,13 @@ mod tests {
             assert_eq!(
                 execute_write_root_module(
                     r#"
-                    output "some_variable" {
-                        value = module.a.field
-                    }
-
                     locals {
                         some_variable = var.some_variable
                         other_variable = var.other_variable
+                    }
+
+                    output "some_variable" {
+                        value = module.a.field
                     }
 
                     variable "some_variable" {
@@ -1302,19 +1301,18 @@ mod tests {
                 ),
                 hcl::parse(
                     r#"
-                    output "some_variable" {
-                        value = module.a.field
-                    }
-
                     locals {
                         some_variable = module.a.field
                         other_variable = var.other_variable
                     }
 
+                    output "some_variable" {
+                        value = module.a.field
+                    }
+
                     variable "other_variable" {
                         type = string
                     }
-
                     "#
                 )
                 .unwrap()
@@ -1334,17 +1332,17 @@ mod tests {
             assert_eq!(
                 execute_write_root_module(
                     r#"
+                    locals {
+                        some_variable = var.some_variable
+                        other_variable = var.other_variable
+                    }
+                    
                     output "some_variable" {
                         value = module.a.field
                     }
 
                     output "other_variable" {
                         value = module.b.field
-                    }
-
-                    locals {
-                        some_variable = var.some_variable
-                        other_variable = var.other_variable
                     }
 
                     variable "some_variable" {
@@ -1359,6 +1357,11 @@ mod tests {
                 ),
                 hcl::parse(
                     r#"
+                    locals {
+                        some_variable = module.a.field
+                        other_variable = module.b.field
+                    }
+
                     output "some_variable" {
                         value = module.a.field
                     }
@@ -1367,15 +1370,9 @@ mod tests {
                         value = module.b.field
                     }
 
-                    locals {
-                        some_variable = module.a.field
-                        other_variable = module.b.field
-                    }
-
                     variable "other_variable" {
                         type = string
                     }
-
                     "#
                 )
                 .unwrap()

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -413,7 +413,10 @@ pub async fn publish_stack(
     validate_examples(
         &tf_stack_provider_variables,
         &tf_variables,
-        &claim_modules.iter().map(|(deplyment,_)| deplyment.metadata.name.clone()).collect::<Vec<String>>(),
+        &claim_modules
+            .iter()
+            .map(|(deplyment, _)| deplyment.metadata.name.clone())
+            .collect::<Vec<String>>(),
         &mut stack_manifest.spec.examples,
     )?;
 
@@ -1754,10 +1757,15 @@ fn validate_examples(
     let mut errors: Vec<String> = Vec::new();
     if let Some(ref mut examples) = examples {
         for example in examples.iter() {
-            errors.extend(validate_example(provider_variables, stack_variables, claim_names, example));
+            errors.extend(validate_example(
+                provider_variables,
+                stack_variables,
+                claim_names,
+                example,
+            ));
         }
         if !errors.is_empty() {
-            return Err(ModuleError::InvalidExampleVariable(errors.join("\n")))
+            return Err(ModuleError::InvalidExampleVariable(errors.join("\n")));
         }
     }
     Ok(())
@@ -1773,27 +1781,34 @@ fn validate_example(
     let example_variables = to_mapping(example.variables.clone()).unwrap();
     errors.extend(
         example_variables
-        .iter()
-        .map(
-            |(key, value)|
-            {
+            .iter()
+            .map(|(key, value)| {
                 let key_str = key.as_str().unwrap();
                 match provider_variables.iter().any(|v| v.name == key_str) {
                     true => validate_example_variable(provider_variables, None, key_str, value),
-                    false => 
-                        match claim_names.contains(&key_str.to_string()) {
-                            true => validate_module_example(stack_variables, key_str, value),
-                            false => vec![format!("There is no claim or provider variable named \"{}\"", key_str)],
-                        }
+                    false => match claim_names.contains(&key_str.to_string()) {
+                        true => validate_module_example(stack_variables, key_str, value),
+                        false => vec![format!(
+                            "There is no claim or provider variable named \"{}\"",
+                            key_str
+                        )],
+                    },
                 }
-            }
-        )
-        .flatten()
-        .map(|s| format!("Example \"{}\": {}", example.name, s))
+            })
+            .flatten()
+            .map(|s| format!("Example \"{}\": {}", example.name, s)),
     );
-    errors.extend(validate_example_required(provider_variables, &example_variables).iter().map(|s| format!("Example \"{}\": {}", example.name, s)));
-    errors.extend(validate_module_example_required(stack_variables, &example_variables).iter().map(|s| format!("Example \"{}\": {}", example.name, s)));
-    return errors
+    errors.extend(
+        validate_example_required(provider_variables, &example_variables)
+            .iter()
+            .map(|s| format!("Example \"{}\": {}", example.name, s)),
+    );
+    errors.extend(
+        validate_module_example_required(stack_variables, &example_variables)
+            .iter()
+            .map(|s| format!("Example \"{}\": {}", example.name, s)),
+    );
+    return errors;
 }
 
 fn validate_example_variable(
@@ -1804,12 +1819,7 @@ fn validate_example_variable(
 ) -> Vec<String> {
     let mut errors = vec![];
     if variable != env_utils::to_camel_case(variable) {
-        errors.push(
-            format!(
-                "Variable \"{}\" should be camelCase",
-                variable
-            )
-        );
+        errors.push(format!("Variable \"{}\" should be camelCase", variable));
     }
     let tf_name = match claim {
         Some(val) => format!("{}__{}", val, to_snake_case(variable)),
@@ -1825,7 +1835,10 @@ fn validate_example_variable(
             && !is_nullable
             && value.is_null()
         {
-            errors.push(format!("Required variable \"{}\" is null but mandatory", variable));
+            errors.push(format!(
+                "Required variable \"{}\" is null but mandatory",
+                variable
+            ));
         }
 
         //TODO: check the value type agains the tf_variable._type (string, map, bool etc, etc)
@@ -1833,17 +1846,20 @@ fn validate_example_variable(
     return errors;
 }
 
-fn validate_example_required(tf_variables: &[TfVariable], example_variables: &serde_yaml::Mapping) -> Vec<String> {
+fn validate_example_required(
+    tf_variables: &[TfVariable],
+    example_variables: &serde_yaml::Mapping,
+) -> Vec<String> {
     tf_variables
-    .iter()
-    .filter(
-        |v| 
-        !v.nullable 
-        && (v.default.is_none() || v.default == Some(serde_json::Value::Null))
-    )
-    .filter(|v| !example_variables.contains_key(&serde_yaml::Value::String(to_camel_case(&v.name))))
-    .map(|v| format!("Required variable \"{}\" is missing", v.name))
-    .collect::<Vec<String>>()
+        .iter()
+        .filter(|v| {
+            !v.nullable && (v.default.is_none() || v.default == Some(serde_json::Value::Null))
+        })
+        .filter(|v| {
+            !example_variables.contains_key(&serde_yaml::Value::String(to_camel_case(&v.name)))
+        })
+        .map(|v| format!("Required variable \"{}\" is missing", v.name))
+        .collect::<Vec<String>>()
 }
 
 fn validate_module_example(
@@ -1853,48 +1869,57 @@ fn validate_module_example(
 ) -> Vec<String> {
     let module_example_variables = to_mapping(value.clone());
     if module_example_variables.is_none() {
-        return vec![format!("\"{}\" is not a provider variable and is missing claim variables", module)]
+        return vec![format!(
+            "\"{}\" is not a provider variable and is missing claim variables",
+            module
+        )];
     }
     module_example_variables
-    .unwrap()
-    .iter()
-    .flat_map(
-        |(key, value)| 
-        validate_example_variable(tf_variables, Some(module), key.as_str().unwrap(), value)
+        .unwrap()
         .iter()
-        .map(|err| format!("{} for claim \"{}\"", err, module))
-        .collect::<Vec<String>>()
-    ).collect()
+        .flat_map(|(key, value)| {
+            validate_example_variable(tf_variables, Some(module), key.as_str().unwrap(), value)
+                .iter()
+                .map(|err| format!("{} for claim \"{}\"", err, module))
+                .collect::<Vec<String>>()
+        })
+        .collect()
 }
 
 fn validate_module_example_required(
-    tf_variables: &[TfVariable], example_variables: &serde_yaml::Mapping
+    tf_variables: &[TfVariable],
+    example_variables: &serde_yaml::Mapping,
 ) -> Vec<String> {
     tf_variables
-    .iter()
-    .filter(
-        |v| 
-        !v.nullable 
-        && (v.default.is_none() || v.default == Some(serde_json::Value::Null))
-    )
-    .map(|v| v.name.split_once("__").unwrap())
-    .filter(|(claim, variable)| {
-        if let Some(example_claim) = example_variables.get(&serde_yaml::to_value(to_camel_case(claim)).unwrap()) {
-            let mapping = to_mapping(example_claim.clone());
-            if mapping.is_none() {
-                return true
+        .iter()
+        .filter(|v| {
+            !v.nullable && (v.default.is_none() || v.default == Some(serde_json::Value::Null))
+        })
+        .map(|v| v.name.split_once("__").unwrap())
+        .filter(|(claim, variable)| {
+            if let Some(example_claim) =
+                example_variables.get(&serde_yaml::to_value(to_camel_case(claim)).unwrap())
+            {
+                let mapping = to_mapping(example_claim.clone());
+                if mapping.is_none() {
+                    return true;
+                }
+                return !mapping
+                    .unwrap()
+                    .get(&serde_yaml::to_value(to_camel_case(variable)).unwrap())
+                    .is_some();
+            } else {
+                return true;
             }
-            return !mapping.unwrap().get(&serde_yaml::to_value(to_camel_case(variable)).unwrap()).is_some() 
-        } else {
-            return true
-        }
-    })
-    .map(|(claim, variable)| {
-        format!("Required variable \"{}\" for claim \"{}\" is missing", variable, claim)
-    })
-    .collect::<Vec<String>>()
+        })
+        .map(|(claim, variable)| {
+            format!(
+                "Required variable \"{}\" for claim \"{}\" is missing",
+                variable, claim
+            )
+        })
+        .collect::<Vec<String>>()
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -1914,21 +1939,22 @@ mod tests {
         use env_defs::{ModuleExample, TfVariable};
         use pretty_assertions::assert_eq;
 
-        use crate::logic::api_stack::{to_mapping, validate_example, validate_example_required, validate_example_variable, validate_module_example, validate_module_example_required};
+        use crate::logic::api_stack::{
+            to_mapping, validate_example, validate_example_required, validate_example_variable,
+            validate_module_example, validate_module_example_required,
+        };
 
         #[test]
         fn provider_ok() {
-            let tf_provider_variables = vec![
-                TfVariable {
-                    name: "tags".to_string(),
-                    description: "Tags to apply to resources".to_string(),
-                    default: None,
-                    sensitive: false,
-                    nullable: true,
-                    _type: serde_json::Value::String("map".to_string()),
-                }
-            ];
-            
+            let tf_provider_variables = vec![TfVariable {
+                name: "tags".to_string(),
+                description: "Tags to apply to resources".to_string(),
+                default: None,
+                sensitive: false,
+                nullable: true,
+                _type: serde_json::Value::String("map".to_string()),
+            }];
+
             let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
                 r#"
                 tags:
@@ -1937,24 +1963,27 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                validate_example_variable(&tf_provider_variables, None, "tags", example_variables.get("tags").unwrap()),
+                validate_example_variable(
+                    &tf_provider_variables,
+                    None,
+                    "tags",
+                    example_variables.get("tags").unwrap()
+                ),
                 Vec::<String>::new()
             )
         }
 
         #[test]
         fn provider_not_camle_case() {
-            let tf_provider_variables = vec![
-                TfVariable {
-                    name: "kubernetes_config".to_string(),
-                    description: "kubernetes_config".to_string(),
-                    default: None,
-                    sensitive: false,
-                    nullable: true,
-                    _type: serde_json::Value::String("object".to_string()),
-                }
-            ];
-            
+            let tf_provider_variables = vec![TfVariable {
+                name: "kubernetes_config".to_string(),
+                description: "kubernetes_config".to_string(),
+                default: None,
+                sensitive: false,
+                nullable: true,
+                _type: serde_json::Value::String("object".to_string()),
+            }];
+
             let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
                 r#"
                 kubernetes_config:
@@ -1963,7 +1992,12 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                validate_example_variable(&tf_provider_variables, None, "kubernetes_config", example_variables.get("kubernetes_config").unwrap()),
+                validate_example_variable(
+                    &tf_provider_variables,
+                    None,
+                    "kubernetes_config",
+                    example_variables.get("kubernetes_config").unwrap()
+                ),
                 vec!["Variable \"kubernetes_config\" should be camelCase".to_string()]
             )
         }
@@ -1986,9 +2020,9 @@ mod tests {
                     sensitive: false,
                     nullable: true,
                     _type: serde_json::Value::String("object".to_string()),
-                }
+                },
             ];
-            
+
             let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
                 r#"
                 kuberneteConfig:
@@ -1997,7 +2031,10 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                validate_example_required(&tf_provider_variables, &to_mapping(example_variables).unwrap()),
+                validate_example_required(
+                    &tf_provider_variables,
+                    &to_mapping(example_variables).unwrap()
+                ),
                 vec!["Required variable \"tags\" is missing"]
             )
         }
@@ -2042,11 +2079,19 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                validate_module_example(&tf_variables, "bucket1a", &example_variables.get("bucket1a").unwrap()),
+                validate_module_example(
+                    &tf_variables,
+                    "bucket1a",
+                    &example_variables.get("bucket1a").unwrap()
+                ),
                 Vec::<String>::new()
             );
             assert_eq!(
-                validate_module_example(&tf_variables, "bucket2", &example_variables.get("bucket2").unwrap()),
+                validate_module_example(
+                    &tf_variables,
+                    "bucket2",
+                    &example_variables.get("bucket2").unwrap()
+                ),
                 Vec::<String>::new()
             );
         }
@@ -2069,7 +2114,11 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                validate_module_example(&tf_variables, "bucket1a", &example_variables.get("bucket1a").unwrap()),
+                validate_module_example(
+                    &tf_variables,
+                    "bucket1a",
+                    &example_variables.get("bucket1a").unwrap()
+                ),
                 vec!["Variable \"bucket_name\" should be camelCase for claim \"bucket1a\""]
             );
         }
@@ -2103,34 +2152,33 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                validate_module_example_required(&tf_variables, &to_mapping(example_variables).unwrap()),
+                validate_module_example_required(
+                    &tf_variables,
+                    &to_mapping(example_variables).unwrap()
+                ),
                 vec!["Required variable \"bucket_name\" for claim \"bucket1a\" is missing"]
             );
         }
 
         #[test]
         fn multiple_issues() {
-            let provider_tf_variables = vec![
-                TfVariable {
-                    name: "tags".to_string(),
-                    description: "Tags to apply to resources".to_string(),
-                    default: None,
-                    sensitive: false,
-                    nullable: false,
-                    _type: serde_json::Value::String("map".to_string()),
-                }
-            ];
-            let stack_tf_variables = vec![
-                TfVariable {
-                    name: "bucket1a__bucket_name".to_string(),
-                    description: "The name of the bucket".to_string(),
-                    default: None,
-                    sensitive: false,
-                    nullable: false,
-                    _type: serde_json::Value::String("string".to_string()),
-                }
-            ];
-            let example = ModuleExample{
+            let provider_tf_variables = vec![TfVariable {
+                name: "tags".to_string(),
+                description: "Tags to apply to resources".to_string(),
+                default: None,
+                sensitive: false,
+                nullable: false,
+                _type: serde_json::Value::String("map".to_string()),
+            }];
+            let stack_tf_variables = vec![TfVariable {
+                name: "bucket1a__bucket_name".to_string(),
+                description: "The name of the bucket".to_string(),
+                default: None,
+                sensitive: false,
+                nullable: false,
+                _type: serde_json::Value::String("string".to_string()),
+            }];
+            let example = ModuleExample {
                 name: "test example".to_string(),
                 description: "".to_string(),
                 variables: serde_yaml::from_str(
@@ -2142,8 +2190,9 @@ mod tests {
                     bVar: provider that is camleCase
                     cNester:
                         dVar: just a nested provider var
-                    "#
-                ).unwrap(),
+                    "#,
+                )
+                .unwrap(),
             };
             assert_eq!(
                 validate_example(
@@ -2183,7 +2232,7 @@ mod tests {
                     sensitive: false,
                     nullable: false,
                     _type: serde_json::Value::String("map".to_string()),
-                }
+                },
             ];
             let stack_tf_variables = vec![
                 TfVariable {
@@ -2201,9 +2250,9 @@ mod tests {
                     sensitive: false,
                     nullable: false,
                     _type: serde_json::Value::String("bool".to_string()),
-                }
+                },
             ];
-            let example = ModuleExample{
+            let example = ModuleExample {
                 name: "test example".to_string(),
                 description: "".to_string(),
                 variables: serde_yaml::from_str(
@@ -2212,8 +2261,9 @@ mod tests {
                         a: some value
                     bucket1a:
                         bucketName: kalle123
-                    "#
-                ).unwrap(),
+                    "#,
+                )
+                .unwrap(),
             };
             assert_eq!(
                 validate_example(

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -411,7 +411,9 @@ pub async fn publish_stack(
         .collect::<Vec<TfVariable>>();
 
     validate_examples(
-        &[&tf_variables as &[_], &tf_stack_provider_variables].concat(),
+        &tf_stack_provider_variables,
+        &tf_variables,
+        &claim_modules.iter().map(|(deplyment,_)| deplyment.metadata.name.clone()).collect::<Vec<String>>(),
         &mut stack_manifest.spec.examples,
     )?;
 
@@ -1743,105 +1745,156 @@ fn to_mapping(value: serde_yaml::Value) -> Option<serde_yaml::Mapping> {
     }
 }
 
-fn is_all_module_example_variables_valid(
-    tf_variables: &[TfVariable],
-    example_variables: &serde_yaml::Value,
-) -> (bool, String) {
-    let example_variables = to_mapping(example_variables.clone()).unwrap();
-    let top_level_keys = example_variables
-        .iter()
-        .map(|f| f.0.as_str().unwrap())
-        .collect::<HashSet<_>>();
-    let variable_top_level_keys = tf_variables
-        .iter()
-        .map(|f| f.name.as_str().split("__").next().unwrap())
-        .collect::<HashSet<_>>();
-
-    // Check if all top level keys in example_variables are present in tf_variables
-    for top_level_key in top_level_keys {
-        if !variable_top_level_keys.contains(top_level_key) {
-            let error = format!(
-                "Example variable under claim name {} does not exist",
-                top_level_key
-            );
-            return (false, error);
-        }
-    }
-
-    let mut required_variables = tf_variables
-        .iter()
-        .filter(|&x| {
-            (x.default.is_none() || x.default == Some(serde_json::Value::Null)) && !x.nullable
-        })
-        .collect::<Vec<_>>();
-
-    for (top_level_key, module_variables) in example_variables.iter() {
-        let claim_key = top_level_key.as_str().unwrap();
-
-        let module_variables = to_mapping(module_variables.clone()).unwrap();
-        for (key, _value) in module_variables.iter() {
-            let key_str = key.as_str().unwrap();
-            // Check if variable is camelCase
-            if key_str != env_utils::to_camel_case(key_str) {
-                let error = format!(
-                    "Example variable {} is not camelCase like in the deployment claims",
-                    key_str
-                );
-                return (false, error); // Example-variable is not camelCase
-            }
-
-            // TODO: Check if variable is hardcoded in claims and report that with more specific error
-
-            let full_variable_name = format!(
-                "{}__{}",
-                env_utils::to_snake_case(claim_key),
-                env_utils::to_snake_case(key_str)
-            );
-            let tf_variable = tf_variables.iter().find(|&x| x.name == full_variable_name);
-            if tf_variable.is_none() {
-                let error = format!("Example variable {} does not exist under {} (or maybe it is already set in claim?)", key_str, claim_key);
-                return (false, error); // Example-variable does not exist
-            }
-
-            // TODO: Check that type is correct
-
-            // Remove found variable
-            required_variables.retain(|&x| x.name != full_variable_name);
-        }
-    }
-
-    if !required_variables.is_empty() {
-        if let Some(required_variable) = required_variables.first() {
-            let key_str = required_variable.name.split("__").last().unwrap();
-            let claim_key = required_variable.name.split("__").next().unwrap();
-
-            let error = format!(
-                "Example variable {} under {} is required but is not set",
-                key_str, claim_key
-            );
-            return (false, error); // Required variable is null
-        }
-    }
-
-    (true, "".to_string())
-}
-
 fn validate_examples(
-    tf_variables: &[TfVariable],
+    provider_variables: &[TfVariable],
+    stack_variables: &[TfVariable],
+    claim_names: &[String],
     examples: &mut Option<Vec<ModuleExample>>,
 ) -> Result<(), ModuleError> {
+    let mut errors: Vec<String> = Vec::new();
     if let Some(ref mut examples) = examples {
         for example in examples.iter() {
-            let example_variables = &example.variables;
-            let (is_valid, error) =
-                is_all_module_example_variables_valid(tf_variables, example_variables);
-            if !is_valid {
-                return Err(ModuleError::InvalidExampleVariable(error));
-            }
+            errors.extend(validate_example(provider_variables, stack_variables, claim_names, example));
+        }
+        if !errors.is_empty() {
+            return Err(ModuleError::InvalidExampleVariable(errors.join("\n")))
         }
     }
     Ok(())
 }
+
+fn validate_example(
+    provider_variables: &[TfVariable],
+    stack_variables: &[TfVariable],
+    claim_names: &[String],
+    example: &ModuleExample,
+) -> Vec<String> {
+    let mut errors: Vec<String> = Vec::new();
+    let example_variables = to_mapping(example.variables.clone()).unwrap();
+    errors.extend(
+        example_variables
+        .iter()
+        .map(
+            |(key, value)|
+            {
+                let key_str = key.as_str().unwrap();
+                match provider_variables.iter().any(|v| v.name == key_str) {
+                    true => validate_example_variable(provider_variables, None, key_str, value),
+                    false => 
+                        match claim_names.contains(&key_str.to_string()) {
+                            true => validate_module_example(stack_variables, key_str, value),
+                            false => vec![format!("There is no claim or provider variable named \"{}\"", key_str)],
+                        }
+                }
+            }
+        )
+        .flatten()
+        .map(|s| format!("Example \"{}\": {}", example.name, s))
+    );
+    errors.extend(validate_example_required(provider_variables, &example_variables).iter().map(|s| format!("Example \"{}\": {}", example.name, s)));
+    errors.extend(validate_module_example_required(stack_variables, &example_variables).iter().map(|s| format!("Example \"{}\": {}", example.name, s)));
+    return errors
+}
+
+fn validate_example_variable(
+    tf_variables: &[TfVariable],
+    claim: Option<&str>,
+    variable: &str,
+    value: &serde_yaml::Value,
+) -> Vec<String> {
+    let mut errors = vec![];
+    if variable != env_utils::to_camel_case(variable) {
+        errors.push(
+            format!(
+                "Variable \"{}\" should be camelCase",
+                variable
+            )
+        );
+    }
+    let tf_name = match claim {
+        Some(val) => format!("{}__{}", val, to_snake_case(variable)),
+        None => to_snake_case(variable),
+    };
+    let tf_variable = tf_variables.iter().find(|x| x.name == tf_name);
+    if tf_variable.is_none() {
+        errors.push(format!("Variable \"{}\" does not exist", variable));
+    } else {
+        let tf_variable = tf_variable.unwrap();
+        let is_nullable = tf_variable.nullable;
+        if (tf_variable.default == Some(serde_json::Value::Null) || tf_variable.default.is_none())
+            && !is_nullable
+            && value.is_null()
+        {
+            errors.push(format!("Required variable \"{}\" is null but mandatory", variable));
+        }
+
+        //TODO: check the value type agains the tf_variable._type (string, map, bool etc, etc)
+    }
+    return errors;
+}
+
+fn validate_example_required(tf_variables: &[TfVariable], example_variables: &serde_yaml::Mapping) -> Vec<String> {
+    tf_variables
+    .iter()
+    .filter(
+        |v| 
+        !v.nullable 
+        && (v.default.is_none() || v.default == Some(serde_json::Value::Null))
+    )
+    .filter(|v| !example_variables.contains_key(&serde_yaml::Value::String(to_camel_case(&v.name))))
+    .map(|v| format!("Required variable \"{}\" is missing", v.name))
+    .collect::<Vec<String>>()
+}
+
+fn validate_module_example(
+    tf_variables: &[TfVariable],
+    module: &str,
+    value: &serde_yaml::Value,
+) -> Vec<String> {
+    let module_example_variables = to_mapping(value.clone());
+    if module_example_variables.is_none() {
+        return vec![format!("\"{}\" is not a provider variable and is missing claim variables", module)]
+    }
+    module_example_variables
+    .unwrap()
+    .iter()
+    .flat_map(
+        |(key, value)| 
+        validate_example_variable(tf_variables, Some(module), key.as_str().unwrap(), value)
+        .iter()
+        .map(|err| format!("{} for claim \"{}\"", err, module))
+        .collect::<Vec<String>>()
+    ).collect()
+}
+
+fn validate_module_example_required(
+    tf_variables: &[TfVariable], example_variables: &serde_yaml::Mapping
+) -> Vec<String> {
+    tf_variables
+    .iter()
+    .filter(
+        |v| 
+        !v.nullable 
+        && (v.default.is_none() || v.default == Some(serde_json::Value::Null))
+    )
+    .map(|v| v.name.split_once("__").unwrap())
+    .filter(|(claim, variable)| {
+        if let Some(example_claim) = example_variables.get(&serde_yaml::to_value(to_camel_case(claim)).unwrap()) {
+            let mapping = to_mapping(example_claim.clone());
+            if mapping.is_none() {
+                return true
+            }
+            return !mapping.unwrap().get(&serde_yaml::to_value(to_camel_case(variable)).unwrap()).is_some() 
+        } else {
+            return true
+        }
+    })
+    .map(|(claim, variable)| {
+        format!("Required variable \"{}\" for claim \"{}\" is missing", variable, claim)
+    })
+    .collect::<Vec<String>>()
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -1856,113 +1909,322 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
 
-    #[test]
-    fn test_is_example_variables_valid() {
-        let tf_variables = vec![
-            TfVariable {
-                name: "bucket1a__bucket_name".to_string(),
-                description: "The name of the bucket".to_string(),
-                default: None,
-                sensitive: false,
-                nullable: false,
-                _type: serde_json::Value::String("string".to_string()),
-            },
-            TfVariable {
-                name: "bucket1a__tags".to_string(),
-                description: "The tags to apply to the bucket".to_string(),
-                default: None,
-                sensitive: false,
-                nullable: true,
-                _type: serde_json::Value::String("map".to_string()),
-            },
-            TfVariable {
-                name: "bucket2__port_mapping".to_string(),
-                description: "The port mapping".to_string(),
-                default: None,
-                sensitive: false,
-                nullable: true,
-                _type: serde_json::Value::String("list".to_string()),
-            },
-        ];
-        let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
-            r#"
-            bucket1a:
-                bucketName: some-bucket-name
-            bucket2:
-                portMapping:
-                    - port: 80
-                      name: http
-"#,
-        )
-        .unwrap();
-        let (is_valid, _error) =
-            is_all_module_example_variables_valid(&tf_variables, &example_variables);
-        assert_eq!(is_valid, true);
-    }
+    #[cfg(test)]
+    mod example_validation {
+        use env_defs::{ModuleExample, TfVariable};
+        use pretty_assertions::assert_eq;
 
-    #[test]
-    fn test_is_example_variables_invalid_snake_case() {
-        let tf_variables = vec![TfVariable {
-            name: "bucket1a__bucket_name".to_string(),
-            description: "The name of the bucket".to_string(),
-            default: None,
-            sensitive: false,
-            nullable: false,
-            _type: serde_json::Value::String("string".to_string()),
-        }];
-        let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
-            r#"
-            bucket1a:
-                bucket_name: some-bucket-name
-"#,
-        )
-        .unwrap();
-        let (is_valid, _error) =
-            is_all_module_example_variables_valid(&tf_variables, &example_variables);
-        assert_eq!(is_valid, false);
-    }
+        use crate::logic::api_stack::{to_mapping, validate_example, validate_example_required, validate_example_variable, validate_module_example, validate_module_example_required};
 
-    #[test]
-    fn test_is_example_variables_invalid_missing_required() {
-        let tf_variables = vec![
-            TfVariable {
-                name: "bucket1a__bucket_name".to_string(),
-                description: "The name of the bucket".to_string(),
-                default: None,
-                sensitive: false,
-                nullable: false,
-                _type: serde_json::Value::String("string".to_string()),
-            },
-            TfVariable {
-                name: "bucket1a__tags".to_string(),
-                description: "The tags to apply to the bucket".to_string(),
-                default: None,
-                sensitive: false,
-                nullable: true,
-                _type: serde_json::Value::String("map".to_string()),
-            },
-        ];
-        let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
-            r#"
-            bucket1a:
+        #[test]
+        fn provider_ok() {
+            let tf_provider_variables = vec![
+                TfVariable {
+                    name: "tags".to_string(),
+                    description: "Tags to apply to resources".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: true,
+                    _type: serde_json::Value::String("map".to_string()),
+                }
+            ];
+            
+            let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
+                r#"
                 tags:
-                    env: dev
-                    department: engineering
-"#,
-        )
-        .unwrap();
-        let (is_valid, _error) =
-            is_all_module_example_variables_valid(&tf_variables, &example_variables);
-        assert_eq!(is_valid, false);
-    }
+                    owner: development
+                "#,
+            )
+            .unwrap();
+            assert_eq!(
+                validate_example_variable(&tf_provider_variables, None, "tags", example_variables.get("tags").unwrap()),
+                Vec::<String>::new()
+            )
+        }
 
-    #[test]
-    fn test_snake_case_conversion() {
-        assert_eq!(to_snake_case("bucketName"), "bucket_name");
-        assert_eq!(to_snake_case("BucketName"), "bucket_name");
-        assert_eq!(to_snake_case("bucket1a"), "bucket1a");
-        assert_eq!(to_snake_case("bucket2"), "bucket2");
-        assert_eq!(to_camel_case("bucket_name"), "bucketName");
+        #[test]
+        fn provider_not_camle_case() {
+            let tf_provider_variables = vec![
+                TfVariable {
+                    name: "kubernetes_config".to_string(),
+                    description: "kubernetes_config".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: true,
+                    _type: serde_json::Value::String("object".to_string()),
+                }
+            ];
+            
+            let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
+                r#"
+                kubernetes_config:
+                    owner: development
+                "#,
+            )
+            .unwrap();
+            assert_eq!(
+                validate_example_variable(&tf_provider_variables, None, "kubernetes_config", example_variables.get("kubernetes_config").unwrap()),
+                vec!["Variable \"kubernetes_config\" should be camelCase".to_string()]
+            )
+        }
+
+        #[test]
+        fn provider_missing_required() {
+            let tf_provider_variables = vec![
+                TfVariable {
+                    name: "tags".to_string(),
+                    description: "Tags to apply to resources".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("map".to_string()),
+                },
+                TfVariable {
+                    name: "kubernetes_config".to_string(),
+                    description: "kubernetes_config".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: true,
+                    _type: serde_json::Value::String("object".to_string()),
+                }
+            ];
+            
+            let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
+                r#"
+                kuberneteConfig:
+                    owner: development
+                "#,
+            )
+            .unwrap();
+            assert_eq!(
+                validate_example_required(&tf_provider_variables, &to_mapping(example_variables).unwrap()),
+                vec!["Required variable \"tags\" is missing"]
+            )
+        }
+
+        #[test]
+        fn module_ok() {
+            let tf_variables = vec![
+                TfVariable {
+                    name: "bucket1a__bucket_name".to_string(),
+                    description: "The name of the bucket".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("string".to_string()),
+                },
+                TfVariable {
+                    name: "bucket1a__tags".to_string(),
+                    description: "The tags to apply to the bucket".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: true,
+                    _type: serde_json::Value::String("map".to_string()),
+                },
+                TfVariable {
+                    name: "bucket2__port_mapping".to_string(),
+                    description: "The port mapping".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: true,
+                    _type: serde_json::Value::String("list".to_string()),
+                },
+            ];
+            let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
+                r#"
+                bucket1a:
+                    bucketName: some-bucket-name
+                bucket2:
+                    portMapping:
+                        - port: 80
+                          name: http
+                "#,
+            )
+            .unwrap();
+            assert_eq!(
+                validate_module_example(&tf_variables, "bucket1a", &example_variables.get("bucket1a").unwrap()),
+                Vec::<String>::new()
+            );
+            assert_eq!(
+                validate_module_example(&tf_variables, "bucket2", &example_variables.get("bucket2").unwrap()),
+                Vec::<String>::new()
+            );
+        }
+
+        #[test]
+        fn module_not_camel_case() {
+            let tf_variables = vec![TfVariable {
+                name: "bucket1a__bucket_name".to_string(),
+                description: "The name of the bucket".to_string(),
+                default: None,
+                sensitive: false,
+                nullable: false,
+                _type: serde_json::Value::String("string".to_string()),
+            }];
+            let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
+                r#"
+                bucket1a:
+                    bucket_name: some-bucket-name
+                "#,
+            )
+            .unwrap();
+            assert_eq!(
+                validate_module_example(&tf_variables, "bucket1a", &example_variables.get("bucket1a").unwrap()),
+                vec!["Variable \"bucket_name\" should be camelCase for claim \"bucket1a\""]
+            );
+        }
+        #[test]
+        fn module_missing_required() {
+            let tf_variables = vec![
+                TfVariable {
+                    name: "bucket1a__bucket_name".to_string(),
+                    description: "The name of the bucket".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("string".to_string()),
+                },
+                TfVariable {
+                    name: "bucket1a__tags".to_string(),
+                    description: "The tags to apply to the bucket".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: true,
+                    _type: serde_json::Value::String("map".to_string()),
+                },
+            ];
+            let example_variables = serde_yaml::from_str::<serde_yaml::Value>(
+                r#"
+                bucket1a:
+                    tags:
+                        env: dev
+                        department: engineering
+                "#,
+            )
+            .unwrap();
+            assert_eq!(
+                validate_module_example_required(&tf_variables, &to_mapping(example_variables).unwrap()),
+                vec!["Required variable \"bucket_name\" for claim \"bucket1a\" is missing"]
+            );
+        }
+
+        #[test]
+        fn multiple_issues() {
+            let provider_tf_variables = vec![
+                TfVariable {
+                    name: "tags".to_string(),
+                    description: "Tags to apply to resources".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("map".to_string()),
+                }
+            ];
+            let stack_tf_variables = vec![
+                TfVariable {
+                    name: "bucket1a__bucket_name".to_string(),
+                    description: "The name of the bucket".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("string".to_string()),
+                }
+            ];
+            let example = ModuleExample{
+                name: "test example".to_string(),
+                description: "".to_string(),
+                variables: serde_yaml::from_str(
+                    r#"
+                    claimA:
+                        claimA_var1: claim variable not camleCase
+                        claimACorrect: proper claim variable
+                    a_var: provider that is not camelCase
+                    bVar: provider that is camleCase
+                    cNester:
+                        dVar: just a nested provider var
+                    "#
+                ).unwrap(),
+            };
+            assert_eq!(
+                validate_example(
+                    &provider_tf_variables,
+                    &stack_tf_variables,
+                    &vec!["claimA".to_string()],
+                    &example
+                ),
+                vec![
+                    "Example \"test example\": Variable \"claimA_var1\" should be camelCase for claim \"claimA\"",
+                    "Example \"test example\": Variable \"claimA_var1\" does not exist for claim \"claimA\"",
+                    "Example \"test example\": Variable \"claimACorrect\" does not exist for claim \"claimA\"",
+                    "Example \"test example\": There is no claim or provider variable named \"a_var\"",
+                    "Example \"test example\": There is no claim or provider variable named \"bVar\"",
+                    "Example \"test example\": There is no claim or provider variable named \"cNester\"",
+                    "Example \"test example\": Required variable \"tags\" is missing",
+                    "Example \"test example\": Required variable \"bucket_name\" for claim \"bucket1a\" is missing"
+                ]
+            )
+        }
+
+        #[test]
+        fn all_ok() {
+            let provider_tf_variables = vec![
+                TfVariable {
+                    name: "tags".to_string(),
+                    description: "Tags to apply to resources".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("map".to_string()),
+                },
+                TfVariable {
+                    name: "tags2".to_string(),
+                    description: "Tags to apply to resources".to_string(),
+                    default: Some(serde_json::Value::String("kalle".to_string())),
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("map".to_string()),
+                }
+            ];
+            let stack_tf_variables = vec![
+                TfVariable {
+                    name: "bucket1a__bucket_name".to_string(),
+                    description: "The name of the bucket".to_string(),
+                    default: None,
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("string".to_string()),
+                },
+                TfVariable {
+                    name: "bucket1a__force_delete".to_string(),
+                    description: "force_delete default: false".to_string(),
+                    default: Some(serde_json::Value::Bool(false)),
+                    sensitive: false,
+                    nullable: false,
+                    _type: serde_json::Value::String("bool".to_string()),
+                }
+            ];
+            let example = ModuleExample{
+                name: "test example".to_string(),
+                description: "".to_string(),
+                variables: serde_yaml::from_str(
+                    r#"
+                    tags:
+                        a: some value
+                    bucket1a:
+                        bucketName: kalle123
+                    "#
+                ).unwrap(),
+            };
+            assert_eq!(
+                validate_example(
+                    &provider_tf_variables,
+                    &stack_tf_variables,
+                    &vec!["bucket1a".to_string()],
+                    &example
+                ),
+                Vec::<String>::new()
+            )
+        }
     }
 
     #[test]

--- a/env_common/src/logic/tf_provider_mgmt.rs
+++ b/env_common/src/logic/tf_provider_mgmt.rs
@@ -1,7 +1,7 @@
 use log::warn;
 use std::collections::HashMap;
 
-use hcl::{Attribute, Block, BlockBuilder, Body, Expression, Identifier, Object, ObjectKey};
+use hcl::{Attribute, Block, Body, Expression, Identifier, Object, ObjectKey};
 
 pub struct TfProviderMgmt {
     terraform: Vec<Block>,
@@ -61,7 +61,7 @@ impl TfProviderMgmt {
         if self.terraform.is_empty() {
             return vec![];
         }
-        vec![BlockBuilder::new("terraform")
+        vec![Block::builder("terraform")
             .add_attributes(self.required_version())
             .add_blocks(self.required_providers())
             .add_blocks(self.provider_meta())
@@ -134,7 +134,7 @@ impl TfProviderMgmt {
             });
         if !providers.is_empty() {
             blocks.push(
-                BlockBuilder::new("required_providers")
+                Block::builder("required_providers")
                     .add_attributes(
                         providers
                             .iter()
@@ -205,7 +205,7 @@ impl TfProviderMgmt {
         if self.locals.is_empty() {
             return vec![];
         }
-        vec![BlockBuilder::new("locals")
+        vec![Block::builder("locals")
             .add_attributes(self.locals.clone())
             .build()]
     }

--- a/integration-tests/modules/eks/main.tf
+++ b/integration-tests/modules/eks/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
   }
 }
 

--- a/integration-tests/modules/eks/module.yaml
+++ b/integration-tests/modules/eks/module.yaml
@@ -11,5 +11,6 @@ spec:
   memory: "4096"
   providers:
     - name: aws-5
+    - name: kubernetes-2
   description: |
     Deploy a simple EKS cluster

--- a/integration-tests/stacks/static-website/stack.yaml
+++ b/integration-tests/stacks/static-website/stack.yaml
@@ -8,3 +8,11 @@ spec:
   description: |
     Static website in a S3Bucket with route53 configuration
     
+  examples:
+    - name: Simple
+      description: Simple deployment
+      variables:
+        webbucket:
+          bucketName: bucket123
+        tags:
+          owner: development

--- a/integration-tests/tests/module.rs
+++ b/integration-tests/tests/module.rs
@@ -6,7 +6,7 @@ mod module_tests {
     use super::*;
     use env_common::{download_to_vec_from_modules, interface::GenericCloudHandler};
     use env_defs::CloudProvider;
-    use env_utils::{get_terraform_lockfile, get_terraform_tfvars};
+    use env_utils::{get_terraform_lockfile, get_terraform_tfvars, read_tf_from_zip};
     use pretty_assertions::assert_eq;
     use std::{collections::HashSet, env};
 
@@ -340,6 +340,78 @@ mod module_tests {
                     .len(),
                 1
             );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_module_eks_with_automapped_kubernetes() {
+        test_scaffold(|| async move {
+            let lambda_endpoint_url = "http://127.0.0.1:8080";
+            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let current_dir = env::current_dir().expect("Failed to get current directory");
+
+            env_common::publish_provider(
+                &handler,
+                &current_dir
+                    .join("providers/aws-5/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                Some("0.1.2"),
+            )
+            .await
+            .unwrap();
+
+            env_common::publish_provider(
+                &handler,
+                &current_dir
+                    .join("providers/kubernetes-2/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                Some("0.1.2"),
+            )
+            .await
+            .unwrap();
+
+            env_common::publish_module(
+                &handler,
+                &current_dir
+                    .join("modules/eks/")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                &"dev".to_string(),
+                Some("0.1.2-dev+test.10"),
+                None,
+            )
+            .await
+            .unwrap();
+
+            let track = "".to_string();
+
+            let modules = match handler.get_all_latest_module(&track).await {
+                Ok(modules) => modules,
+                Err(_e) => {
+                    let empty: Vec<env_defs::ModuleResp> = vec![];
+                    empty
+                }
+            };
+
+            let zip_data = download_to_vec_from_modules(&handler, &modules[0].s3_key).await;
+            let tf_content = read_tf_from_zip(&zip_data).unwrap();
+            let body = hcl::parse(&tf_content).unwrap();
+
+            let module_eks = body.blocks().find(|b| b.identifier() == "module" && b.labels().contains(&hcl::BlockLabel::String("eks".to_string())));
+            assert_ne!(module_eks, None, "Missing webapp module");
+
+            let locals = body.blocks().find(|b| b.identifier() == "locals");
+            assert_ne!(locals, None, "Missing locals");
+            let locals = locals.unwrap();
+            let kubernetes_endpoint = locals.body().attributes().find(|attr| attr.key() == "kubernetes_endpoint");
+            assert_ne!(kubernetes_endpoint, None, "Missing local \"kubernetes_endpoint\"");
+            assert_eq!(kubernetes_endpoint.unwrap().expr.to_string(), "module.eks.kubernetes_endpoint", "kubernetes_endpoint has not been mapped correctly");
         })
         .await;
     }

--- a/integration-tests/tests/module.rs
+++ b/integration-tests/tests/module.rs
@@ -403,15 +403,29 @@ mod module_tests {
             let tf_content = read_tf_from_zip(&zip_data).unwrap();
             let body = hcl::parse(&tf_content).unwrap();
 
-            let module_eks = body.blocks().find(|b| b.identifier() == "module" && b.labels().contains(&hcl::BlockLabel::String("eks".to_string())));
+            let module_eks = body.blocks().find(|b| {
+                b.identifier() == "module"
+                    && b.labels()
+                        .contains(&hcl::BlockLabel::String("eks".to_string()))
+            });
             assert_ne!(module_eks, None, "Missing webapp module");
 
             let locals = body.blocks().find(|b| b.identifier() == "locals");
             assert_ne!(locals, None, "Missing locals");
             let locals = locals.unwrap();
-            let kubernetes_endpoint = locals.body().attributes().find(|attr| attr.key() == "kubernetes_endpoint");
-            assert_ne!(kubernetes_endpoint, None, "Missing local \"kubernetes_endpoint\"");
-            assert_eq!(kubernetes_endpoint.unwrap().expr.to_string(), "module.eks.kubernetes_endpoint", "kubernetes_endpoint has not been mapped correctly");
+            let kubernetes_endpoint = locals
+                .body()
+                .attributes()
+                .find(|attr| attr.key() == "kubernetes_endpoint");
+            assert_ne!(
+                kubernetes_endpoint, None,
+                "Missing local \"kubernetes_endpoint\""
+            );
+            assert_eq!(
+                kubernetes_endpoint.unwrap().expr.to_string(),
+                "module.eks.kubernetes_endpoint",
+                "kubernetes_endpoint has not been mapped correctly"
+            );
         })
         .await;
     }

--- a/integration-tests/tests/stack.rs
+++ b/integration-tests/tests/stack.rs
@@ -793,7 +793,7 @@ mod stack_tests {
             assert_eq!(stacks[0].track, "dev");
 
             let examples = stacks[0].clone().manifest.spec.examples;
-            assert_eq!(examples.is_none(), true);
+            assert_eq!(examples.is_none(), false);
 
             assert_eq!(stacks[0].tf_variables.len(), 2);
             assert_eq!(


### PR DESCRIPTION
This pull request introduces improvements to Terraform provider management, expands integration test coverage, and enhances stack manifest configuration. The main focus is on supporting automatic mapping of the Kubernetes provider in EKS modules, updating test cases to validate this functionality, and enabling stack manifests to include deployment examples.

### Terraform provider management improvements

* Replaced usage of `BlockBuilder::new` with `Block::builder` in `tf_provider_mgmt.rs` to align with updated `hcl` crate API and ensure compatibility when constructing Terraform blocks. [[1]](diffhunk://#diff-4f5d89cbd8b62dd82b0b12965c0eefcfab73dd5416b4cbcea9ededd653bfca94L64-R64) [[2]](diffhunk://#diff-4f5d89cbd8b62dd82b0b12965c0eefcfab73dd5416b4cbcea9ededd653bfca94L137-R137) [[3]](diffhunk://#diff-4f5d89cbd8b62dd82b0b12965c0eefcfab73dd5416b4cbcea9ededd653bfca94L208-R208) [[4]](diffhunk://#diff-4f5d89cbd8b62dd82b0b12965c0eefcfab73dd5416b4cbcea9ededd653bfca94L4-R4)

### Integration test coverage enhancements

* Added a new test case `test_module_eks_with_automapped_kubernetes` in `module.rs` to validate that the Kubernetes provider is automatically mapped and its endpoint is correctly set in the `locals` block for EKS modules.
* Updated imports in `module.rs` to include `read_tf_from_zip`, supporting the new test logic.

### Stack manifest and module configuration updates

* Added a `kubernetes` provider block in `eks/main.tf` and included `kubernetes-2` in the `providers` list in `eks/module.yaml` to support multi-provider module deployments. [[1]](diffhunk://#diff-e6829ea863a082850aabe612884eab4ab032132935daf9ce6be4159d58a0270cR7-R10) [[2]](diffhunk://#diff-a94c57d6a148dacca2e6131a26d6d824d9adba97f0cbc5d2a9606aa7985e5c8aR14)
* Introduced an `examples` section in `static-website/stack.yaml` to allow stack manifests to define deployment examples.
* Modified stack test assertion in `stack.rs` to expect `examples` to be present in the stack manifest.