### PR TITLE
fix: bump aws-lc-sys to 0.39.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         run: cargo install cargo-nextest --locked
 
       - name: Build nextest archive
-        run: cargo nextest archive --archive-file nextest-archive.tar.zst --cargo-profile ci-tests --frozen
+        run: cargo nextest archive --archive-file nextest-archive.tar.zst --cargo-profile ci-tests --locked
 
       - name: Upload nextest archive
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
To resolve:
* AWS-LC X.509 Name Constraints Bypass via Wildcard/Unicode CN
* CRL Distribution Point Scope Check Logic Error in AWS-LC
