### PR TITLE
feat(defs): add module_version to PublishJob event

### DIFF
--- a/defs/src/event.rs
+++ b/defs/src/event.rs
@@ -30,6 +30,8 @@ pub struct EventData {
     pub next_drift_check_epoch: i128,
     pub has_drifted: bool,
     pub module: String,
+    #[serde(default)]
+    pub module_version: String,
     pub name: String,
     pub status: String,
     pub timestamp: String,

--- a/env_common/src/interface/deployment_status_handler.rs
+++ b/env_common/src/interface/deployment_status_handler.rs
@@ -165,6 +165,7 @@ impl<'a> DeploymentStatusHandler<'a> {
             epoch,
             status: self.status.to_string(),
             module: self.module.to_string(),
+            module_version: self.module_version.to_string(),
             drift_detection: self.drift_detection.clone(),
             next_drift_check_epoch: self.next_drift_check_epoch,
             has_drifted: self.has_drifted,


### PR DESCRIPTION
This pull request introduces support for tracking the module version in event data structures and ensures that the version information is properly propagated when handling deployment status updates.

Event data structure update:

* Added a new `module_version` field (with a default value) to the `EventData` struct in `defs/src/event.rs` to store the version of the module associated with an event.

Deployment status handling:

* Updated the `DeploymentStatusHandler` in `env_common/src/interface/deployment_status_handler.rs` to set the `module_version` field when constructing event data, ensuring version information is included in status events.