### PR TITLE
fix: use --locked for clippy, and check no modifications before version update

### DIFF
--- a/.github/scripts/lint_clippy-2-md.sh
+++ b/.github/scripts/lint_clippy-2-md.sh
@@ -30,7 +30,7 @@ cd "$WORKSPACE_ROOT"
 members=()
 while IFS= read -r line; do
   members+=( "$line" )
-done < <(cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.workspace_members[] as $id | .packages[] | select(.id == $id) | .name')
+done < <(cargo metadata --locked --no-deps --format-version 1 | jq -r '.workspace_members[] as $id | .packages[] | select(.id == $id) | .name')
 
 if [ ${#members[@]} -eq 0 ]; then
   echo "Error: No workspace members found (run from workspace root or check cargo metadata)" >&2
@@ -64,7 +64,7 @@ for pkg in "${crates[@]}"; do
   echo "Running clippy on ${pkg}..."
   echo -e "### Crate: \`${pkg}\`\n" >> "$GITHUB_STEP_SUMMARY"
   set +e
-  cargo clippy -p "$pkg" -q --message-format json-diagnostic-rendered-ansi --no-deps --all-targets > "$tmpout"
+  cargo clippy --locked -p "$pkg" -q --message-format json-diagnostic-rendered-ansi --no-deps --all-targets > "$tmpout"
   pkg_exit=$?
   if [ "$pkg_exit" -ne 0 ]; then
     cat "$tmpout" | jq -n -r 'inputs | select(.reason == "compiler-message" and .message.level == "error") | .message.rendered '

--- a/.github/scripts_test/test_lint_clippy-2-md.sh
+++ b/.github/scripts_test/test_lint_clippy-2-md.sh
@@ -20,7 +20,7 @@ WRAPPER_SCRIPT="$SCRIPT_DIR/github_wrapper.sh"
 members=()
 while IFS= read -r line; do
   members+=( "$line" )
-done < <(cd "$REPO_ROOT" && cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.workspace_members[] as $id | .packages[] | select(.id == $id) | .name')
+done < <(cd "$REPO_ROOT" && cargo metadata --locked --no-deps --format-version 1 | jq -r '.workspace_members[] as $id | .packages[] | select(.id == $id) | .name')
 
 if [ ${#members[@]} -eq 0 ]; then
   echo "Error: No workspace members found (run from repo root or check cargo metadata)" >&2

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           fetch-depth: 1
       
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4
+        with:
+          toolchain: stable
+
+      - name: Check Cargo.lock up to date
+        run: cargo update --workspace --locked --quiet
+
       - name: Validate targets
         env:
           TARGETS: ${{ vars.TARGETS }}
@@ -70,9 +78,10 @@ jobs:
       - name: Set version in Cargo.toml
         shell: bash
         run: |
+          cargo update --workspace --locked --quiet
           sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
           rm -f Cargo.toml.bak
-          cargo metadata > /dev/null 2>&1
+          cargo update --workspace --offline
         
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Check Cargo.lock up to date
+        run: cargo update --workspace --locked --quiet
+      
       - name: Rust Cache
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,20 @@ jobs:
       - name: Run fmt
         run: cargo fmt --check
 
-      - name: Run clippy
+      - name: Check Cargo.lock up to date
         if: ${{ always() }}
+        id: check-cargo-lock
+        run: cargo update --workspace --locked --quiet
+
+      - name: Rust Cache
+        if: ${{ always() && steps.check-cargo-lock.outputs.success == true }}
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          shared-key: "test"
+          save-if: false
+
+      - name: Run clippy
+        if: ${{ always() && steps.check-cargo-lock.outputs.success }}
         run: bash .github/scripts/lint_clippy-2-md.sh ALL
 
   build-tests:
@@ -45,6 +57,9 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Check Cargo.lock up to date
+        run: cargo update --workspace --locked --quiet
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
@@ -55,7 +70,7 @@ jobs:
         run: cargo install cargo-nextest --locked
 
       - name: Build nextest archive
-        run: cargo nextest archive --archive-file nextest-archive.tar.zst --cargo-profile ci-tests
+        run: cargo nextest archive --archive-file nextest-archive.tar.zst --cargo-profile ci-tests --frozen
 
       - name: Upload nextest archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels-maturin-action.yml
+++ b/.github/workflows/wheels-maturin-action.yml
@@ -32,6 +32,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4
+        with:
+          toolchain: stable
+  
+      - name: Check Cargo.lock up to date
+        run: cargo update --workspace --locked --quiet
       
       - name: Validate targets
         env:
@@ -66,9 +74,10 @@ jobs:
       - name: Set version in Cargo.toml
         shell: bash
         run: |
+          cargo update --workspace --locked --quiet
           sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
           rm -f Cargo.toml.bak
-          cargo metadata > /dev/null 2>&1
+          cargo update --workspace --offline
 
       - name: Update pyproject.toml
         shell: bash
@@ -110,18 +119,19 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.rust_target }}
 
+      - name: Set version in Cargo.toml
+        shell: bash
+        run: |
+          cargo update --workspace --locked --quiet
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
+          cargo update --workspace --offline
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
           shared-key: "wheels-${{ matrix.rust_target }}"
           save-if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-      
-      - name: Set version in Cargo.toml
-        shell: bash
-        run: |
-          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-          rm -f Cargo.toml.bak
-          cargo metadata > /dev/null 2>&1
       
       - name: Update pyproject.toml
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
       - id: cargo-clippy
         name: cargo clippy
         entry: cargo
-        args: ["clippy", "--no-deps", "--all-targets"]
+        args: ["clippy", "--locked", "--no-deps", "--all-targets"]
         language: system
         pass_filenames: false


### PR DESCRIPTION
This only contains the check, so this should be failing based on the merge_base (before fixing)

Fix will then be rebased and should then start to work

Failing as expected
CI -> https://github.com/infraweave-io/infraweave/actions/runs/24423486674
Docs -> https://github.com/infraweave-io/infraweave/actions/runs/24423486660

After rebase the build failed, using frozen before cache restore is bad. So switched to only lock.
Will restore old cargo lock so that it's out of sync to make sure that it starts to fail.

Working runs with --locked instead of --frozen:
CI -> https://github.com/infraweave-io/infraweave/actions/runs/24424782944
Docs -> https://github.com/infraweave-io/infraweave/actions/runs/24424782798

Failing builds with Cargo.lock reverted:
CI -> https://github.com/infraweave-io/infraweave/actions/runs/24425941445
Docs -> https://github.com/infraweave-io/infraweave/actions/runs/24425941428