### PR TITLE
feat: wire CLI commands to use HTTP transport mode

### DIFF
--- a/cli/src/commands/deployment.rs
+++ b/cli/src/commands/deployment.rs
@@ -1,39 +1,143 @@
+use anyhow::Result;
+use http_client::{
+    http_describe_deployment, http_get_deployments, http_get_logs, http_get_module_version,
+    is_http_mode_enabled,
+};
 use log::error;
 
+use super::{exit_on_err, exit_on_none, fetch_all_projects};
 use crate::current_region_handler;
-use env_defs::{CloudProvider, CloudProviderCommon};
-use std::fs::File;
-use std::io::Write;
+use env_defs::{CloudProvider, CloudProviderCommon, DeploymentResp, ModuleResp};
 
-pub async fn handle_describe(deployment_id: &str, environment: &str) {
-    let (deployment, _) = current_region_handler()
-        .await
-        .get_deployment_and_dependents(deployment_id, environment, false)
-        .await
-        .unwrap();
-    if deployment.is_some() {
-        let deployment = deployment.unwrap();
-        println!(
-            "Deployment: {}",
-            serde_json::to_string_pretty(&deployment).unwrap()
-        );
+// ── Transport-agnostic fetch helpers ────────────────────────────────────────
+
+async fn fetch_deployment(
+    deployment_id: &str,
+    environment: &str,
+) -> Result<Option<DeploymentResp>> {
+    if is_http_mode_enabled() {
+        let handler = current_region_handler().await;
+        let value = http_describe_deployment(
+            handler.get_project_id(),
+            handler.get_region(),
+            environment,
+            deployment_id,
+        )
+        .await?;
+        if value.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::from_value(value)?))
+    } else {
+        let (dep, _) = current_region_handler()
+            .await
+            .get_deployment_and_dependents(deployment_id, environment, false)
+            .await?;
+        Ok(dep)
     }
 }
 
