### PR TITLE
fix: add deployment bool deserializer

### DIFF
--- a/defs/src/deployment.rs
+++ b/defs/src/deployment.rs
@@ -111,6 +111,32 @@ impl DeploymentStatus {
     }
 }
 
+// Custom deserializer for boolean fields that may come as 0/1 from DynamoDB
+fn deserialize_bool_from_int<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    match Value::deserialize(deserializer)? {
+        Value::Bool(b) => Ok(b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i != 0)
+            } else {
+                Err(D::Error::custom("expected boolean or integer"))
+            }
+        }
+        Value::String(s) => match s.as_str() {
+            "true" | "1" => Ok(true),
+            "false" | "0" => Ok(false),
+            _ => Err(D::Error::custom(
+                "expected boolean, integer, or boolean string",
+            )),
+        },
+        _ => Err(D::Error::custom("expected boolean or integer")),
+    }
+}
+
 pub fn get_deployment_identifier(
     project_id: &str,
     region: &str,
@@ -187,11 +213,13 @@ pub struct DeploymentResp {
     pub module_track: String,
     pub drift_detection: DriftDetection,
     pub next_drift_check_epoch: i128,
+    #[serde(deserialize_with = "deserialize_bool_from_int")]
     pub has_drifted: bool,
     pub variables: Value,
     pub output: Value,
     pub policy_results: Vec<crate::PolicyResult>,
     pub error_text: String,
+    #[serde(deserialize_with = "deserialize_bool_from_int")]
     pub deleted: bool,
     pub dependencies: Vec<Dependency>,
     pub initiated_by: String,


### PR DESCRIPTION
This pull request introduces a custom deserializer to better handle boolean fields in the `DeploymentResp` struct, allowing them to be correctly parsed from various formats (such as integers or strings) that may be returned by DynamoDB. This improves the reliability and flexibility of deserialization for deployment responses.

**Improvements to deserialization robustness:**

* Added a `deserialize_bool_from_int` function to handle boolean fields that may be represented as integers (0/1), strings ("true"/"false", "1"/"0"), or booleans in DynamoDB responses. (`defs/src/deployment.rs`)
* Updated the `DeploymentResp` struct to use the new custom deserializer for the `has_drifted` and `deleted` boolean fields, ensuring correct deserialization regardless of input format. (`defs/src/deployment.rs`)