### PR TITLE
feat: add cargo-deny for dependency checks and create deny.toml configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,12 @@ jobs:
           shared-key: "test"
           save-if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
+      - name: Install cargo-deny
+        run: cargo install cargo-deny@0.19.4 --locked
+
+      - name: Run cargo deny
+        run: cargo deny check
+
       - name: Install nextest
         run: cargo install cargo-nextest --locked
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
+publish = false
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ build-check:
 	@echo "Building with warnings as errors..."
 	RUSTFLAGS="-D warnings" cargo build --all-targets
 
+deny:
+	cargo deny check
+
 unit-tests: build-check
 	cargo test --workspace --exclude integration-tests
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 build = "build.rs"
 
 [dependencies]

--- a/crd-templator/Cargo.toml
+++ b/crd-templator/Cargo.toml
@@ -3,6 +3,7 @@ name = "crd_templator"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/defs/Cargo.toml
+++ b/defs/Cargo.toml
@@ -3,6 +3,7 @@ name = "env_defs"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,270 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #"x86_64-unknown-linux-musl",
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory databases are cloned/fetched into
+#db-path = "$CARGO_HOME/advisory-dbs"
+# The url(s) of the advisory databases to use
+#db-urls = ["https://github.com/rustsec/advisory-db"]
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    # TODO: Fix these vulnerabilities by upgrading dependencies
+    { id = "RUSTSEC-2023-0071", reason = "rsa: Marvin Attack timing sidechannel - pending upgrade" },
+    { id = "RUSTSEC-2026-0097", reason = "rand: unsound with custom logger - pending upgrade" },
+    { id = "RUSTSEC-2026-0098", reason = "webpki: URI name constraints bug - pending upgrade" },
+    { id = "RUSTSEC-2026-0099", reason = "webpki: wildcard name constraints bug - pending upgrade" },
+    # Unmaintained crates (transitive dependencies, no direct fix available)
+    { id = "RUSTSEC-2024-0384", reason = "instant is unmaintained" },
+    { id = "RUSTSEC-2025-0012", reason = "backoff is unmaintained" },
+    { id = "RUSTSEC-2025-0074", reason = "unic-ucd-segment is unmaintained" },
+    { id = "RUSTSEC-2025-0075", reason = "unic-segment is unmaintained" },
+    { id = "RUSTSEC-2025-0080", reason = "unic-char-property is unmaintained" },
+    { id = "RUSTSEC-2025-0081", reason = "unic-common is unmaintained" },
+    { id = "RUSTSEC-2025-0098", reason = "unic-char-range is unmaintained" },
+    { id = "RUSTSEC-2025-0104", reason = "unic-ucd-version is unmaintained" },
+    { id = "RUSTSEC-2025-0119", reason = "number_prefix is unmaintained" },
+    { id = "RUSTSEC-2025-0134", reason = "paste is unmaintained" },
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained" },
+    { id = "RUSTSEC-2024-0436", reason = "rustls-pemfile is unmaintained" },
+    { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained" },
+    # Yanked crate
+    { crate = "half@2.7.0", reason = "yanked version, pending cargo update" },
+]
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "MIT-0",
+    "0BSD",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], crate = "adler32" },
+    { allow = ["LGPL-2.1-or-later"], crate = "r-efi" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The package spec the clarification applies to
+#crate = "ring"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = true
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+]
+# If true, workspace members are automatically allowed even when using deny-by-default
+# This is useful for organizations that want to deny all external dependencies by default
+# but allow their own workspace crates without having to explicitly list them
+allow-workspace = false
+# List of crates to deny
+deny = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#crate = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# github.com organizations to allow git sources for
+github = []
+# gitlab.com organizations to allow git sources for
+gitlab = []
+# bitbucket.org organizations to allow git sources for
+bitbucket = []

--- a/env_aws/Cargo.toml
+++ b/env_aws/Cargo.toml
@@ -3,6 +3,7 @@ name = "env_aws"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"

--- a/env_aws_direct/Cargo.toml
+++ b/env_aws_direct/Cargo.toml
@@ -3,6 +3,7 @@ name = "env_aws_direct"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"

--- a/env_azure/Cargo.toml
+++ b/env_azure/Cargo.toml
@@ -3,6 +3,7 @@ name = "env_azure"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"

--- a/env_azure_direct/Cargo.toml
+++ b/env_azure_direct/Cargo.toml
@@ -3,6 +3,7 @@ name = "env_azure_direct"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"

--- a/env_common/Cargo.toml
+++ b/env_common/Cargo.toml
@@ -3,6 +3,7 @@ name = "env_common"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/gitops/Cargo.toml
+++ b/gitops/Cargo.toml
@@ -3,6 +3,7 @@ name = "gitops"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "graph"
-version = "0.1.0"
 edition = "2024"
+version.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/http_client/Cargo.toml
+++ b/http_client/Cargo.toml
@@ -3,6 +3,7 @@ name = "http_client"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/infraweave-mcp/Cargo.toml
+++ b/infraweave-mcp/Cargo.toml
@@ -3,6 +3,7 @@ name = "infraweave-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 rmcp-openapi = "0.20"

--- a/infraweave_py/Cargo.toml
+++ b/infraweave_py/Cargo.toml
@@ -3,6 +3,7 @@ name = "infraweave_py"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 build = "build.rs"
 
 [dependencies]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "integration-tests"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/internal-api/Cargo.toml
+++ b/internal-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "internal-api"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [features]
 default = ["aws"]

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -3,6 +3,7 @@ name = "operator"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.cross.build.env]
 passthrough = ["K8S_OPENAPI_ENABLED_VERSION"]

--- a/prometheus_exporter/Cargo.toml
+++ b/prometheus_exporter/Cargo.toml
@@ -3,6 +3,7 @@ name = "prometheus_exporter"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/reconciler/Cargo.toml
+++ b/reconciler/Cargo.toml
@@ -3,6 +3,7 @@ name = "reconciler"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/terraform_runner/Cargo.toml
+++ b/terraform_runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "terraform_runner"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "env_utils"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [dependencies]
 zip = "0.6.6"

--- a/webserver-openapi/Cargo.toml
+++ b/webserver-openapi/Cargo.toml
@@ -3,6 +3,7 @@ name = "webserver-openapi"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Add cargo-deny for dependency auditing

- Configure license allow list for Apache-2.0 compatible dependencies
- Ignore existing advisories (vulnerabilities, unmaintained crates) to unblock merge
- Add cargo deny check to CI lint job
- Add make deny target for local use
- Mark all crates as publish = false via workspace setting