-pub async fn handle_list() {
-    let deployments = current_region_handler()
-        .await
-        .get_all_deployments("", false)
-        .await
-        .unwrap();
-    println!(
-        "{:<15} {:<50} {:<20} {:<25} {:<40}",
-        "Status", "Deployment ID", "Module", "Version", "Environment",
+async fn fetch_module_version(module: &str, track: &str, version: &str) -> Result<ModuleResp> {
+    if is_http_mode_enabled() {
+        Ok(http_get_module_version(track, module, version).await?)
+    } else {
+        current_region_handler()
+            .await
+            .get_module_version(module, track, version)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Module {module} {track} {version} not found"))
+    }
+}
+
+async fn fetch_logs(job_id: &str) -> Result<String> {
+    if is_http_mode_enabled() {
+        let handler = current_region_handler().await;
+        Ok(http_get_logs(handler.get_project_id(), handler.get_region(), job_id).await?)
+    } else {
+        let logs = current_region_handler().await.read_logs(job_id).await?;
+        Ok(logs
+            .iter()
+            .map(|l| l.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n"))
+    }
+}
+
+async fn fetch_deployments(project: &str, region: &str) -> Result<Vec<DeploymentResp>> {
+    if is_http_mode_enabled() {
+        http_get_deployments(project, region)
+            .await?
+            .into_iter()
+            .map(|v| serde_json::from_value(v).map_err(Into::into))
+            .collect()
+    } else {
+        Ok(
+            env_common::interface::GenericCloudHandler::workload(project, region)
+                .await
+                .get_all_deployments("", false)
+                .await?,
+        )
+    }
+}
+
+async fn fetch_deployments_across_projects(
+    filter_project: Option<&str>,
+    filter_region: Option<&str>,
+) -> Result<Vec<DeploymentResp>> {
+    let projects = fetch_all_projects().await?;
+    let mut all = Vec::new();
+    for pd in projects {
+        if let Some(p) = filter_project {
+            if p != pd.project_id {
+                continue;
+            }
+        }
+        let regions: Vec<String> = match filter_region {
+            Some(r) if pd.regions.contains(&r.to_string()) => vec![r.to_string()],
+            Some(_) => vec![],
+            None => pd.regions,
+        };
+        for r in regions {
+            match fetch_deployments(&pd.project_id, &r).await {
+                Ok(deps) => all.extend(deps),
+                Err(e) => error!(
+                    "Failed to fetch deployments for {}/{}: {}",
+                    pd.project_id, r, e
+                ),
+            }
+        }
+    }
+    Ok(all)
+}
+
+// ── Public handlers ─────────────────────────────────────────────────────────
+
+pub async fn handle_describe(deployment_id: &str, environment: &str) {
+    let d = exit_on_none(
+        exit_on_err(fetch_deployment(deployment_id, environment).await),
+        &format!("Deployment not found: {}", deployment_id),
     );
-    for entry in &deployments {
+    println!("Deployment: {}", serde_json::to_string_pretty(&d).unwrap());
+}
+
+pub async fn handle_list(project: Option<&str>, region: Option<&str>) {
+    let all_deployments = if let (Some(p), Some(r)) = (project, region) {
+        exit_on_err(fetch_deployments(p, r).await)
+    } else {
+        // Iterates over known projects/regions, filtering by --project / --region if given
+        exit_on_err(fetch_deployments_across_projects(project, region).await)
+    };
+
+    println!(
+        "{:<15} {:<30} {:<15} {:<50} {:<20} {:<25} {:<40}",
+        "Status", "Project", "Region", "Deployment ID", "Module", "Version", "Environment",
+    );
+    for entry in &all_deployments {
         println!(
-            "{:<15} {:<50} {:<20} {:<25} {:<40}",
+            "{:<15} {:<30} {:<15} {:<50} {:<20} {:<25} {:<40}",
             entry.status,
+            entry.project_id,
+            entry.region,
             entry.deployment_id,
             entry.module,
             format!(
@@ -51,73 +155,36 @@ pub async fn handle_list() {
 }
 
 pub async fn handle_get_claim(deployment_id: &str, environment: &str) {
-    match current_region_handler()
-        .await
-        .get_deployment(deployment_id, environment, false)
-        .await
-    {
-        Ok(deployment) => {
-            if let Some(deployment) = deployment {
-                let module = current_region_handler()
-                    .await
-                    .get_module_version(
-                        &deployment.module,
-                        &deployment.module_track,
-                        &deployment.module_version,
-                    )
-                    .await
-                    .unwrap()
-                    .unwrap();
+    let deployment = exit_on_none(
+        exit_on_err(fetch_deployment(deployment_id, environment).await),
+        &format!("Deployment not found: {}", deployment_id),
+    );
 
-                println!(
-                    "{}",
-                    env_utils::generate_deployment_claim(&deployment, &module)
-                );
-            } else {
-                error!("Deployment not found: {}", deployment_id);
-                std::process::exit(1);
-            }
-        }
-        Err(e) => {
-            error!("Failed to get claim: {}", e);
-            std::process::exit(1);
-        }
-    }
+    let module = exit_on_err(
+        fetch_module_version(
+            &deployment.module,
+            &deployment.module_track,
+            &deployment.module_version,
+        )
+        .await,
+    );
+
+    println!(
+        "{}",
+        env_utils::generate_deployment_claim(&deployment, &module)
+    );
 }
 
 pub async fn handle_get_logs(job_id: &str, output_path: Option<&str>) {
-    match current_region_handler().await.read_logs(job_id).await {
-        Ok(logs) => {
-            let log_content = logs
-                .iter()
-                .map(|log| log.message.as_str())
-                .collect::<Vec<&str>>()
-                .join("\n");
+    let log_content = exit_on_err(fetch_logs(job_id).await);
 
-            match output_path {
-                Some(path) => match File::create(path) {
-                    Ok(mut file) => match file.write_all(log_content.as_bytes()) {
-                        Ok(_) => {
-                            println!("Logs successfully written to: {}", path);
-                        }
-                        Err(e) => {
-                            error!("Failed to write logs to file: {}", e);
-                            std::process::exit(1);
-                        }
-                    },
-                    Err(e) => {
-                        error!("Failed to create file {}: {}", path, e);
-                        std::process::exit(1);
-                    }
-                },
-                None => {
-                    println!("{}", log_content);
-                }
-            }
-        }
-        Err(e) => {
-            error!("Failed to get logs for job {}: {}", job_id, e);
-            std::process::exit(1);
-        }
+    if let Some(path) = output_path {
+        exit_on_err(
+            std::fs::write(path, &log_content)
+                .map_err(|e| anyhow::anyhow!("Failed to write to {}: {}", path, e)),
+        );
+        println!("Logs successfully written to: {}", path);
+    } else {
+        println!("{}", log_content);
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -11,7 +11,26 @@ pub mod provider;
 pub mod stack;
 pub mod upgrade;
 
+use anyhow::Result;
 use colored::Colorize;
+use env_defs::CloudProvider;
+use http_client::{http_get_all_projects, is_http_mode_enabled};
+
+use crate::current_region_handler;
+
+// ── Shared transport-agnostic helpers ───────────────────────────────────────
+
+pub async fn fetch_all_projects() -> Result<Vec<env_defs::ProjectData>> {
+    if is_http_mode_enabled() {
+        http_get_all_projects()
+            .await?
+            .into_iter()
+            .map(|v| serde_json::from_value(v).map_err(Into::into))
+            .collect()
+    } else {
+        Ok(current_region_handler().await.get_all_projects().await?)
+    }
+}
 
 pub fn exit_on_err<T>(result: anyhow::Result<T>) -> T {
     match result {

--- a/cli/src/commands/module.rs
+++ b/cli/src/commands/module.rs
@@ -1,11 +1,85 @@
+use anyhow::Result;
 use env_common::{
     errors::ModuleError,
     logic::{deprecate_module, precheck_module, publish_module},
 };
+use env_defs::CloudProvider;
+use http_client::{
+    http_deprecate_module, http_get_all_latest_modules, http_get_all_versions_for_module,
+    http_get_module_version, is_http_mode_enabled, is_not_found_error,
+};
 use log::{error, info};
 
+use super::{exit_on_err, exit_on_none};
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+// ── Transport-agnostic fetch helpers ────────────────────────────────────────
+
+async fn fetch_all_latest_modules(track: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_latest_modules(track).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_latest_module(track)
+            .await?)
+    }
+}
+
+async fn fetch_module_version(
+    track: &str,
+    module: &str,
+    version: &str,
+) -> Result<Option<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        match http_get_module_version(track, module, version).await {
+            Ok(m) => Ok(Some(m)),
+            Err(e) if is_not_found_error(&e) => Ok(None),
+            Err(e) => Err(e),
+        }
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_module_version(module, track, version)
+            .await?)
+    }
+}
+
+async fn fetch_all_module_versions(track: &str, module: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_versions_for_module(track, module).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_module_versions(module, track)
+            .await?)
+    }
+}
+
+async fn do_deprecate_module(
+    module: &str,
+    track: &str,
+    version: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    if is_http_mode_enabled() {
+        http_deprecate_module(track, module, version, message.map(|s| s.to_string()))
+            .await
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("Failed to deprecate module: {}", e))
+    } else {
+        deprecate_module(
+            &current_region_handler().await,
+            module,
+            track,
+            version,
+            message,
+        )
+        .await
+    }
+}
+
+// ── Public handlers ─────────────────────────────────────────────────────────
 
 pub async fn handle_publish(
     path: &str,
@@ -20,7 +94,7 @@ pub async fn handle_publish(
         Err(ModuleError::ModuleVersionExists(version, error)) => {
             if no_fail_on_exist {
                 info!(
-                    "Module version {} already exists: {}, but continuing due to --no-fail-on-exist exits with success",
+                    "Module version {} already exists: {}, but continuing due to --no-fail-on-exist",
                     version, error
                 );
             } else {
@@ -36,23 +110,13 @@ pub async fn handle_publish(
 }
 
 pub async fn handle_precheck(file: &str) {
-    match precheck_module(&file.to_string()).await {
-        Ok(_) => {
-            info!("Module prechecked successfully");
-        }
-        Err(e) => {
-            error!("Failed during module precheck: {}", e);
-            std::process::exit(1);
-        }
-    }
+    exit_on_err(precheck_module(&file.to_string()).await);
+    info!("Module prechecked successfully");
 }
 
 pub async fn handle_list(track: &str) {
-    let modules = current_region_handler()
-        .await
-        .get_all_latest_module(track)
-        .await
-        .unwrap();
+    let modules = exit_on_err(fetch_all_latest_modules(track).await);
+
     println!(
         "{:<20} {:<20} {:<20} {:<15} {:<15} {:<10}",
         "Module", "ModuleName", "Version", "Track", "Status", "Ref"
@@ -71,88 +135,53 @@ pub async fn handle_list(track: &str) {
 }
 
 pub async fn handle_get(module: &str, version: &str) {
-    let track = "dev".to_string();
-    match current_region_handler()
-        .await
-        .get_module_version(module, &track, version)
-        .await
-        .unwrap()
-    {
-        Some(module) => {
-            println!("Module: {}", serde_json::to_string_pretty(&module).unwrap());
-            if module.deprecated {
-                println!("\n⚠️  WARNING: This module version is DEPRECATED");
-                if let Some(msg) = &module.deprecated_message {
-                    println!("   Reason: {}", msg);
-                }
-            }
-        }
-        None => {
-            error!("Module not found");
-            std::process::exit(1);
+    let track = "dev";
+    let module = exit_on_none(
+        exit_on_err(fetch_module_version(track, module, version).await),
+        "Module not found",
+    );
+    println!(
+        "Module: {}",
+        serde_json::to_string_pretty(&module).unwrap_or_else(|_| "Failed to serialize".to_string())
+    );
+    if module.deprecated {
+        println!("\n⚠️  WARNING: This module version is DEPRECATED");
+        if let Some(msg) = &module.deprecated_message {
+            println!("   Reason: {}", msg);
         }
     }
 }
 
 pub async fn handle_versions(module: &str, track: &str) {
-    match current_region_handler()
-        .await
-        .get_all_module_versions(module, track)
-        .await
-    {
-        Ok(versions) => {
-            if versions.is_empty() {
-                println!("No versions found for module {} on track {}", module, track);
-                return;
-            }
+    let versions = exit_on_err(fetch_all_module_versions(track, module).await);
 
-            println!(
-                "{:<20} {:<15} {:<30} {}",
-                "Version", "Status", "Created", "Message"
-            );
-            for entry in &versions {
-                let status = if entry.deprecated {
-                    "DEPRECATED"
-                } else {
-                    "Active"
-                };
-                let message = if let Some(msg) = &entry.deprecated_message {
-                    msg.as_str()
-                } else {
-                    ""
-                };
-                println!(
-                    "{:<20} {:<15} {:<30} {}",
-                    entry.version, status, entry.timestamp, message
-                );
-            }
-        }
-        Err(e) => {
-            error!("Failed to get module versions: {}", e);
-            std::process::exit(1);
-        }
+    if versions.is_empty() {
+        println!("No versions found for module {} on track {}", module, track);
+        return;
+    }
+
+    println!(
+        "{:<20} {:<15} {:<30} {}",
+        "Version", "Status", "Created", "Message"
+    );
+    for entry in &versions {
+        let status = if entry.deprecated {
+            "DEPRECATED"
+        } else {
+            "Active"
+        };
+        let message = entry.deprecated_message.as_deref().unwrap_or("");
+        println!(
+            "{:<20} {:<15} {:<30} {}",
+            entry.version, status, entry.timestamp, message
+        );
     }
 }
 
 pub async fn handle_deprecate(module: &str, track: &str, version: &str, message: Option<&str>) {
-    match deprecate_module(
-        &current_region_handler().await,
-        module,
-        track,
-        version,
-        message,
-    )
-    .await
-    {
-        Ok(_) => {
-            info!(
-                "Module {} version {} in track {} has been deprecated",
-                module, version, track
-            );
-        }
-        Err(e) => {
-            error!("Failed to deprecate module: {}", e);
-            std::process::exit(1);
-        }
-    }
+    exit_on_err(do_deprecate_module(module, track, version, message).await);
+    info!(
+        "Module {} version {} in track {} has been deprecated",
+        module, version, track
+    );
 }

--- a/cli/src/commands/policy.rs
+++ b/cli/src/commands/policy.rs
@@ -1,8 +1,46 @@
+use anyhow::Result;
 use env_common::logic::publish_policy;
+use env_defs::CloudProvider;
+use http_client::{http_get_policies, http_get_policy_version, is_http_mode_enabled};
 use log::{error, info};
 
+use super::exit_on_err;
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+// ── Transport-agnostic fetch helpers ────────────────────────────────────────
+
+async fn fetch_all_policies(environment: &str) -> Result<Vec<env_defs::PolicyResp>> {
+    if is_http_mode_enabled() {
+        http_get_policies(environment)
+            .await?
+            .into_iter()
+            .map(|v| serde_json::from_value(v).map_err(Into::into))
+            .collect()
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_policies(environment)
+            .await?)
+    }
+}
+
+async fn fetch_policy(
+    policy: &str,
+    environment: &str,
+    version: &str,
+) -> Result<env_defs::PolicyResp> {
+    if is_http_mode_enabled() {
+        let value = http_get_policy_version(environment, policy, version).await?;
+        Ok(serde_json::from_value(value)?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_policy(policy, environment, version)
+            .await?)
+    }
+}
+
+// ── Public handlers ─────────────────────────────────────────────────────────
 
 pub async fn handle_publish(file: &str, environment: &str) {
     match publish_policy(&current_region_handler().await, file, environment).await {
@@ -17,11 +55,8 @@ pub async fn handle_publish(file: &str, environment: &str) {
 }
 
 pub async fn handle_list(environment: &str) {
-    let policies = current_region_handler()
-        .await
-        .get_all_policies(environment)
-        .await
-        .unwrap();
+    let policies = exit_on_err(fetch_all_policies(environment).await);
+
     println!(
         "{:<30} {:<20} {:<20} {:<15} {:<10}",
         "Policy", "PolicyName", "Version", "Environment", "Ref"
@@ -35,17 +70,6 @@ pub async fn handle_list(environment: &str) {
 }
 
 pub async fn handle_get(policy: &str, environment: &str, version: &str) {
-    match current_region_handler()
-        .await
-        .get_policy(policy, environment, version)
-        .await
-    {
-        Ok(policy) => {
-            println!("Policy: {}", serde_json::to_string_pretty(&policy).unwrap());
-        }
-        Err(e) => {
-            error!("Failed to get policy: {}", e);
-            std::process::exit(1);
-        }
-    }
+    let policy = exit_on_err(fetch_policy(policy, environment, version).await);
+    println!("Policy: {}", serde_json::to_string_pretty(&policy).unwrap());
 }

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -1,36 +1,45 @@
-use log::error;
+use colored::Colorize;
 
+use super::{exit_on_err, fetch_all_projects};
 use crate::current_region_handler;
 use env_defs::CloudProvider;
+use http_client::is_http_mode_enabled;
+
+// ── Public handlers ─────────────────────────────────────────────────────────
 
 pub async fn handle_get_current() {
-    match current_region_handler().await.get_current_project().await {
-        Ok(project) => {
-            println!(
-                "Project: {}",
-                serde_json::to_string_pretty(&project).unwrap()
-            );
-        }
-        Err(e) => {
-            error!("Failed to insert project: {}", e);
-            std::process::exit(1);
-        }
+    if is_http_mode_enabled() {
+        eprintln!(
+            "{}",
+            "Error: 'project get' is not supported in HTTP mode".red()
+        );
+        std::process::exit(1);
     }
+    let project = exit_on_err(current_region_handler().await.get_current_project().await);
+    println!(
+        "Project: {}",
+        serde_json::to_string_pretty(&project).unwrap()
+    );
 }
 
 pub async fn handle_get_all() {
-    match current_region_handler().await.get_all_projects().await {
-        Ok(projects) => {
-            for project in projects {
-                println!(
-                    "Project: {}",
-                    serde_json::to_string_pretty(&project).unwrap()
-                );
-            }
-        }
-        Err(e) => {
-            error!("Failed to insert project: {}", e);
-            std::process::exit(1);
+    let projects = exit_on_err(fetch_all_projects().await);
+
+    if projects.is_empty() {
+        println!("No projects found.");
+    } else {
+        println!("{:<20} {:<50}", "Project ID", "Name");
+        println!("{}", "-".repeat(70));
+        for project in projects {
+            println!(
+                "{:<20} {:<50}",
+                project.project_id,
+                if project.name.is_empty() {
+                    "(no name)"
+                } else {
+                    &project.name
+                }
+            );
         }
     }
 }

--- a/cli/src/commands/provider.rs
+++ b/cli/src/commands/provider.rs
@@ -1,8 +1,26 @@
+use anyhow::Result;
 use env_common::{errors::ModuleError, publish_provider};
+use env_defs::CloudProvider;
+use http_client::{http_get_all_latest_providers, is_http_mode_enabled};
 use log::{error, info};
 
+use super::exit_on_err;
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+// ── Transport-agnostic fetch helpers ────────────────────────────────────────
+
+async fn fetch_all_latest_providers() -> Result<Vec<env_defs::ProviderResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_latest_providers().await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_latest_provider()
+            .await?)
+    }
+}
+
+// ── Public handlers ─────────────────────────────────────────────────────────
 
 pub async fn handle_publish(path: &str, version: Option<&str>, no_fail_on_exist: bool) {
     match publish_provider(&current_region_handler().await, path, version).await {
@@ -25,11 +43,8 @@ pub async fn handle_publish(path: &str, version: Option<&str>, no_fail_on_exist:
 }
 
 pub async fn handle_list() {
-    let providers = current_region_handler()
-        .await
-        .get_all_latest_provider()
-        .await
-        .unwrap();
+    let providers = exit_on_err(fetch_all_latest_providers().await);
+
     println!(
         "{:<20} {:<20} {:<20} {:<15} {:<10}",
         "Provider", "Version", "Config name", "Config alias", "Ref"

--- a/cli/src/commands/stack.rs
+++ b/cli/src/commands/stack.rs
@@ -1,23 +1,91 @@
+use anyhow::Result;
 use env_common::{
     errors::ModuleError,
     logic::{deprecate_stack, get_stack_preview, publish_stack},
 };
+use env_defs::CloudProvider;
+use http_client::{
+    http_deprecate_stack, http_get_all_latest_stacks, http_get_all_versions_for_stack,
+    http_get_stack_version, is_http_mode_enabled, is_not_found_error,
+};
 use log::{error, info};
 
+use super::{exit_on_err, exit_on_none};
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+// ── Transport-agnostic fetch helpers ────────────────────────────────────────
+
+async fn fetch_all_latest_stacks(track: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_latest_stacks(track).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_latest_stack(track)
+            .await?)
+    }
+}
+
+async fn fetch_stack_version(
+    track: &str,
+    stack: &str,
+    version: &str,
+) -> Result<Option<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        match http_get_stack_version(track, stack, version).await {
+            Ok(s) => Ok(Some(s)),
+            Err(e) if is_not_found_error(&e) => Ok(None),
+            Err(e) => Err(e),
+        }
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_stack_version(stack, track, version)
+            .await?)
+    }
+}
+
+async fn fetch_all_stack_versions(track: &str, stack: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_versions_for_stack(track, stack).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_stack_versions(stack, track)
+            .await?)
+    }
+}
+
+async fn do_deprecate_stack(
+    stack: &str,
+    track: &str,
+    version: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    if is_http_mode_enabled() {
+        http_deprecate_stack(track, stack, version, message.map(|s| s.to_string()))
+            .await
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("Failed to deprecate stack: {}", e))
+    } else {
+        deprecate_stack(
+            &current_region_handler().await,
+            stack,
+            track,
+            version,
+            message,
+        )
+        .await
+    }
+}
+
+// ── Public handlers ─────────────────────────────────────────────────────────
 
 pub async fn handle_preview(path: &str) {
-    match get_stack_preview(&current_region_handler().await, &path.to_string()).await {
-        Ok(stack_module) => {
-            info!("Stack generated successfully");
-            println!("{}", stack_module);
-        }
-        Err(e) => {
-            error!("Failed to generate preview for stack: {}", e);
-            std::process::exit(1);
-        }
-    }
+    let stack_module =
+        exit_on_err(get_stack_preview(&current_region_handler().await, &path.to_string()).await);
+    info!("Stack generated successfully");
+    println!("{}", stack_module);
 }
 
 pub async fn handle_publish(
@@ -49,11 +117,8 @@ pub async fn handle_publish(
 }
 
 pub async fn handle_list(track: &str) {
-    let stacks = current_region_handler()
-        .await
-        .get_all_latest_stack(track)
-        .await
-        .unwrap();
+    let stacks = exit_on_err(fetch_all_latest_stacks(track).await);
+
     println!(
         "{:<20} {:<20} {:<20} {:<15} {:<15} {:<10}",
         "Stack", "StackName", "Version", "Track", "Status", "Ref"
@@ -72,88 +137,50 @@ pub async fn handle_list(track: &str) {
 }
 
 pub async fn handle_get(stack: &str, version: &str) {
-    let track = "dev".to_string();
-    match current_region_handler()
-        .await
-        .get_stack_version(stack, &track, version)
-        .await
-        .unwrap()
-    {
-        Some(stack) => {
-            println!("Stack: {}", serde_json::to_string_pretty(&stack).unwrap());
-            if stack.deprecated {
-                println!("\n⚠️  WARNING: This stack version is DEPRECATED");
-                if let Some(msg) = &stack.deprecated_message {
-                    println!("   Reason: {}", msg);
-                }
-            }
-        }
-        None => {
-            error!("Stack not found");
-            std::process::exit(1);
+    let track = "dev";
+    let stack = exit_on_none(
+        exit_on_err(fetch_stack_version(track, stack, version).await),
+        "Stack not found",
+    );
+    println!("Stack: {}", serde_json::to_string_pretty(&stack).unwrap());
+    if stack.deprecated {
+        println!("\n⚠️  WARNING: This stack version is DEPRECATED");
+        if let Some(msg) = &stack.deprecated_message {
+            println!("   Reason: {}", msg);
         }
     }
 }
 
 pub async fn handle_versions(stack: &str, track: &str) {
-    match current_region_handler()
-        .await
-        .get_all_stack_versions(stack, track)
-        .await
-    {
-        Ok(versions) => {
-            if versions.is_empty() {
-                println!("No versions found for stack {} on track {}", stack, track);
-                return;
-            }
+    let versions = exit_on_err(fetch_all_stack_versions(track, stack).await);
 
-            println!(
-                "{:<20} {:<15} {:<30} {}",
-                "Version", "Status", "Created", "Message"
-            );
-            for entry in &versions {
-                let status = if entry.deprecated {
-                    "DEPRECATED"
-                } else {
-                    "Active"
-                };
-                let message = if let Some(msg) = &entry.deprecated_message {
-                    msg.as_str()
-                } else {
-                    ""
-                };
-                println!(
-                    "{:<20} {:<15} {:<30} {}",
-                    entry.version, status, entry.timestamp, message
-                );
-            }
-        }
-        Err(e) => {
-            error!("Failed to get stack versions: {}", e);
-            std::process::exit(1);
-        }
+    if versions.is_empty() {
+        println!("No versions found for stack {} on track {}", stack, track);
+        return;
+    }
+
+    println!(
+        "{:<20} {:<15} {:<30} {}",
+        "Version", "Status", "Created", "Message"
+    );
+    for entry in &versions {
+        let status = if entry.deprecated {
+            "DEPRECATED"
+        } else {
+            "Active"
+        };
+        let message = entry.deprecated_message.as_deref().unwrap_or("");
+        println!(
+            "{:<20} {:<15} {:<30} {}",
+            entry.version, status, entry.timestamp, message
+        );
     }
 }
 
 pub async fn handle_deprecate(stack: &str, track: &str, version: &str, message: Option<&str>) {
-    match deprecate_stack(
-        &current_region_handler().await,
-        stack,
-        track,
-        version,
-        message,
-    )
-    .await
-    {
-        Ok(_) => {
-            info!(
-                "Stack {} version {} in track {} has been deprecated",
-                stack, version, track
-            );
-        }
-        Err(e) => {
-            error!("Failed to deprecate stack: {}", e);
-            std::process::exit(1);
-        }
-    }
+    exit_on_err(do_deprecate_stack(stack, track, version, message).await);
+    info!(
+        "Stack {} version {} in track {} has been deprecated",
+        stack, version, track
+    );
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -71,6 +71,9 @@ enum Commands {
         /// Environment id used when planning, e.g. cli/default (optional, will prompt if not provided)
         #[arg(short, long)]
         environment_id: Option<String>,
+        /// Project ID (AWS account ID) for HTTP mode
+        #[arg(short, long)]
+        project: Option<String>,
         /// Flag to indicate if output files should be stored
         #[arg(long)]
         store_files: bool,
@@ -88,6 +91,12 @@ enum Commands {
         /// Environment id used when checking drift, e.g. cli/default (optional, will prompt if not provided)
         #[arg(short, long)]
         environment_id: Option<String>,
+        /// Project ID (AWS account ID) for HTTP mode
+        #[arg(short, long)]
+        project: Option<String>,
+        /// Region for the deployment, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        region: Option<String>,
         /// Flag to indicate if remediate should be performed
         #[arg(long)]
         remediate: bool,
@@ -99,6 +108,9 @@ enum Commands {
         /// Environment id used when applying, e.g. cli/default (optional, will prompt if not provided)
         #[arg(short, long)]
         environment_id: Option<String>,
+        /// Project ID (AWS account ID) for HTTP mode
+        #[arg(short, long)]
+        project: Option<String>,
         /// Flag to indicate if output files should be stored
         #[arg(long)]
         store_files: bool,
@@ -113,6 +125,12 @@ enum Commands {
         /// Environment id where the deployment exists, e.g. cli/default (optional, will prompt if not provided)
         #[arg(short, long)]
         environment_id: Option<String>,
+        /// Project ID (AWS account ID) for HTTP mode
+        #[arg(long)]
+        project: Option<String>,
+        /// Region for the deployment, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        region: Option<String>,
         /// Optional override version of module/stack used during destroy
         #[arg(short, long)]
         version: Option<String>,
@@ -130,11 +148,23 @@ enum Commands {
         /// Environment id of the existing deployment, e.g. cli/default (optional, will prompt if not provided)
         #[arg(short, long)]
         environment_id: Option<String>,
+        /// Project ID, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        project: Option<String>,
+        /// Region for the deployment, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        region: Option<String>,
     },
     /// Download logs for a specific job ID
     GetLogs {
         /// Job ID to download logs for
         job_id: String,
+        /// Project ID, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        project: Option<String>,
+        /// Region for the deployment, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        region: Option<String>,
         /// Optional output file path (prints to stdout if not specified)
         #[arg(short, long)]
         output: Option<String>,
@@ -451,13 +481,26 @@ enum GitopsCommands {
 #[derive(Subcommand)]
 enum DeploymentCommands {
     /// List all deployments for a specific environment
-    List,
+    List {
+        /// Project ID to list deployments from (required in HTTP mode)
+        #[arg(long)]
+        project: Option<String>,
+        /// AWS region (defaults to current region)
+        #[arg(long)]
+        region: Option<String>,
+    },
     /// Describe a specific deployment
     Describe {
         /// Environment id where the deployment exists, e.g. cli/default (optional, will prompt if not provided)
         environment_id: Option<String>,
         /// Deployment id to describe, e.g. s3bucket/my-s3-bucket (optional, will prompt if not provided)
         deployment_id: Option<String>,
+        /// Project ID, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        project: Option<String>,
+        /// Region for the deployment, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        region: Option<String>,
     },
 }
 
@@ -469,6 +512,12 @@ enum AdminCommands {
         environment_id: Option<String>,
         /// Deployment id to set up workspace for, e.g. s3bucket/s3bucket-my-s3-bucket-7FV (optional, will prompt if not provided)
         deployment_id: Option<String>,
+        /// Project ID, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        project: Option<String>,
+        /// Region for the deployment, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        region: Option<String>,
     },
     /// Download the Terraform state file for a specific deployment
     GetState {
@@ -476,6 +525,12 @@ enum AdminCommands {
         environment_id: Option<String>,
         /// Deployment id to get state for, e.g. s3bucket/s3bucket-my-s3-bucket-7FV (optional, will prompt if not provided)
         deployment_id: Option<String>,
+        /// Project ID, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        project: Option<String>,
+        /// Region for the deployment, only used in HTTP mode (ignored otherwise)
+        #[arg(long)]
+        region: Option<String>,
         /// Optional output file path (prints to stdout if not specified)
         #[arg(short, long)]
         output: Option<String>,
@@ -485,6 +540,154 @@ enum AdminCommands {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+
+    // Extract project flag early and set PROJECT_ID OnceCell before initialization.
+    // Login is intentionally excluded – it doesn't interact with project-scoped APIs.
+    match &cli.command {
+        Commands::Plan { project, .. }
+        | Commands::Apply { project, .. }
+        | Commands::Driftcheck { project, .. }
+        | Commands::Destroy { project, .. }
+        | Commands::GetClaim { project, .. }
+        | Commands::GetLogs { project, .. } => {
+            if let Some(project_id) = project {
+                let _ = env_common::logic::PROJECT_ID.set(project_id.clone());
+            }
+        }
+        Commands::Deployments { command } => match command {
+            DeploymentCommands::Describe { project, .. }
+            | DeploymentCommands::List { project, .. } => {
+                if let Some(project_id) = project {
+                    let _ = env_common::logic::PROJECT_ID.set(project_id.clone());
+                }
+            }
+        },
+        Commands::Admin { command } => match command {
+            AdminCommands::SetupWorkspace { project, .. }
+            | AdminCommands::GetState { project, .. } => {
+                if let Some(project_id) = project {
+                    let _ = env_common::logic::PROJECT_ID.set(project_id.clone());
+                }
+            }
+        },
+        _ => {}
+    }
+
+    // Extract region from claim file for plan/apply so the global REGION is set
+    // correctly before initialization (needed for environment prompts, etc.)
+    match &cli.command {
+        Commands::Plan { claim, .. } | Commands::Apply { claim, .. } => {
+            if let Ok(content) = std::fs::read_to_string(claim) {
+                match serde_yaml::from_str::<env_defs::DeploymentManifest>(&content) {
+                    Ok(manifest) => {
+                        let _ = env_common::logic::REGION.set(manifest.spec.region);
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: Failed to parse claim file '{}' as DeploymentManifest: {}",
+                            claim, e
+                        );
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // In HTTP mode, validate that --project and --region are provided for commands
+    // that need them. In non-HTTP mode these are discovered from the cloud provider SDK.
+    if http_client::is_http_mode_enabled() {
+        let require_project = |project: &Option<String>, command_name: &str| {
+            if project.is_none() && env_common::logic::PROJECT_ID.get().is_none() {
+                eprintln!(
+                    "Error: --project is required for '{}' in HTTP mode.\n\
+                     Usage: infraweave <cmd> --project <project-id>",
+                    command_name
+                );
+                std::process::exit(1);
+            }
+        };
+
+        // Validates that a region is available and sets the global REGION OnceCell.
+        // Called only for commands that don't get their region from a claim file
+        // (i.e. everything except plan/apply).
+        let resolve_region = |region: &Option<String>, command_name: &str| {
+            if let Some(r) = region {
+                let _ = env_common::logic::REGION.set(r.clone());
+            } else if let Ok(r) = std::env::var("AWS_REGION") {
+                let _ = env_common::logic::REGION.set(r);
+            } else {
+                eprintln!(
+                    "Error: --region is required for '{}' in HTTP mode.\n\
+                         Usage: infraweave {} --region <region>\n\n\
+                         Alternatively, set the AWS_REGION environment variable.",
+                    command_name, command_name
+                );
+                std::process::exit(1);
+            }
+        };
+
+        match &cli.command {
+            Commands::Plan { project, .. } => {
+                require_project(project, "plan");
+                // Region comes from each claim document's spec.region — no --region needed.
+            }
+            Commands::Apply { project, .. } => {
+                require_project(project, "apply");
+                // Region comes from each claim document's spec.region — no --region needed.
+            }
+            Commands::Destroy {
+                project, region, ..
+            } => {
+                require_project(project, "destroy");
+                resolve_region(region, "destroy");
+            }
+            Commands::Driftcheck {
+                project, region, ..
+            } => {
+                require_project(project, "driftcheck");
+                resolve_region(region, "driftcheck");
+            }
+            Commands::GetClaim {
+                project, region, ..
+            } => {
+                require_project(project, "get-claim");
+                resolve_region(region, "get-claim");
+            }
+            Commands::GetLogs {
+                project, region, ..
+            } => {
+                require_project(project, "get-logs");
+                resolve_region(region, "get-logs");
+            }
+            Commands::Deployments { command } => match command {
+                DeploymentCommands::List { project, .. } => {
+                    require_project(project, "deployments list");
+                }
+                DeploymentCommands::Describe {
+                    project, region, ..
+                } => {
+                    require_project(project, "deployments describe");
+                    resolve_region(region, "deployments describe");
+                }
+            },
+            Commands::Admin { command } => match command {
+                AdminCommands::SetupWorkspace {
+                    project, region, ..
+                } => {
+                    require_project(project, "admin setup-workspace");
+                    resolve_region(region, "admin setup-workspace");
+                }
+                AdminCommands::GetState {
+                    project, region, ..
+                } => {
+                    require_project(project, "admin get-state");
+                    resolve_region(region, "admin get-state");
+                }
+            },
+            _ => {}
+        }
+    }
 
     // Skip initialization for documentation generation and MCP server
     // MCP uses stdio for JSON-RPC, so initialization logging would interfere
@@ -507,6 +710,11 @@ async fn main() {
 
     if !skip_init {
         setup_logging().unwrap();
+
+        // Always initialize - AWS SDK calls will be skipped automatically in HTTP mode.
+        // If PROJECT_ID or REGION were already set above (from --project/--region flags or
+        // claim file parsing), the OnceCells inside this function will no-op on `.set()`
+        // since they can only be written once. This is safe and intentional.
         initialize_project_id_and_region().await;
     }
 
@@ -666,18 +874,26 @@ async fn main() {
         Commands::GetClaim {
             environment_id,
             deployment_id,
+            project: _,
+            region: _,
         } => {
             let (environment_id, deployment_id) =
                 resolve_environment_and_deployment(environment_id, deployment_id).await;
             let env = get_environment(&environment_id);
             commands::deployment::handle_get_claim(&deployment_id, &env).await;
         }
-        Commands::GetLogs { job_id, output } => {
+        Commands::GetLogs {
+            job_id,
+            project: _,
+            region: _,
+            output,
+        } => {
             commands::deployment::handle_get_logs(&job_id, output.as_deref()).await;
         }
         Commands::Plan {
             environment_id,
             claim,
+            project: _,
             store_files,
             destroy,
             follow,
@@ -689,6 +905,8 @@ async fn main() {
         Commands::Driftcheck {
             environment_id,
             deployment_id,
+            project: _,
+            region: _,
             remediate,
         } => {
             let (environment_id, deployment_id) =
@@ -699,6 +917,7 @@ async fn main() {
         Commands::Apply {
             environment_id,
             claim,
+            project: _,
             store_files,
             follow,
         } => {
@@ -709,6 +928,8 @@ async fn main() {
         Commands::Destroy {
             environment_id,
             deployment_id,
+            project: _,
+            region: _,
             version,
             store_files,
             follow,
@@ -726,12 +947,14 @@ async fn main() {
             .await;
         }
         Commands::Deployments { command } => match command {
-            DeploymentCommands::List => {
-                commands::deployment::handle_list().await;
+            DeploymentCommands::List { project, region } => {
+                commands::deployment::handle_list(project.as_deref(), region.as_deref()).await;
             }
             DeploymentCommands::Describe {
                 environment_id,
                 deployment_id,
+                project: _,
+                region: _,
             } => {
                 let (environment_id, deployment_id) =
                     resolve_environment_and_deployment(environment_id, deployment_id).await;
@@ -742,6 +965,8 @@ async fn main() {
             AdminCommands::SetupWorkspace {
                 environment_id,
                 deployment_id,
+                project: _,
+                region: _,
             } => {
                 let (environment_id, deployment_id) =
                     resolve_environment_and_deployment(environment_id, deployment_id).await;
@@ -750,6 +975,8 @@ async fn main() {
             AdminCommands::GetState {
                 environment_id,
                 deployment_id,
+                project: _,
+                region: _,
                 output,
             } => {
                 let (environment_id, deployment_id) =
@@ -764,7 +991,7 @@ async fn main() {
         },
         Commands::Ui => {
             if let Err(e) = run_tui().await {
-                eprintln!("Error running TUI: {}", e);
+                eprintln!("Error running TUI: {:?}", e);
                 std::process::exit(1);
             }
         }
@@ -883,6 +1110,9 @@ async fn run_tui() -> anyhow::Result<()> {
     let mut app = cli::tui::App::new();
     let (bg_sender, mut bg_receiver) = cli::tui::background::create_channel();
     app.set_background_sender(bg_sender);
+
+    // Preload projects in background to speed up Deployments view
+    app.preload_projects();
 
     // Main loop
     loop {

--- a/cli/src/plan.rs
+++ b/cli/src/plan.rs
@@ -1,89 +1,272 @@
-use std::{collections::HashMap, thread, time::Duration, vec};
+use std::{collections::HashMap, time::Duration, vec};
 
 use anyhow::Result;
-use colored::Colorize;
 use env_common::{
     interface::{get_region_env_var, GenericCloudHandler},
-    logic::{is_deployment_in_progress, is_deployment_plan_in_progress},
+    logic::{is_deployment_in_progress, is_deployment_plan_in_progress, PROJECT_ID},
 };
-use env_defs::{pretty_print_resource_changes, CloudProvider, DeploymentResp, DeploymentStatus};
+use env_defs::{pretty_print_resource_changes, CloudProvider, DeploymentResp, DeploymentStatus, InfraChangeRecord};
+use http_client::{
+    http_check_deployment_progress as http_check_progress, http_get_change_record,
+    http_is_deployment_plan_in_progress as http_is_plan_in_progress, is_http_mode_enabled,
+};
 use prettytable::{row, Table};
 
 use log::error;
 
 use crate::ClaimJobStruct;
 
+/// Return the PROJECT_ID or bail with a clear error.
+fn require_project_id() -> Result<&'static str> {
+    PROJECT_ID
+        .get()
+        .map(|s| s.as_str())
+        .ok_or_else(|| anyhow::anyhow!("PROJECT_ID is not set – pass --project in HTTP mode"))
+}
+
 pub async fn follow_execution(
     job_ids: &Vec<ClaimJobStruct>,
     operation: &str, // "plan", "apply", or "destroy"
 ) -> Result<(String, String, String), anyhow::Error> {
+    use colored::Colorize;
+
+    let http_mode = is_http_mode_enabled();
+
     // Keep track of statuses in a hashmap
     let mut statuses: HashMap<String, DeploymentResp> = HashMap::new();
+    let mut last_status: HashMap<String, String> = HashMap::new();
 
     // Polling loop to check job statuses periodically until all are finished
+    let mut failure_errors: Vec<String> = Vec::new();
+
     loop {
-        let mut all_successful = true;
+        let mut all_finished = true;
+        let mut any_failed = false;
 
         for claim_job in job_ids {
             if operation == "plan" {
-                let (in_progress, job_id, deployment) = is_deployment_plan_in_progress(
-                    &GenericCloudHandler::region(&claim_job.region).await,
-                    &claim_job.deployment_id,
-                    &claim_job.environment,
-                    &claim_job.job_id,
-                )
-                .await;
+                let (in_progress, job_id, deployment) = if http_mode {
+                    let project_id = require_project_id()?;
+                    http_is_plan_in_progress(
+                        project_id,
+                        &claim_job.region,
+                        &claim_job.deployment_id,
+                        &claim_job.environment,
+                        &claim_job.job_id,
+                    )
+                    .await
+                } else {
+                    is_deployment_plan_in_progress(
+                        &GenericCloudHandler::region(&claim_job.region).await,
+                        &claim_job.deployment_id,
+                        &claim_job.environment,
+                        &claim_job.job_id,
+                    )
+                    .await
+                };
+
+                // Extract short job ID for display (last part of ARN)
+                let short_job_id = job_id.split('/').last().unwrap_or(&job_id);
 
                 if in_progress {
-                    println!(
-                        "Status of job {}: {}",
-                        job_id,
-                        if in_progress {
-                            "in progress"
+                    // Only print status if it changed
+                    let status_key = format!("{}:in_progress", job_id);
+                    if last_status.get(&job_id) != Some(&status_key) {
+                        println!(
+                            "{} Task {} is {}...",
+                            "⏳".cyan(),
+                            short_job_id.cyan(),
+                            "running".cyan().bold()
+                        );
+                        last_status.insert(job_id.clone(), status_key);
+                    }
+                    all_finished = false;
+                } else {
+                    // Task completed - check if it succeeded or failed
+                    if let Some(dep) = &deployment {
+                        // Status can be "successful", "completed", "success"
+                        let status_msg = if dep.status == "completed"
+                            || dep.status == "success"
+                            || dep.status == "successful"
+                        {
+                            format!(
+                                "{} Task {} {}",
+                                "✓".green(),
+                                short_job_id.green(),
+                                "completed successfully".green().bold()
+                            )
                         } else {
-                            "completed"
+                            any_failed = true;
+                            let mut msg = format!(
+                                "{} Task {} {}",
+                                "✗".red(),
+                                short_job_id.red(),
+                                "failed".red().bold()
+                            );
+                            if !dep.error_text.is_empty() {
+                                msg.push_str(&format!(
+                                    "\n   {}: {}",
+                                    "Error".red().bold(),
+                                    dep.error_text.red()
+                                ));
+                                // Store error for final summary
+                                if !failure_errors.iter().any(|e| e == &dep.error_text) {
+                                    failure_errors.push(dep.error_text.clone());
+                                }
+                            }
+                            msg
+                        };
+
+                        let status_key = format!("{}:done", job_id);
+                        if last_status.get(&job_id) != Some(&status_key) {
+                            println!("{}", status_msg);
+                            last_status.insert(job_id.clone(), status_key);
                         }
-                    );
-                    all_successful = false;
-                }
-
-                statuses.insert(job_id.clone(), deployment.unwrap().clone());
-            } else {
-                let (in_progress, job_id, status, deployment) = is_deployment_in_progress(
-                    &GenericCloudHandler::region(&claim_job.region).await,
-                    &claim_job.deployment_id,
-                    &claim_job.environment,
-                    false,
-                    false,
-                )
-                .await;
-
-                if in_progress {
-                    println!(
-                        "Status of job {}: {} ({})",
-                        job_id,
-                        if in_progress {
-                            "in progress"
-                        } else {
-                            "completed"
-                        },
-                        status
-                    );
-                    all_successful = false;
+                    } else {
+                        // No deployment record and task not in progress = failed
+                        any_failed = true;
+                        let status_key = format!("{}:failed", job_id);
+                        if last_status.get(&job_id) != Some(&status_key) {
+                            println!(
+                                "{} Task {} {}",
+                                "✗".red(),
+                                short_job_id.red(),
+                                "failed".red().bold()
+                            );
+                            last_status.insert(job_id.clone(), status_key);
+                        }
+                    }
                 }
 
                 if let Some(dep) = deployment {
                     statuses.insert(job_id.clone(), dep);
                 }
+            } else {
+                // Apply/Destroy: Use polling logic similar to Plan, checking ECS task status
+                let (in_progress, validated_job_id, deployment) = if http_mode {
+                    let project_id = require_project_id()?;
+                    http_check_progress(
+                        project_id,
+                        &claim_job.region,
+                        &claim_job.deployment_id,
+                        &claim_job.environment,
+                        &claim_job.job_id,
+                    )
+                    .await
+                } else {
+                    let (in_progress, _, _, deployment) = is_deployment_in_progress(
+                        &GenericCloudHandler::region(&claim_job.region).await,
+                        &claim_job.deployment_id,
+                        &claim_job.environment,
+                        false,
+                        false,
+                    )
+                    .await;
+                    (in_progress, claim_job.job_id.clone(), deployment)
+                };
+
+                // Extract short job ID for display
+                let short_job_id = validated_job_id
+                    .split('/')
+                    .last()
+                    .unwrap_or(&validated_job_id);
+
+                if in_progress {
+                    let status_key = format!("{}:in_progress", validated_job_id);
+                    if last_status.get(&validated_job_id) != Some(&status_key) {
+                        println!(
+                            "{} Task {} is {}...",
+                            "⏳".cyan(),
+                            short_job_id.cyan(),
+                            "running".cyan().bold()
+                        );
+                        last_status.insert(validated_job_id.clone(), status_key);
+                    }
+                    all_finished = false;
+                } else {
+                    // Task completed - check if it succeeded or failed
+                    if let Some(dep) = &deployment {
+                        let status_msg = if dep.status == "completed"
+                            || dep.status == "success"
+                            || dep.status == "successful"
+                        {
+                            format!(
+                                "{} Task {} {}",
+                                "✓".green(),
+                                short_job_id.green(),
+                                "completed successfully".green().bold()
+                            )
+                        } else {
+                            any_failed = true;
+                            let mut msg = format!(
+                                "{} Task {} {}",
+                                "✗".red(),
+                                short_job_id.red(),
+                                "failed".red().bold()
+                            );
+                            if !dep.error_text.is_empty() {
+                                msg.push_str(&format!(
+                                    "\n   {}: {}",
+                                    "Error".red().bold(),
+                                    dep.error_text.red()
+                                ));
+                                // Store error for final summary
+                                if !failure_errors.iter().any(|e| e == &dep.error_text) {
+                                    failure_errors.push(dep.error_text.clone());
+                                }
+                            }
+                            msg
+                        };
+
+                        let status_key = format!("{}:done", validated_job_id);
+                        if last_status.get(&validated_job_id) != Some(&status_key) {
+                            println!("{}", status_msg);
+                            last_status.insert(validated_job_id.clone(), status_key);
+                        }
+                    } else {
+                        // Failed but no deployment record updated?
+                        any_failed = true;
+                        let status_key = format!("{}:failed", validated_job_id);
+                        if last_status.get(&validated_job_id) != Some(&status_key) {
+                            println!(
+                                "{} Task {} {}",
+                                "✗".red(),
+                                short_job_id.red(),
+                                "failed".red().bold()
+                            );
+                            last_status.insert(validated_job_id.clone(), status_key);
+                        }
+                    }
+                }
+
+                if let Some(dep) = deployment {
+                    // Use job_id (short) as key
+                    statuses.insert(validated_job_id.clone(), dep);
+                }
             }
         }
 
-        if all_successful {
-            println!("All {} jobs are successful!", operation);
+        if all_finished {
+            if any_failed {
+                println!("\n{} Some {} jobs failed!", "✗".red(), operation);
+                if !failure_errors.is_empty() {
+                    println!("\n{}", "Failure reasons:".red().bold());
+                    for (i, error) in failure_errors.iter().enumerate() {
+                        println!("  {}. {}", i + 1, error.red());
+                    }
+                }
+                return Err(anyhow::anyhow!("One or more jobs failed"));
+            } else {
+                println!(
+                    "\n{} All {} jobs completed successfully!",
+                    "✓".green(),
+                    operation
+                );
+            }
             break;
         }
 
-        thread::sleep(Duration::from_secs(10));
+        tokio::time::sleep(Duration::from_secs(10)).await;
     }
 
     // Build table strings for store_files feature (for plan) and backward compatibility
@@ -115,7 +298,13 @@ pub async fn follow_execution(
         let job_id = &claim_job.job_id;
         let region = &claim_job.region;
 
-        if let Some(deployment) = statuses.get(job_id) {
+        // Normalize to short job ID to match the keys stored in statuses map
+        let job_id_short = job_id.split('/').last().unwrap_or(job_id);
+
+        if let Some(deployment) = statuses
+            .get(job_id_short)
+            .or_else(|| statuses.get(job_id.as_str()))
+        {
             println!("\n{}", "=".repeat(80));
             println!(
                 "Deployment: {} (Environment: {})",
@@ -143,11 +332,35 @@ pub async fn follow_execution(
             // Get change record for the operation (only if job didn't fail during init)
             if deployment.status != DeploymentStatus::FailedInit {
                 let record_type = operation.to_uppercase();
-                match GenericCloudHandler::region(region)
+                log::debug!(
+                    "Fetching change record for job {} in region {} (type: {})",
+                    job_id,
+                    region,
+                    record_type
+                );
+                let change_result = if http_mode {
+                    let project_id = require_project_id()?;
+                    match http_get_change_record(
+                        project_id,
+                        region,
+                        environment,
+                        deployment_id,
+                        job_id,
+                        &record_type,
+                    )
                     .await
-                    .get_change_record(environment, deployment_id, job_id, &record_type)
-                    .await
-                {
+                    {
+                        Ok(value) => serde_json::from_value::<InfraChangeRecord>(value)
+                            .map_err(|e| anyhow::anyhow!(e)),
+                        Err(e) => Err(anyhow::anyhow!(e)),
+                    }
+                } else {
+                    GenericCloudHandler::region(region)
+                        .await
+                        .get_change_record(environment, deployment_id, job_id, &record_type)
+                        .await
+                };
+                match change_result {
                     Ok(change_record) => {
                         println!("\nOutput:\n{}", change_record.plan_std_output);
                         std_output_table.add_row(row![

--- a/http_client/src/client.rs
+++ b/http_client/src/client.rs
@@ -200,6 +200,13 @@ async fn http_get(path: &str) -> Result<Value> {
         .context("Failed to parse JSON response")
 }
 
+/// Check if an error represents a 404 Not Found response from the API.
+/// Use this instead of string-matching on error messages.
+pub fn is_not_found_error(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("status 404") || msg.contains("404 Not Found")
+}
+
 /// Make an authenticated HTTP POST request using JWT token
 pub async fn http_post(path: &str, body: &Value) -> Result<Value> {
     let endpoint = get_api_endpoint()?;
@@ -675,7 +682,7 @@ pub async fn http_get_latest_module_version(
         }
         Ok(_) => Ok(None),
         Err(e) => {
-            if e.to_string().contains("404") || e.to_string().to_lowercase().contains("not found") {
+            if is_not_found_error(&e) {
                 Ok(None)
             } else {
                 Err(e)
@@ -697,7 +704,7 @@ pub async fn http_get_latest_stack_version(track: &str, stack: &str) -> Result<O
         }
         Ok(_) => Ok(None),
         Err(e) => {
-            if e.to_string().contains("404") || e.to_string().to_lowercase().contains("not found") {
+            if is_not_found_error(&e) {
                 Ok(None)
             } else {
                 Err(e)

--- a/http_client/src/lib.rs
+++ b/http_client/src/lib.rs
@@ -11,5 +11,6 @@ pub use client::{
     http_get_latest_stack_version, http_get_logs, http_get_module_version,
     http_get_plan_deployment, http_get_policies, http_get_policy_version, http_get_stack_version,
     http_is_deployment_plan_in_progress, http_post, http_publish_module, http_publish_provider,
-    http_publish_stack, http_submit_claim_job, is_http_mode_enabled, LOCAL_TOKEN,
+    http_publish_stack, http_submit_claim_job, is_http_mode_enabled, is_not_found_error,
+    LOCAL_TOKEN,
 };


### PR DESCRIPTION
**Transport-agnostic fetch helpers and error handling:**
- Introduced helper functions (e.g., `fetch_deployment`, `fetch_all_projects`, `fetch_module_version`, etc.) in `deployment.rs`, `module.rs`, `policy.rs`, and `provider.rs` to abstract over HTTP and direct transport modes, reducing code duplication and centralizing error handling. 
- Replaced ad-hoc error handling with standardized `exit_on_err` and `exit_on_none` helpers, ensuring consistent error reporting and process exit behavior. 

**Deployment command improvements:**
- Updated `handle_list` to support project/region filtering and improved output formatting with additional columns for project and region.
- Refactored `handle_get_claim` and `handle_get_logs` to use new helpers and streamlined error handling.

**Module, policy, and provider command improvements:**
- Added fetch helpers for listing, getting, and deprecating modules, policies, and providers, supporting both HTTP and direct modes. 
- Improved user feedback and output formatting for list and get commands. 

**Project command improvements:**
- Updated project commands to use the new `fetch_all_projects` helper and improved output formatting for project listings. Added a user-friendly error message for unsupported operations in HTTP mode. 

**General codebase cleanup:**
- Removed repetitive error handling and legacy code paths, leading to more maintainable and readable CLI command modules. 
