### PR TITLE
fix: minor fixups

### DIFF
--- a/env_azure_direct/README.md
+++ b/env_azure_direct/README.md
@@ -1,3 +1,5 @@
-# Env Azure
+# Env Azure Direct
+
+> **Warning:** This package is not ready for use. It is currently under development and should not be relied upon in any environment.
 
 This package implements the trait CloudProvider for the Azure cloud provider.

--- a/http_client/src/client.rs
+++ b/http_client/src/client.rs
@@ -543,12 +543,6 @@ pub async fn http_publish_module(
     http_post(path, &body).await
 }
 
-/// Get publish job status via HTTP API
-pub async fn http_get_publish_job_status(job_id: &str) -> Result<Value> {
-    let path = format!("/api/v1/module/publish/{}", job_id);
-    http_get(&path).await
-}
-
 /// Deprecate a module version via HTTP API (using PUT)
 pub async fn http_deprecate_module(
     track: &str,

--- a/http_client/src/lib.rs
+++ b/http_client/src/lib.rs
@@ -9,8 +9,7 @@ pub use client::{
     http_get_change_record, http_get_deployments, http_get_events, http_get_job_status,
     http_get_latest_module_version, http_get_latest_provider_version,
     http_get_latest_stack_version, http_get_logs, http_get_module_version,
-    http_get_plan_deployment, http_get_policies, http_get_policy_version,
-    http_get_publish_job_status, http_get_stack_version, http_is_deployment_plan_in_progress,
-    http_post, http_publish_module, http_publish_provider, http_publish_stack,
-    http_submit_claim_job, is_http_mode_enabled, LOCAL_TOKEN,
+    http_get_plan_deployment, http_get_policies, http_get_policy_version, http_get_stack_version,
+    http_is_deployment_plan_in_progress, http_post, http_publish_module, http_publish_provider,
+    http_publish_stack, http_submit_claim_job, is_http_mode_enabled, LOCAL_TOKEN,
 };


### PR DESCRIPTION
This pull request introduces a new `module_version` field to the event data structures and related code, updates documentation for the Azure Direct environment, and removes an unused HTTP API function for publish job status. The main focus is on supporting module versioning in event handling, while also cleaning up and clarifying the codebase.

**Event Data Model and Handling Updates:**

* Added a new `module_version` field to the `EventData` struct, with Serde default support for backward compatibility (`defs/src/event.rs`).
* Updated the `DeploymentStatusHandler` implementation to populate the new `module_version` field when constructing event data (`env_common/src/interface/deployment_status_handler.rs`).

**Documentation:**

* Updated the `env_azure_direct/README.md` to clarify the package name and add a warning that it is under development and not ready for use (`env_azure_direct/README.md`).

**HTTP Client Cleanup:**

* Removed the unused `http_get_publish_job_status` function from the HTTP client and its exports, cleaning up the API surface (`http_client/src/client.rs`, `http_client/src/lib.rs`). [[1]](diffhunk://#diff-06c55bc5afd75af6c03fa7e2fe5edb0a45b76d8c3210b09ea8eab63d966ba14fL546-L551) [[2]](diffhunk://#diff-25542b989b29d8e93daa50f097c29bf226436d13b1fcbea63b4052d48a817923L12-R14)