### PR TITLE
fix: always show initiated_by for new reconcile

### DIFF
--- a/env_common/src/logic/api_infra.rs
+++ b/env_common/src/logic/api_infra.rs
@@ -480,11 +480,7 @@ pub async fn driftcheck_infra(
                     next_drift_check_epoch: -1, // Prevent reconciler from finding this deployment since it is in progress
                     annotations,
                     dependencies,
-                    initiated_by: if remediate {
-                        handler.get_user_id().await.unwrap()
-                    } else {
-                        deployment.initiated_by.clone()
-                    }, // Dont change the user if it's only a drift check
+                    initiated_by: handler.get_user_id().await.unwrap(),
                     cpu: deployment.cpu.clone(),
                     memory: deployment.memory.clone(),
                     reference: deployment.reference.clone(),


### PR DESCRIPTION
This pull request makes a targeted change to the logic for setting the `initiated_by` field during infrastructure drift checks. Now, the `initiated_by` field is always set to the current user's ID, regardless of whether the operation is a remediation or a drift check.

- Drift check logic update:
  * In `env_common/src/logic/api_infra.rs`, the assignment to the `initiated_by` field in `driftcheck_infra` was changed to always use the current user ID from `handler.get_user_id().await.unwrap()`, instead of preserving the previous initiator for non-remediation drift checks.