### PR TITLE
fix: remove sensitive data from log messages

### DIFF
--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -570,7 +570,7 @@ pub async fn initialize_project_id_and_region() -> String {
             }
         };
         if !is_http_mode {
-            eprintln!("Region: {}", &region);
+            eprintln!("Region initialized");
         }
         crate::logic::REGION
             .set(region)

--- a/internal-api/src/http_router.rs
+++ b/internal-api/src/http_router.rs
@@ -377,10 +377,6 @@ fn extract_jwt_claims(headers: &HeaderMap) -> Option<Value> {
         Ok(claims) => Some(claims),
         Err(e) => {
             log::error!("Failed to parse JWT claims as JSON: {}", e);
-            log::debug!(
-                "Raw payload bytes: {:?}",
-                String::from_utf8_lossy(&payload_bytes)
-            );
             None
         }
     }
@@ -390,7 +386,7 @@ async fn ensure_access(
     headers: &HeaderMap,
     project_id: &str,
 ) -> Result<(), (StatusCode, axum::response::Json<serde_json::Value>)> {
-    if let Some(user_id) = headers.get("x-auth-user").and_then(|v| v.to_str().ok()) {
+    if let Some(_user_id) = headers.get("x-auth-user").and_then(|v| v.to_str().ok()) {
         // Extract JWT claims from Authorization header
         if let Some(claims) = extract_jwt_claims(headers) {
             // Check for allowed_projects claim (configurable via AUTH_ALLOWED_PROJECTS_CLAIM)
@@ -417,10 +413,8 @@ async fn ensure_access(
 
         // No allowed_projects claim found in JWT — deny access
         log::warn!(
-            "User {} has no '{}' claim in JWT — denying access to project {}",
-            user_id,
+            "User has no '{}' claim in JWT — denying access to project",
             crate::auth_handler::allowed_projects_claim_key(),
-            project_id
         );
         Err((
             StatusCode::FORBIDDEN,
@@ -525,7 +519,7 @@ async fn ensure_publish_access(
 ) -> Result<(), (StatusCode, axum::response::Json<serde_json::Value>)> {
     let resource_desc = format!("{}/{}", resource_type, resource_name);
 
-    if let Some(user_id) = headers.get("x-auth-user").and_then(|v| v.to_str().ok()) {
+    if let Some(_user_id) = headers.get("x-auth-user").and_then(|v| v.to_str().ok()) {
         // Check JWT claims for publish permissions (configurable via AUTH_PUBLISH_PERMISSIONS_CLAIM)
         if let Some(claims) = extract_jwt_claims(headers) {
             let claim_key = crate::auth_handler::publish_permissions_claim_key();
@@ -537,19 +531,10 @@ async fn ensure_publish_access(
                     .collect();
 
                 if matches_publish_permission(&permissions, resource_type, resource_name) {
-                    log::info!(
-                        "User {} authorized to publish {} via JWT claim",
-                        user_id,
-                        resource_desc
-                    );
+                    log::info!("User authorized to publish {} via JWT claim", resource_desc);
                     return Ok(());
                 } else {
-                    log::warn!(
-                        "User {} denied publish access to {} (permissions: {:?})",
-                        user_id,
-                        resource_desc,
-                        permissions
-                    );
+                    log::warn!("User denied publish access to {}", resource_desc,);
                     return Err((
                         StatusCode::FORBIDDEN,
                         Json(json!({
@@ -565,7 +550,7 @@ async fn ensure_publish_access(
         }
 
         // No publish_permissions claim found at all → deny
-        log::warn!("User {} has no publish_permissions claim in JWT", user_id);
+        log::warn!("User has no publish_permissions claim in JWT");
         Err((
             StatusCode::FORBIDDEN,
             Json(json!({
@@ -1077,9 +1062,8 @@ async fn get_projects(
 
             if !allowed_projects.is_empty() {
                 log::info!(
-                    "Using allowed_projects from JWT claims for user {}: {:?}",
-                    user_id,
-                    allowed_projects
+                    "Applying {} allowed_projects from JWT claims",
+                    allowed_projects.len()
                 );
                 payload["allowed_projects"] = json!(allowed_projects);
             }


### PR DESCRIPTION
This pull request primarily refines logging in authentication and authorization flows by removing user-identifying information from log messages and reducing log verbosity. These changes help improve privacy and reduce unnecessary log output. The most important changes are:

**Logging Privacy and Verbosity Improvements:**

* Removed user IDs from log messages in the `ensure_access` and `ensure_publish_access` functions, so logs no longer include potentially sensitive user-identifying information. [[1]](diffhunk://#diff-5adf48cc9d732890b7edd2be5901a6bbafcb0797a387240bb3a915547e65b9c8L393-R389) [[2]](diffhunk://#diff-5adf48cc9d732890b7edd2be5901a6bbafcb0797a387240bb3a915547e65b9c8L420-L423) [[3]](diffhunk://#diff-5adf48cc9d732890b7edd2be5901a6bbafcb0797a387240bb3a915547e65b9c8L528-R522) [[4]](diffhunk://#diff-5adf48cc9d732890b7edd2be5901a6bbafcb0797a387240bb3a915547e65b9c8L540-R537) [[5]](diffhunk://#diff-5adf48cc9d732890b7edd2be5901a6bbafcb0797a387240bb3a915547e65b9c8L568-R553)
* Simplified log output in the `get_projects` function to only report the number of allowed projects, instead of logging the user ID and the full list.
* Reduced log verbosity in JWT claim extraction by removing debug logs that output raw payload bytes on failure.
* Updated a log message in `initialize_project_id_and_region` to a more generic message, removing the region value from output.