### PR TITLE
fix: add http api integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4706,6 +4706,8 @@ dependencies = [
  "env_defs",
  "env_utils",
  "hcl-rs",
+ "http_client",
+ "internal-api",
  "k8s-openapi",
  "kube",
  "kube-runtime",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -29,6 +29,8 @@ terraform_runner = { path = "../terraform_runner" }
 pretty_assertions = "1.4.1"
 tempfile = "3.0"
 env_utils = { path = "../utils" }
+http_client = { path = "../http_client" }
+internal-api = { path = "../internal-api", features = ["local"] }
 kube = { version = "0.96.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "=0.23.0", features = ["v1_31"] }
 kube-runtime = "0.96.0"

--- a/integration-tests/src/scaffold.rs
+++ b/integration-tests/src/scaffold.rs
@@ -10,6 +10,10 @@ use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
 use testcontainers_modules::dynamodb_local::DynamoDb;
 use testcontainers_modules::localstack::LocalStack;
 
+pub const DYNAMODB_IMAGE: &str = "amazon/dynamodb-local";
+pub const MINIO_IMAGE: &str = "minio/minio";
+pub const ALL_IMAGES: &[&str] = &[DYNAMODB_IMAGE, MINIO_IMAGE];
+
 /// Returns the path to the integration-tests directory (resolved at compile time).
 pub fn integration_tests_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -26,9 +30,9 @@ fn get_image_name(original_image: &str, tag: &str) -> (String, String) {
         "public.ecr.aws/lambda/python" => "lambda-python",
         "mcr.microsoft.com/azure-functions/python" => "azure-functions-python",
         "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator" => "azure-cosmos-emulator",
-        "minio/minio" => "minio",
+        MINIO_IMAGE => "minio",
         "mcr.microsoft.com/azure-storage/azurite" => "azurite",
-        "amazon/dynamodb-local" => "dynamodb-local",
+        DYNAMODB_IMAGE => "dynamodb-local",
         "localstack/localstack" => "localstack",
         _ => return (original_image.to_string(), tag.to_string()),
     };
@@ -257,7 +261,7 @@ pub async fn start_azure_function(
 }
 
 pub async fn start_local_dynamodb(network: &str, port: u16) -> (ContainerAsync<DynamoDb>, String) {
-    let (image_name, image_tag) = get_image_name("amazon/dynamodb-local", "latest");
+    let (image_name, image_tag) = get_image_name(DYNAMODB_IMAGE, "latest");
     let db = DynamoDb::default()
         .with_name(image_name)
         .with_tag(image_tag)
@@ -306,7 +310,7 @@ pub async fn start_local_cosmosdb(network: &str, port: u16) -> ContainerAsync<Ge
 }
 
 pub async fn start_local_minio(network: &str, port: u16) -> (ContainerAsync<GenericImage>, String) {
-    let (image_name, image_tag) = get_image_name("minio/minio", "latest");
+    let (image_name, image_tag) = get_image_name(MINIO_IMAGE, "latest");
     let minio = GenericImage::new(&image_name, &image_tag)
         .with_network(network)
         .with_container_name("minio")

--- a/integration-tests/tests/cli_http.rs
+++ b/integration-tests/tests/cli_http.rs
@@ -1,0 +1,236 @@
+/// Integration tests for the CLI HTTP transport mode.
+///
+/// These tests start the internal-api HTTP server in-process **once** (backed
+/// by testcontainers DynamoDB + MinIO), then all tests reuse the same server.
+/// This validates the full round-trip from the CLI's HTTP transport helpers
+/// through the internal-api HTTP endpoints and back.
+mod utils;
+
+#[cfg(test)]
+#[allow(deprecated)] // set_var/remove_var: safe here — all writes happen inside OnceCell::get_or_init before any test runs
+mod cli_http_tests {
+    use env_common::interface::initialize_project_id_and_region;
+    use integration_tests::scaffold::ALL_IMAGES;
+    use pretty_assertions::assert_eq;
+    use tokio::sync::OnceCell;
+
+    /// Shared infrastructure + server port, initialized exactly once.
+    static SERVER: OnceCell<u16> = OnceCell::const_new();
+
+    /// Remove leftover DynamoDB/MinIO containers from a previous crashed run.
+    fn cleanup_stale_containers() {
+        for image in ALL_IMAGES {
+            let output = std::process::Command::new("docker")
+                .args(["ps", "-q", "--filter", &format!("ancestor={}", image)])
+                .output();
+            if let Ok(out) = output {
+                let ids = String::from_utf8_lossy(&out.stdout);
+                for id in ids.split_whitespace() {
+                    let _ = std::process::Command::new("docker")
+                        .args(["rm", "-f", id])
+                        .output();
+                }
+            }
+        }
+    }
+
+    /// Start local infra and HTTP server once; return the port for all tests.
+    async fn ensure_server() -> u16 {
+        *SERVER
+            .get_or_init(|| async {
+                // Set CWD to workspace root so relative paths in bootstrap work.
+                let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .parent()
+                    .expect("integration-tests must be inside workspace");
+                std::env::set_current_dir(workspace_root)
+                    .expect("Failed to set CWD to workspace root");
+
+                // Remove any leftover containers from a previous failed run.
+                cleanup_stale_containers();
+
+                // Leak the guard so containers stay alive for the entire test run.
+                let infra = internal_api::local_setup::start_local_infrastructure()
+                    .await
+                    .expect("Failed to start local infrastructure");
+                Box::leak(Box::new(infra));
+
+                initialize_project_id_and_region().await;
+
+                let port = internal_api::local_setup::start_test_server();
+
+                // Remove TEST_MODE so is_http_mode_enabled() returns true.
+                std::env::remove_var("TEST_MODE");
+                std::env::set_var(
+                    "INFRAWEAVE_API_ENDPOINT",
+                    format!("http://127.0.0.1:{}", port),
+                );
+
+                // Write a tokens.json with the "local" sentinel to bypass JWT validation.
+                let tokens_path =
+                    env_utils::config_path::get_token_path().expect("Failed to get token path");
+                std::fs::create_dir_all(tokens_path.parent().unwrap()).ok();
+                let tokens_json = serde_json::json!({
+                    "id_token": "local",
+                    "api_endpoint": format!("http://127.0.0.1:{}", port)
+                });
+                std::fs::write(&tokens_path, tokens_json.to_string())
+                    .expect("Failed to write tokens.json");
+
+                // Give the server a moment to start accepting connections.
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+                port
+            })
+            .await
+    }
+
+    // ── Module tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_http_list_modules() {
+        let _port = ensure_server().await;
+
+        // The scaffold seeds s3bucket-simple on the "stable" track
+        let modules = http_client::http_get_all_latest_modules("stable")
+            .await
+            .expect("http_get_all_latest_modules failed");
+
+        assert!(!modules.is_empty(), "Expected at least one seeded module");
+
+        let names: Vec<&str> = modules.iter().map(|m| m.module.as_str()).collect();
+        assert!(
+            names.iter().any(|n| n.contains("s3bucket")),
+            "Expected seeded s3bucket module, got: {:?}",
+            names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_http_get_module_version() {
+        let _port = ensure_server().await;
+
+        let module = http_client::http_get_module_version("stable", "s3bucketsimple", "1.0.0")
+            .await
+            .expect("http_get_module_version failed");
+
+        assert_eq!(module.module, "s3bucketsimple");
+        assert_eq!(module.version, "1.0.0");
+    }
+
+    #[tokio::test]
+    async fn test_http_get_module_version_not_found() {
+        let _port = ensure_server().await;
+
+        let result =
+            http_client::http_get_module_version("stable", "nonexistent-module", "0.0.0").await;
+
+        assert!(result.is_err(), "Expected error for nonexistent module");
+    }
+
+    #[tokio::test]
+    async fn test_http_get_all_versions_for_module() {
+        let _port = ensure_server().await;
+
+        let versions = http_client::http_get_all_versions_for_module("stable", "s3bucketsimple")
+            .await
+            .expect("http_get_all_versions_for_module failed");
+
+        assert!(!versions.is_empty(), "Expected at least one version");
+        assert!(versions.iter().any(|v| v.version == "1.0.0"));
+    }
+
+    // ── Provider tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_http_list_providers() {
+        let _port = ensure_server().await;
+
+        // The scaffold seeds the aws-5 provider
+        let providers = http_client::http_get_all_latest_providers()
+            .await
+            .expect("http_get_all_latest_providers failed");
+
+        assert!(
+            !providers.is_empty(),
+            "Expected at least one seeded provider"
+        );
+    }
+
+    // ── Project tests ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_http_list_projects() {
+        let _port = ensure_server().await;
+
+        // In local mode with no JWT claims, get_projects filters out all
+        // projects (no allowed_projects claim). The test verifies the HTTP
+        // round-trip succeeds without error.
+        let result = http_client::http_get_all_projects().await;
+        assert!(
+            result.is_ok(),
+            "http_get_all_projects should succeed, got: {:?}",
+            result.err()
+        );
+    }
+
+    // ── Deployment tests (protected routes) ─────────────────────────────
+
+    #[tokio::test]
+    async fn test_http_list_deployments_empty() {
+        let _port = ensure_server().await;
+
+        let region = std::env::var("AWS_REGION").unwrap_or_else(|_| "us-west-2".to_string());
+        // No deployments have been created, so the list should be empty
+        let deployments = http_client::http_get_deployments("000000000000", &region)
+            .await
+            .expect("http_get_deployments failed");
+
+        assert!(
+            deployments.is_empty(),
+            "Expected no deployments in fresh scaffold, got: {}",
+            deployments.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_http_describe_deployment_not_found() {
+        let _port = ensure_server().await;
+
+        let region = std::env::var("AWS_REGION").unwrap_or_else(|_| "us-west-2".to_string());
+        let result = http_client::http_describe_deployment(
+            "000000000000",
+            &region,
+            "dev/staging",
+            "nonexistent/deployment",
+        )
+        .await;
+
+        // Should return null for a non-existent deployment (not crash)
+        assert!(
+            result.is_ok(),
+            "Expected graceful handling of missing deployment, got: {:?}",
+            result.err()
+        );
+        let value = result.unwrap();
+        assert!(
+            value.is_null() || value == serde_json::json!(null),
+            "Expected null for non-existent deployment"
+        );
+    }
+
+    // ── Policy tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_http_list_policies_empty() {
+        let _port = ensure_server().await;
+
+        let policies = http_client::http_get_policies("dev")
+            .await
+            .expect("http_get_policies failed");
+
+        assert!(
+            policies.is_empty(),
+            "Expected no policies in fresh scaffold"
+        );
+    }
+}

--- a/internal-api/src/local_setup.rs
+++ b/internal-api/src/local_setup.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "local")]
 use env_common::interface::GenericCloudHandler;
 use env_common::logic::{publish_module, publish_provider};
+use integration_tests::scaffold::MINIO_IMAGE;
 use testcontainers::{runners::AsyncRunner, ContainerAsync, GenericImage, ImageExt};
 use testcontainers_modules::dynamodb_local::DynamoDb;
 
@@ -12,9 +13,7 @@ pub struct LocalInfra {
 pub async fn start_local_infrastructure() -> anyhow::Result<LocalInfra> {
     println!("Starting local infrastructure...");
 
-    // Start DynamoDB - attempt to use port 8000, but verify what we actually got
     let dynamo_container = DynamoDb::default()
-        .with_mapped_port(8000, 8000.into())
         .start()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to start DynamoDB: {}", e))?;
@@ -23,16 +22,14 @@ pub async fn start_local_infrastructure() -> anyhow::Result<LocalInfra> {
     // Force use of localhost for Colima compatibility (avoids issues with non-localhost container hosts)
     let dynamo_endpoint = format!("http://localhost:{}/", dynamo_port);
     println!("DynamoDB started at {}", dynamo_endpoint);
-    println!("NOTE: CLI should use port {} for DynamoDB", dynamo_port);
 
     // Set env vars so standard AWS SDK usage picks them up
     std::env::set_var("DYNAMODB_ENDPOINT", &dynamo_endpoint);
     std::env::set_var("DYNAMODB_ENDPOINT_URL", &dynamo_endpoint);
     std::env::set_var("AWS_ENDPOINT_URL_DYNAMODB", &dynamo_endpoint);
 
-    // Start MinIO - attempt to use port 9000, but verify what we actually got
-    let minio_container = GenericImage::new("minio/minio", "latest")
-        .with_mapped_port(9000, 9000.into())
+    // Start MinIO on a random host port
+    let minio_container = GenericImage::new(MINIO_IMAGE, "latest")
         .with_env_var("MINIO_ACCESS_KEY", "minio")
         .with_env_var("MINIO_SECRET_KEY", "minio123")
         .with_env_var("MINIO_ROOT_USER", "minio")
@@ -46,7 +43,6 @@ pub async fn start_local_infrastructure() -> anyhow::Result<LocalInfra> {
     let minio_port = minio_container.get_host_port_ipv4(9000).await?;
     let minio_endpoint = format!("http://{}:{}/", minio_host, minio_port);
     println!("MinIO started at {}", minio_endpoint);
-    println!("NOTE: CLI should use port {} for S3", minio_port);
 
     // Wait for MinIO to be ready
     let mut minio_ready = false;
@@ -172,4 +168,24 @@ async fn bootstrap_resources() -> anyhow::Result<()> {
     println!("  cargo run --bin cli --features local -- module list dev");
 
     Ok(())
+}
+
+/// Start the HTTP server on a random port and return that port.
+/// Runs for the lifetime of the process; no shutdown is provided.
+pub fn start_test_server() -> u16 {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create server runtime");
+        rt.block_on(async {
+            let app = crate::http_router::create_router();
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("Failed to bind test server");
+            let port = listener.local_addr().unwrap().port();
+            tx.send(port).unwrap();
+            axum::serve(listener, app).await.unwrap();
+        });
+    });
+    rx.recv()
+        .expect("Failed to receive port from server thread")
 }


### PR DESCRIPTION
This pull request adds comprehensive integration tests for the CLI's HTTP transport mode and related infrastructure, ensuring the full round-trip from the CLI through the internal API HTTP endpoints. It also introduces test utilities and necessary dependencies to support these tests.

**Integration test infrastructure and utilities:**

* Added a new test file `cli_http.rs` with integration tests that start the internal-api HTTP server in-process, backed by local DynamoDB and MinIO containers, and validate round-trip HTTP interactions via the CLI.
* Introduced a utility function `start_test_server` in `local_setup.rs` to launch the internal-api HTTP server on a random port in a dedicated thread for test isolation and reliability.

**Dependency and configuration updates:**

* Added `http_client` and `internal-api` (with `local` feature) as path dependencies in `integration-tests/Cargo.toml` to enable direct use of HTTP client helpers and local API server for testing.