### PR TITLE
feat: add login command

### DIFF
--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -413,8 +413,8 @@ fn store_local_tokens(api_endpoint: &str) -> Result<()> {
             .yellow()
     );
     let tokens = StoredTokens {
-        access_token: "local".to_string(),
-        id_token: "local".to_string(),
+        access_token: http_client::LOCAL_TOKEN.to_string(),
+        id_token: http_client::LOCAL_TOKEN.to_string(),
         refresh_token: None,
         expires_at: None,
         api_endpoint: api_endpoint.to_string(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -152,6 +152,12 @@ enum Commands {
     },
     /// Launch interactive TUI for exploring modules and deployments
     Ui,
+    /// Authenticate with InfraWeave API using AWS IAM credentials
+    Login {
+        /// API endpoint URL (e.g., https://api.example.com/v1) or use INFRAWEAVE_API_ENDPOINT env var
+        #[arg(short, long)]
+        api_endpoint: Option<String>,
+    },
     /// Start MCP (Model Context Protocol) server for AI tool integration
     #[command(
         about = "MCP server commands for AI tools like Claude Desktop, VSCode Copilot, etc."
@@ -484,6 +490,7 @@ async fn main() {
     // MCP uses stdio for JSON-RPC, so initialization logging would interfere
     let skip_init = matches!(cli.command, Commands::GenerateDocs)
         || matches!(cli.command, Commands::Upgrade { .. })
+        || matches!(cli.command, Commands::Login { .. })
         || matches!(cli.command, Commands::Mcp { command: None })
         || matches!(
             cli.command,
@@ -758,6 +765,35 @@ async fn main() {
         Commands::Ui => {
             if let Err(e) = run_tui().await {
                 eprintln!("Error running TUI: {}", e);
+                std::process::exit(1);
+            }
+        }
+        Commands::Login { api_endpoint } => {
+            // Get endpoint from argument, environment variable, or previously saved config
+            let endpoint = api_endpoint
+                .or_else(|| std::env::var("INFRAWEAVE_API_ENDPOINT").ok())
+                .or_else(|| {
+                    // Try to read from existing config file
+                    env_utils::config_path::get_token_path()
+                        .ok()
+                        .and_then(|path| {
+                            std::fs::read_to_string(&path).ok().and_then(|json| {
+                                serde_json::from_str::<serde_json::Value>(&json)
+                                    .ok()
+                                    .and_then(|v| {
+                                        v.get("api_endpoint")
+                                            .and_then(|e| e.as_str().map(|s| s.to_string()))
+                                    })
+                            })
+                        })
+                })
+                .unwrap_or_else(|| {
+                    eprintln!("Error: API endpoint must be provided via --api-endpoint");
+                    std::process::exit(1);
+                });
+
+            if let Err(e) = commands::auth::execute_login(endpoint).await {
+                eprintln!("Login failed: {}", e);
                 std::process::exit(1);
             }
         }

--- a/http_client/src/client.rs
+++ b/http_client/src/client.rs
@@ -6,6 +6,9 @@ use serde_json::{json, Value};
 use std::sync::OnceLock;
 use std::time::Duration;
 
+/// Sentinel token value used for unauthenticated local mode.
+pub const LOCAL_TOKEN: &str = "local";
+
 /// Returns a shared reqwest::Client with sensible timeouts.
 /// The client is created once and reused for all requests,
 /// avoiding the cost of a new TLS connection pool per request.
@@ -74,7 +77,7 @@ fn get_id_token() -> Result<String> {
         .ok_or_else(|| anyhow!("No id_token found in tokens file. Please run 'infraweave login' to re-authenticate."))?;
 
     // Skip JWT validation for local/unauthenticated mode
-    if token == "local" {
+    if token == LOCAL_TOKEN {
         return Ok(token);
     }
 
@@ -87,6 +90,37 @@ fn get_id_token() -> Result<String> {
     }
 
     Ok(token)
+}
+
+/// Extract user identity (email or sub) from the stored JWT token.
+pub fn get_token_identity() -> Result<String> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+    let token = get_id_token()?;
+    if token == LOCAL_TOKEN {
+        return Ok(LOCAL_TOKEN.into());
+    }
+
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return Err(anyhow!("Invalid JWT format"));
+    }
+
+    let payload_bytes = URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .context("Failed to decode JWT payload")?;
+    let payload: Value = serde_json::from_str(&String::from_utf8(payload_bytes)?)?;
+
+    // Try common identity claims in order of preference
+    for claim in &["email", "preferred_username", "sub"] {
+        if let Some(val) = payload.get(*claim).and_then(|v| v.as_str()) {
+            if !val.is_empty() {
+                return Ok(val.to_string());
+            }
+        }
+    }
+
+    Err(anyhow!("No identity claim found in token"))
 }
 
 /// Check if a JWT token is expired

--- a/http_client/src/lib.rs
+++ b/http_client/src/lib.rs
@@ -11,5 +11,5 @@ pub use client::{
     http_get_module_version, http_get_plan_deployment, http_get_policies, http_get_policy_version,
     http_get_publish_job_status, http_get_stack_version, http_is_deployment_plan_in_progress,
     http_post, http_publish_module, http_publish_provider, http_publish_stack,
-    http_submit_claim_job, is_http_mode_enabled,
+    http_submit_claim_job, is_http_mode_enabled, LOCAL_TOKEN,
 };


### PR DESCRIPTION
Add `infraweave login` CLI command for authenticating with the InfraWeave
API using AWS IAM credentials.

- Add `Login` command variant with `--api-endpoint` flag
- Resolve endpoint from flag, `INFRAWEAVE_API_ENDPOINT` env var, or saved config
- Add `LOCAL_TOKEN` constant in `http_client` to replace hardcoded "local" strings
- Add `get_token_identity()` to extract user identity (email/sub) from stored JWT