### PR TITLE
fix: handle job ID ARN parsing and graceful missing deployment

### DIFF
--- a/env_common/src/logic/api_infra.rs
+++ b/env_common/src/logic/api_infra.rs
@@ -711,15 +711,26 @@ pub async fn is_deployment_plan_in_progress(
     environment: &str,
     job_id: &str,
 ) -> (bool, String, Option<DeploymentResp>) {
+    // Ensure we use the task ID, not the full ARN, for DB lookups
+    let job_id_short = job_id.split('/').last().unwrap_or(job_id);
+
+    // Check deployment record
     let busy_statuses = ["requested", "initiated"]; // TODO: use enums
 
     let deployment = match handler
-        .get_plan_deployment(deployment_id, environment, job_id)
+        .get_plan_deployment(deployment_id, environment, job_id_short)
         .await
     {
         Ok(deployment_resp) => match deployment_resp {
             Some(deployment) => deployment,
-            None => panic!("Deployment plan could not describe since it was not found"),
+            None => {
+                // Deployment not found yet - job may still be starting
+                info!(
+                    "Deployment plan not found yet for {}, job is likely still starting",
+                    deployment_id
+                );
+                return (true, job_id_short.to_string(), None);
+            }
         },
         Err(e) => {
             error!("Failed to describe deployment: {}", e);


### PR DESCRIPTION
This pull request improves the reliability of deployment plan status checks by ensuring the correct job identifier is used for database lookups and by handling missing deployment records more gracefully.

Deployment plan lookup improvements:

* Updated `is_deployment_plan_in_progress` in `env_common/src/logic/api_infra.rs` to extract and use only the task ID portion of `job_id` (not the full ARN) when querying for deployment records, preventing lookup failures due to mismatched identifiers.
* Added logic to handle cases where a deployment record is not found: instead of panicking, the function now logs an informational message and returns early, indicating the job may still be starting.


Dependent on: https://github.com/infraweave-io/infraweave/pull/315