### PR TITLE
refactor: clean up deprecate_stack transaction

### DIFF
--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -798,6 +798,11 @@ pub async fn deprecate_stack(
         }
     }
 
+    // Serialize the existing stack with deprecated flag set to true and optional message
+    let mut updated_stack = existing_stack.clone();
+    updated_stack.deprecated = true;
+    updated_stack.deprecated_message = message.map(|s| s.to_string());
+
     let module_table_placeholder = "modules";
     let mut transaction_items = vec![];
 
@@ -810,10 +815,6 @@ pub async fn deprecate_stack(
     }))
     .unwrap();
 
-    // Serialize the existing stack with deprecated flag set to true and optional message
-    let mut updated_stack = existing_stack.clone();
-    updated_stack.deprecated = true;
-    updated_stack.deprecated_message = message.map(|s| s.to_string());
     let stack_value = serde_json::to_value(&updated_stack)?;
     merge_json_dicts(&mut stack_payload, &stack_value);
 
@@ -824,11 +825,8 @@ pub async fn deprecate_stack(
         }
     }));
 
-    // Execute the Transaction
-    let payload = serde_json::json!({
-        "event": "transact_write",
-        "items": transaction_items,
-    });
+    let items = serde_json::to_value(&transaction_items)?;
+    let payload = env_defs::transact_write_event(&items);
 
     // Get all regions to update deprecation status across all of them
     let all_regions = handler.get_all_regions().await?;


### PR DESCRIPTION
This pull request refactors the `deprecate_stack` function in `api_stack.rs` to improve how stack deprecation is handled and how transactional writes are constructed. The main changes focus on code clarity and using more robust serialization utilities.

**Refactoring and Serialization Improvements:**

* Moved the logic for setting the `deprecated` flag and `deprecated_message` on the stack to an earlier point in the function, clarifying the flow and intent. [[1]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70R801-R805) [[2]](diffhunk://#diff-a8509f6a51910c429dd125f49c8b2c53627adbb34f75c48c4ad33a461902dc70L813-L816)
* Replaced manual construction of the transaction payload with a call to `env_defs::transact_write_event`, ensuring consistency and reducing duplication.