### PR TITLE
fix: don't store version_diff if not specified

### DIFF
--- a/defs/schema_test/module_resp/module_resp_gen_0006.json
+++ b/defs/schema_test/module_resp/module_resp_gen_0006.json
@@ -1,0 +1,40 @@
+{
+  "track": "",
+  "track_version": "",
+  "version": "",
+  "timestamp": "",
+  "module_name": "",
+  "module": "",
+  "module_type": "",
+  "description": "",
+  "reference": "",
+  "manifest": {
+    "metadata": {
+      "name": ""
+    },
+    "apiVersion": "",
+    "kind": "",
+    "spec": {
+      "moduleName": "",
+      "version": null,
+      "description": "",
+      "reference": "",
+      "examples": null,
+      "cpu": null,
+      "memory": null,
+      "providers": []
+    }
+  },
+  "tf_variables": [],
+  "tf_outputs": [],
+  "tf_providers": [],
+  "tf_required_providers": [],
+  "tf_lock_providers": [],
+  "tf_extra_environment_variables": [],
+  "s3_key": "",
+  "oci_artifact_set": null,
+  "stack_data": null,
+  "cpu": "",
+  "memory": "",
+  "deprecated": false
+}

--- a/defs/src/module.rs
+++ b/defs/src/module.rs
@@ -157,6 +157,9 @@ pub struct ModuleResp {
     pub s3_key: String,
     pub oci_artifact_set: Option<OciArtifactSet>,
     pub stack_data: Option<ModuleStackData>,
+    /// Deprecated: This field is no longer populated and will always be None.
+    /// Kept for backward compatibility only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version_diff: Option<ModuleVersionDiff>,
     pub cpu: String,
     pub memory: String,


### PR DESCRIPTION
This pull request introduces a new test schema file and clarifies the deprecation status of a field in the `ModuleResp` struct for improved backward compatibility and documentation.

**Schema and compatibility improvements:**

* Updated the `ModuleResp` struct in `defs/src/module.rs` to document that the `version_diff` field is deprecated, will always be `None`, and is maintained only for backward compatibility. Also, ensured the field is skipped during serialization if it is `None`.
* Added a new JSON schema file `module_resp_gen_0006.json` in `defs/schema_test/module_resp/` to provide a test fixture for module response objects, including all relevant fields and structure.