### PR TITLE
feat(cli): wire CLI commands to HTTP transport mode

### DIFF
--- a/cli/src/commands/deployment.rs
+++ b/cli/src/commands/deployment.rs
@@ -1,39 +1,138 @@
+use anyhow::Result;
+use http_client::{
+    http_describe_deployment, http_get_deployments, http_get_logs, http_get_module_version,
+    is_http_mode_enabled,
+};
 use log::error;
 
+use super::{exit_on_err, exit_on_none, fetch_all_projects};
 use crate::current_region_handler;
-use env_defs::{CloudProvider, CloudProviderCommon};
-use std::fs::File;
-use std::io::Write;
+use env_defs::{CloudProvider, CloudProviderCommon, DeploymentResp, ModuleResp};
 
-pub async fn handle_describe(deployment_id: &str, environment: &str) {
-    let (deployment, _) = current_region_handler()
-        .await
-        .get_deployment_and_dependents(deployment_id, environment, false)
-        .await
-        .unwrap();
-    if deployment.is_some() {
-        let deployment = deployment.unwrap();
-        println!(
-            "Deployment: {}",
-            serde_json::to_string_pretty(&deployment).unwrap()
-        );
+async fn fetch_deployment(
+    deployment_id: &str,
+    environment: &str,
+) -> Result<Option<DeploymentResp>> {
+    if is_http_mode_enabled() {
+        let handler = current_region_handler().await;
+        let value = http_describe_deployment(
+            handler.get_project_id(),
+            handler.get_region(),
+            environment,
+            deployment_id,
+        )
+        .await?;
+        if value.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::from_value(value)?))
+    } else {
+        let (dep, _) = current_region_handler()
+            .await
+            .get_deployment_and_dependents(deployment_id, environment, false)
+            .await?;
+        Ok(dep)
     }
 }
 
-pub async fn handle_list() {
-    let deployments = current_region_handler()
-        .await
-        .get_all_deployments("", false)
-        .await
-        .unwrap();
-    println!(
-        "{:<15} {:<50} {:<20} {:<25} {:<40}",
-        "Status", "Deployment ID", "Module", "Version", "Environment",
+async fn fetch_module_version(module: &str, track: &str, version: &str) -> Result<ModuleResp> {
+    if is_http_mode_enabled() {
+        Ok(http_get_module_version(track, module, version).await?)
+    } else {
+        current_region_handler()
+            .await
+            .get_module_version(module, track, version)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Module {module} {track} {version} not found"))
+    }
+}
+
+async fn fetch_logs(job_id: &str) -> Result<String> {
+    if is_http_mode_enabled() {
+        let handler = current_region_handler().await;
+        Ok(http_get_logs(handler.get_project_id(), handler.get_region(), job_id).await?)
+    } else {
+        let logs = current_region_handler().await.read_logs(job_id).await?;
+        Ok(logs
+            .iter()
+            .map(|l| l.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n"))
+    }
+}
+
+async fn fetch_deployments(project: &str, region: &str) -> Result<Vec<DeploymentResp>> {
+    if is_http_mode_enabled() {
+        http_get_deployments(project, region)
+            .await?
+            .into_iter()
+            .map(|v| serde_json::from_value(v).map_err(Into::into))
+            .collect()
+    } else {
+        Ok(
+            env_common::interface::GenericCloudHandler::workload(project, region)
+                .await
+                .get_all_deployments("", false)
+                .await?,
+        )
+    }
+}
+
+async fn fetch_deployments_across_projects(
+    filter_project: Option<&str>,
+    filter_region: Option<&str>,
+) -> Result<Vec<DeploymentResp>> {
+    let projects = fetch_all_projects().await?;
+    let mut all = Vec::new();
+    for pd in projects {
+        if let Some(p) = filter_project {
+            if p != pd.project_id {
+                continue;
+            }
+        }
+        let regions: Vec<String> = match filter_region {
+            Some(r) if pd.regions.contains(&r.to_string()) => vec![r.to_string()],
+            Some(_) => vec![],
+            None => pd.regions,
+        };
+        for r in regions {
+            match fetch_deployments(&pd.project_id, &r).await {
+                Ok(deps) => all.extend(deps),
+                Err(e) => error!(
+                    "Failed to fetch deployments for {}/{}: {}",
+                    pd.project_id, r, e
+                ),
+            }
+        }
+    }
+    Ok(all)
+}
+
+pub async fn handle_describe(deployment_id: &str, environment: &str) {
+    let d = exit_on_none(
+        exit_on_err(fetch_deployment(deployment_id, environment).await),
+        &format!("Deployment not found: {}", deployment_id),
     );
-    for entry in &deployments {
+    println!("Deployment: {}", serde_json::to_string_pretty(&d).unwrap());
+}
+
+pub async fn handle_list(project: Option<&str>, region: Option<&str>) {
+    let all_deployments = if let (Some(p), Some(r)) = (project, region) {
+        exit_on_err(fetch_deployments(p, r).await)
+    } else {
+        exit_on_err(fetch_deployments_across_projects(project, region).await)
+    };
+
+    println!(
+        "{:<15} {:<30} {:<15} {:<50} {:<20} {:<25} {:<40}",
+        "Status", "Project", "Region", "Deployment ID", "Module", "Version", "Environment",
+    );
+    for entry in &all_deployments {
         println!(
-            "{:<15} {:<50} {:<20} {:<25} {:<40}",
+            "{:<15} {:<30} {:<15} {:<50} {:<20} {:<25} {:<40}",
             entry.status,
+            entry.project_id,
+            entry.region,
             entry.deployment_id,
             entry.module,
             format!(
@@ -51,73 +150,36 @@ pub async fn handle_list() {
 }
 
 pub async fn handle_get_claim(deployment_id: &str, environment: &str) {
-    match current_region_handler()
-        .await
-        .get_deployment(deployment_id, environment, false)
-        .await
-    {
-        Ok(deployment) => {
-            if let Some(deployment) = deployment {
-                let module = current_region_handler()
-                    .await
-                    .get_module_version(
-                        &deployment.module,
-                        &deployment.module_track,
-                        &deployment.module_version,
-                    )
-                    .await
-                    .unwrap()
-                    .unwrap();
+    let deployment = exit_on_none(
+        exit_on_err(fetch_deployment(deployment_id, environment).await),
+        &format!("Deployment not found: {}", deployment_id),
+    );
 
-                println!(
-                    "{}",
-                    env_utils::generate_deployment_claim(&deployment, &module)
-                );
-            } else {
-                error!("Deployment not found: {}", deployment_id);
-                std::process::exit(1);
-            }
-        }
-        Err(e) => {
-            error!("Failed to get claim: {}", e);
-            std::process::exit(1);
-        }
-    }
+    let module = exit_on_err(
+        fetch_module_version(
+            &deployment.module,
+            &deployment.module_track,
+            &deployment.module_version,
+        )
+        .await,
+    );
+
+    println!(
+        "{}",
+        env_utils::generate_deployment_claim(&deployment, &module)
+    );
 }
 
 pub async fn handle_get_logs(job_id: &str, output_path: Option<&str>) {
-    match current_region_handler().await.read_logs(job_id).await {
-        Ok(logs) => {
-            let log_content = logs
-                .iter()
-                .map(|log| log.message.as_str())
-                .collect::<Vec<&str>>()
-                .join("\n");
+    let log_content = exit_on_err(fetch_logs(job_id).await);
 
-            match output_path {
-                Some(path) => match File::create(path) {
-                    Ok(mut file) => match file.write_all(log_content.as_bytes()) {
-                        Ok(_) => {
-                            println!("Logs successfully written to: {}", path);
-                        }
-                        Err(e) => {
-                            error!("Failed to write logs to file: {}", e);
-                            std::process::exit(1);
-                        }
-                    },
-                    Err(e) => {
-                        error!("Failed to create file {}: {}", path, e);
-                        std::process::exit(1);
-                    }
-                },
-                None => {
-                    println!("{}", log_content);
-                }
-            }
-        }
-        Err(e) => {
-            error!("Failed to get logs for job {}: {}", job_id, e);
-            std::process::exit(1);
-        }
+    if let Some(path) = output_path {
+        exit_on_err(
+            std::fs::write(path, &log_content)
+                .map_err(|e| anyhow::anyhow!("Failed to write to {}: {}", path, e)),
+        );
+        println!("Logs successfully written to: {}", path);
+    } else {
+        println!("{}", log_content);
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -11,7 +11,24 @@ pub mod provider;
 pub mod stack;
 pub mod upgrade;
 
+use anyhow::Result;
 use colored::Colorize;
+use env_defs::CloudProvider;
+use http_client::{http_get_all_projects, is_http_mode_enabled};
+
+use crate::current_region_handler;
+
+pub async fn fetch_all_projects() -> Result<Vec<env_defs::ProjectData>> {
+    if is_http_mode_enabled() {
+        http_get_all_projects()
+            .await?
+            .into_iter()
+            .map(|v| serde_json::from_value(v).map_err(Into::into))
+            .collect()
+    } else {
+        Ok(current_region_handler().await.get_all_projects().await?)
+    }
+}
 
 pub fn exit_on_err<T>(result: anyhow::Result<T>) -> T {
     match result {

--- a/cli/src/commands/module.rs
+++ b/cli/src/commands/module.rs
@@ -1,11 +1,81 @@
+use anyhow::Result;
 use env_common::{
     errors::ModuleError,
     logic::{deprecate_module, precheck_module, publish_module},
 };
+use env_defs::CloudProvider;
+use http_client::{
+    http_deprecate_module, http_get_all_latest_modules, http_get_all_versions_for_module,
+    http_get_module_version, is_http_mode_enabled, is_not_found_error,
+};
 use log::{error, info};
 
+use super::{exit_on_err, exit_on_none};
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+async fn fetch_all_latest_modules(track: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_latest_modules(track).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_latest_module(track)
+            .await?)
+    }
+}
+
+async fn fetch_module_version(
+    track: &str,
+    module: &str,
+    version: &str,
+) -> Result<Option<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        match http_get_module_version(track, module, version).await {
+            Ok(m) => Ok(Some(m)),
+            Err(e) if is_not_found_error(&e) => Ok(None),
+            Err(e) => Err(e),
+        }
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_module_version(module, track, version)
+            .await?)
+    }
+}
+
+async fn fetch_all_module_versions(track: &str, module: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_versions_for_module(track, module).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_module_versions(module, track)
+            .await?)
+    }
+}
+
+async fn do_deprecate_module(
+    module: &str,
+    track: &str,
+    version: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    if is_http_mode_enabled() {
+        http_deprecate_module(track, module, version, message.map(|s| s.to_string()))
+            .await
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("Failed to deprecate module: {}", e))
+    } else {
+        deprecate_module(
+            &current_region_handler().await,
+            module,
+            track,
+            version,
+            message,
+        )
+        .await
+    }
+}
 
 pub async fn handle_publish(
     path: &str,
@@ -20,7 +90,7 @@ pub async fn handle_publish(
         Err(ModuleError::ModuleVersionExists(version, error)) => {
             if no_fail_on_exist {
                 info!(
-                    "Module version {} already exists: {}, but continuing due to --no-fail-on-exist exits with success",
+                    "Module version {} already exists: {}, but continuing due to --no-fail-on-exist",
                     version, error
                 );
             } else {
@@ -36,23 +106,13 @@ pub async fn handle_publish(
 }
 
 pub async fn handle_precheck(file: &str) {
-    match precheck_module(&file.to_string()).await {
-        Ok(_) => {
-            info!("Module prechecked successfully");
-        }
-        Err(e) => {
-            error!("Failed during module precheck: {}", e);
-            std::process::exit(1);
-        }
-    }
+    exit_on_err(precheck_module(&file.to_string()).await);
+    info!("Module prechecked successfully");
 }
 
 pub async fn handle_list(track: &str) {
-    let modules = current_region_handler()
-        .await
-        .get_all_latest_module(track)
-        .await
-        .unwrap();
+    let modules = exit_on_err(fetch_all_latest_modules(track).await);
+
     println!(
         "{:<20} {:<20} {:<20} {:<15} {:<15} {:<10}",
         "Module", "ModuleName", "Version", "Track", "Status", "Ref"
@@ -71,88 +131,53 @@ pub async fn handle_list(track: &str) {
 }
 
 pub async fn handle_get(module: &str, version: &str) {
-    let track = "dev".to_string();
-    match current_region_handler()
-        .await
-        .get_module_version(module, &track, version)
-        .await
-        .unwrap()
-    {
-        Some(module) => {
-            println!("Module: {}", serde_json::to_string_pretty(&module).unwrap());
-            if module.deprecated {
-                println!("\n⚠️  WARNING: This module version is DEPRECATED");
-                if let Some(msg) = &module.deprecated_message {
-                    println!("   Reason: {}", msg);
-                }
-            }
-        }
-        None => {
-            error!("Module not found");
-            std::process::exit(1);
+    let track = "dev";
+    let module = exit_on_none(
+        exit_on_err(fetch_module_version(track, module, version).await),
+        "Module not found",
+    );
+    println!(
+        "Module: {}",
+        serde_json::to_string_pretty(&module).unwrap_or_else(|_| "Failed to serialize".to_string())
+    );
+    if module.deprecated {
+        println!("\n⚠️  WARNING: This module version is DEPRECATED");
+        if let Some(msg) = &module.deprecated_message {
+            println!("   Reason: {}", msg);
         }
     }
 }
 
 pub async fn handle_versions(module: &str, track: &str) {
-    match current_region_handler()
-        .await
-        .get_all_module_versions(module, track)
-        .await
-    {
-        Ok(versions) => {
-            if versions.is_empty() {
-                println!("No versions found for module {} on track {}", module, track);
-                return;
-            }
+    let versions = exit_on_err(fetch_all_module_versions(track, module).await);
 
-            println!(
-                "{:<20} {:<15} {:<30} {}",
-                "Version", "Status", "Created", "Message"
-            );
-            for entry in &versions {
-                let status = if entry.deprecated {
-                    "DEPRECATED"
-                } else {
-                    "Active"
-                };
-                let message = if let Some(msg) = &entry.deprecated_message {
-                    msg.as_str()
-                } else {
-                    ""
-                };
-                println!(
-                    "{:<20} {:<15} {:<30} {}",
-                    entry.version, status, entry.timestamp, message
-                );
-            }
-        }
-        Err(e) => {
-            error!("Failed to get module versions: {}", e);
-            std::process::exit(1);
-        }
+    if versions.is_empty() {
+        println!("No versions found for module {} on track {}", module, track);
+        return;
+    }
+
+    println!(
+        "{:<20} {:<15} {:<30} {}",
+        "Version", "Status", "Created", "Message"
+    );
+    for entry in &versions {
+        let status = if entry.deprecated {
+            "DEPRECATED"
+        } else {
+            "Active"
+        };
+        let message = entry.deprecated_message.as_deref().unwrap_or("");
+        println!(
+            "{:<20} {:<15} {:<30} {}",
+            entry.version, status, entry.timestamp, message
+        );
     }
 }
 
 pub async fn handle_deprecate(module: &str, track: &str, version: &str, message: Option<&str>) {
-    match deprecate_module(
-        &current_region_handler().await,
-        module,
-        track,
-        version,
-        message,
-    )
-    .await
-    {
-        Ok(_) => {
-            info!(
-                "Module {} version {} in track {} has been deprecated",
-                module, version, track
-            );
-        }
-        Err(e) => {
-            error!("Failed to deprecate module: {}", e);
-            std::process::exit(1);
-        }
-    }
+    exit_on_err(do_deprecate_module(module, track, version, message).await);
+    info!(
+        "Module {} version {} in track {} has been deprecated",
+        module, version, track
+    );
 }

--- a/cli/src/commands/policy.rs
+++ b/cli/src/commands/policy.rs
@@ -1,8 +1,42 @@
+use anyhow::Result;
 use env_common::logic::publish_policy;
+use env_defs::CloudProvider;
+use http_client::{http_get_policies, http_get_policy_version, is_http_mode_enabled};
 use log::{error, info};
 
+use super::exit_on_err;
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+async fn fetch_all_policies(environment: &str) -> Result<Vec<env_defs::PolicyResp>> {
+    if is_http_mode_enabled() {
+        http_get_policies(environment)
+            .await?
+            .into_iter()
+            .map(|v| serde_json::from_value(v).map_err(Into::into))
+            .collect()
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_policies(environment)
+            .await?)
+    }
+}
+
+async fn fetch_policy(
+    policy: &str,
+    environment: &str,
+    version: &str,
+) -> Result<env_defs::PolicyResp> {
+    if is_http_mode_enabled() {
+        let value = http_get_policy_version(environment, policy, version).await?;
+        Ok(serde_json::from_value(value)?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_policy(policy, environment, version)
+            .await?)
+    }
+}
 
 pub async fn handle_publish(file: &str, environment: &str) {
     match publish_policy(&current_region_handler().await, file, environment).await {
@@ -17,11 +51,8 @@ pub async fn handle_publish(file: &str, environment: &str) {
 }
 
 pub async fn handle_list(environment: &str) {
-    let policies = current_region_handler()
-        .await
-        .get_all_policies(environment)
-        .await
-        .unwrap();
+    let policies = exit_on_err(fetch_all_policies(environment).await);
+
     println!(
         "{:<30} {:<20} {:<20} {:<15} {:<10}",
         "Policy", "PolicyName", "Version", "Environment", "Ref"
@@ -35,17 +66,6 @@ pub async fn handle_list(environment: &str) {
 }
 
 pub async fn handle_get(policy: &str, environment: &str, version: &str) {
-    match current_region_handler()
-        .await
-        .get_policy(policy, environment, version)
-        .await
-    {
-        Ok(policy) => {
-            println!("Policy: {}", serde_json::to_string_pretty(&policy).unwrap());
-        }
-        Err(e) => {
-            error!("Failed to get policy: {}", e);
-            std::process::exit(1);
-        }
-    }
+    let policy = exit_on_err(fetch_policy(policy, environment, version).await);
+    println!("Policy: {}", serde_json::to_string_pretty(&policy).unwrap());
 }

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -1,36 +1,43 @@
-use log::error;
+use colored::Colorize;
 
+use super::{exit_on_err, fetch_all_projects};
 use crate::current_region_handler;
 use env_defs::CloudProvider;
+use http_client::is_http_mode_enabled;
 
 pub async fn handle_get_current() {
-    match current_region_handler().await.get_current_project().await {
-        Ok(project) => {
-            println!(
-                "Project: {}",
-                serde_json::to_string_pretty(&project).unwrap()
-            );
-        }
-        Err(e) => {
-            error!("Failed to insert project: {}", e);
-            std::process::exit(1);
-        }
+    if is_http_mode_enabled() {
+        eprintln!(
+            "{}",
+            "Error: 'project get' is not supported in HTTP mode".red()
+        );
+        std::process::exit(1);
     }
+    let project = exit_on_err(current_region_handler().await.get_current_project().await);
+    println!(
+        "Project: {}",
+        serde_json::to_string_pretty(&project).unwrap()
+    );
 }
 
 pub async fn handle_get_all() {
-    match current_region_handler().await.get_all_projects().await {
-        Ok(projects) => {
-            for project in projects {
-                println!(
-                    "Project: {}",
-                    serde_json::to_string_pretty(&project).unwrap()
-                );
-            }
-        }
-        Err(e) => {
-            error!("Failed to insert project: {}", e);
-            std::process::exit(1);
+    let projects = exit_on_err(fetch_all_projects().await);
+
+    if projects.is_empty() {
+        println!("No projects found.");
+    } else {
+        println!("{:<20} {:<50}", "Project ID", "Name");
+        println!("{}", "-".repeat(70));
+        for project in projects {
+            println!(
+                "{:<20} {:<50}",
+                project.project_id,
+                if project.name.is_empty() {
+                    "(no name)"
+                } else {
+                    &project.name
+                }
+            );
         }
     }
 }

--- a/cli/src/commands/provider.rs
+++ b/cli/src/commands/provider.rs
@@ -1,8 +1,22 @@
+use anyhow::Result;
 use env_common::{errors::ModuleError, publish_provider};
+use env_defs::CloudProvider;
+use http_client::{http_get_all_latest_providers, is_http_mode_enabled};
 use log::{error, info};
 
+use super::exit_on_err;
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+async fn fetch_all_latest_providers() -> Result<Vec<env_defs::ProviderResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_latest_providers().await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_latest_provider()
+            .await?)
+    }
+}
 
 pub async fn handle_publish(path: &str, version: Option<&str>, no_fail_on_exist: bool) {
     match publish_provider(&current_region_handler().await, path, version).await {
@@ -25,11 +39,8 @@ pub async fn handle_publish(path: &str, version: Option<&str>, no_fail_on_exist:
 }
 
 pub async fn handle_list() {
-    let providers = current_region_handler()
-        .await
-        .get_all_latest_provider()
-        .await
-        .unwrap();
+    let providers = exit_on_err(fetch_all_latest_providers().await);
+
     println!(
         "{:<20} {:<20} {:<20} {:<15} {:<10}",
         "Provider", "Version", "Config name", "Config alias", "Ref"

--- a/cli/src/commands/stack.rs
+++ b/cli/src/commands/stack.rs
@@ -1,23 +1,87 @@
+use anyhow::Result;
 use env_common::{
     errors::ModuleError,
     logic::{deprecate_stack, get_stack_preview, publish_stack},
 };
+use env_defs::CloudProvider;
+use http_client::{
+    http_deprecate_stack, http_get_all_latest_stacks, http_get_all_versions_for_stack,
+    http_get_stack_version, is_http_mode_enabled, is_not_found_error,
+};
 use log::{error, info};
 
+use super::{exit_on_err, exit_on_none};
 use crate::current_region_handler;
-use env_defs::CloudProvider;
+
+async fn fetch_all_latest_stacks(track: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_latest_stacks(track).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_latest_stack(track)
+            .await?)
+    }
+}
+
+async fn fetch_stack_version(
+    track: &str,
+    stack: &str,
+    version: &str,
+) -> Result<Option<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        match http_get_stack_version(track, stack, version).await {
+            Ok(s) => Ok(Some(s)),
+            Err(e) if is_not_found_error(&e) => Ok(None),
+            Err(e) => Err(e),
+        }
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_stack_version(stack, track, version)
+            .await?)
+    }
+}
+
+async fn fetch_all_stack_versions(track: &str, stack: &str) -> Result<Vec<env_defs::ModuleResp>> {
+    if is_http_mode_enabled() {
+        Ok(http_get_all_versions_for_stack(track, stack).await?)
+    } else {
+        Ok(current_region_handler()
+            .await
+            .get_all_stack_versions(stack, track)
+            .await?)
+    }
+}
+
+async fn do_deprecate_stack(
+    stack: &str,
+    track: &str,
+    version: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    if is_http_mode_enabled() {
+        http_deprecate_stack(track, stack, version, message.map(|s| s.to_string()))
+            .await
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("Failed to deprecate stack: {}", e))
+    } else {
+        deprecate_stack(
+            &current_region_handler().await,
+            stack,
+            track,
+            version,
+            message,
+        )
+        .await
+    }
+}
 
 pub async fn handle_preview(path: &str) {
-    match get_stack_preview(&current_region_handler().await, &path.to_string()).await {
-        Ok(stack_module) => {
-            info!("Stack generated successfully");
-            println!("{}", stack_module);
-        }
-        Err(e) => {
-            error!("Failed to generate preview for stack: {}", e);
-            std::process::exit(1);
-        }
-    }
+    let stack_module =
+        exit_on_err(get_stack_preview(&current_region_handler().await, &path.to_string()).await);
+    info!("Stack generated successfully");
+    println!("{}", stack_module);
 }
 
 pub async fn handle_publish(
@@ -49,11 +113,8 @@ pub async fn handle_publish(
 }
 
 pub async fn handle_list(track: &str) {
-    let stacks = current_region_handler()
-        .await
-        .get_all_latest_stack(track)
-        .await
-        .unwrap();
+    let stacks = exit_on_err(fetch_all_latest_stacks(track).await);
+
     println!(
         "{:<20} {:<20} {:<20} {:<15} {:<15} {:<10}",
         "Stack", "StackName", "Version", "Track", "Status", "Ref"
@@ -72,88 +133,50 @@ pub async fn handle_list(track: &str) {
 }
 
 pub async fn handle_get(stack: &str, version: &str) {
-    let track = "dev".to_string();
-    match current_region_handler()
-        .await
-        .get_stack_version(stack, &track, version)
-        .await
-        .unwrap()
-    {
-        Some(stack) => {
-            println!("Stack: {}", serde_json::to_string_pretty(&stack).unwrap());
-            if stack.deprecated {
-                println!("\n⚠️  WARNING: This stack version is DEPRECATED");
-                if let Some(msg) = &stack.deprecated_message {
-                    println!("   Reason: {}", msg);
-                }
-            }
-        }
-        None => {
-            error!("Stack not found");
-            std::process::exit(1);
+    let track = "dev";
+    let stack = exit_on_none(
+        exit_on_err(fetch_stack_version(track, stack, version).await),
+        "Stack not found",
+    );
+    println!("Stack: {}", serde_json::to_string_pretty(&stack).unwrap());
+    if stack.deprecated {
+        println!("\n⚠️  WARNING: This stack version is DEPRECATED");
+        if let Some(msg) = &stack.deprecated_message {
+            println!("   Reason: {}", msg);
         }
     }
 }
 
 pub async fn handle_versions(stack: &str, track: &str) {
-    match current_region_handler()
-        .await
-        .get_all_stack_versions(stack, track)
-        .await
-    {
-        Ok(versions) => {
-            if versions.is_empty() {
-                println!("No versions found for stack {} on track {}", stack, track);
-                return;
-            }
+    let versions = exit_on_err(fetch_all_stack_versions(track, stack).await);
 
-            println!(
-                "{:<20} {:<15} {:<30} {}",
-                "Version", "Status", "Created", "Message"
-            );
-            for entry in &versions {
-                let status = if entry.deprecated {
-                    "DEPRECATED"
-                } else {
-                    "Active"
-                };
-                let message = if let Some(msg) = &entry.deprecated_message {
-                    msg.as_str()
-                } else {
-                    ""
-                };
-                println!(
-                    "{:<20} {:<15} {:<30} {}",
-                    entry.version, status, entry.timestamp, message
-                );
-            }
-        }
-        Err(e) => {
-            error!("Failed to get stack versions: {}", e);
-            std::process::exit(1);
-        }
+    if versions.is_empty() {
+        println!("No versions found for stack {} on track {}", stack, track);
+        return;
+    }
+
+    println!(
+        "{:<20} {:<15} {:<30} {}",
+        "Version", "Status", "Created", "Message"
+    );
+    for entry in &versions {
+        let status = if entry.deprecated {
+            "DEPRECATED"
+        } else {
+            "Active"
+        };
+        let message = entry.deprecated_message.as_deref().unwrap_or("");
+        println!(
+            "{:<20} {:<15} {:<30} {}",
+            entry.version, status, entry.timestamp, message
+        );
     }
 }
 
 pub async fn handle_deprecate(stack: &str, track: &str, version: &str, message: Option<&str>) {
-    match deprecate_stack(
-        &current_region_handler().await,
-        stack,
-        track,
-        version,
-        message,
-    )
-    .await
-    {
-        Ok(_) => {
-            info!(
-                "Stack {} version {} in track {} has been deprecated",
-                stack, version, track
-            );
-        }
-        Err(e) => {
-            error!("Failed to deprecate stack: {}", e);
-            std::process::exit(1);
-        }
-    }
+    exit_on_err(do_deprecate_stack(stack, track, version, message).await);
+    info!(
+        "Stack {} version {} in track {} has been deprecated",
+        stack, version, track
+    );
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -727,7 +727,7 @@ async fn main() {
         }
         Commands::Deployments { command } => match command {
             DeploymentCommands::List => {
-                commands::deployment::handle_list().await;
+                commands::deployment::handle_list(None, None).await;
             }
             DeploymentCommands::Describe {
                 environment_id,

--- a/http_client/src/client.rs
+++ b/http_client/src/client.rs
@@ -200,6 +200,11 @@ async fn http_get(path: &str) -> Result<Value> {
         .context("Failed to parse JSON response")
 }
 
+pub fn is_not_found_error(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("status 404") || msg.contains("404 Not Found")
+}
+
 /// Make an authenticated HTTP POST request using JWT token
 pub async fn http_post(path: &str, body: &Value) -> Result<Value> {
     let endpoint = get_api_endpoint()?;
@@ -675,7 +680,7 @@ pub async fn http_get_latest_module_version(
         }
         Ok(_) => Ok(None),
         Err(e) => {
-            if e.to_string().contains("404") || e.to_string().to_lowercase().contains("not found") {
+            if is_not_found_error(&e) {
                 Ok(None)
             } else {
                 Err(e)
@@ -697,7 +702,7 @@ pub async fn http_get_latest_stack_version(track: &str, stack: &str) -> Result<O
         }
         Ok(_) => Ok(None),
         Err(e) => {
-            if e.to_string().contains("404") || e.to_string().to_lowercase().contains("not found") {
+            if is_not_found_error(&e) {
                 Ok(None)
             } else {
                 Err(e)

--- a/http_client/src/lib.rs
+++ b/http_client/src/lib.rs
@@ -11,5 +11,6 @@ pub use client::{
     http_get_latest_stack_version, http_get_logs, http_get_module_version,
     http_get_plan_deployment, http_get_policies, http_get_policy_version, http_get_stack_version,
     http_is_deployment_plan_in_progress, http_post, http_publish_module, http_publish_provider,
-    http_publish_stack, http_submit_claim_job, is_http_mode_enabled, LOCAL_TOKEN,
+    http_publish_stack, http_submit_claim_job, is_http_mode_enabled, is_not_found_error,
+    LOCAL_TOKEN,
 };


### PR DESCRIPTION
Adds HTTP-transport dispatch to every CLI command handler so they can run against the InfraWeave API server instead of the direct cloud SDK. Each handler checks is_http_mode_enabled() and either calls the matching http_client function or falls back to the existing SDK-backed handler.

- http_client: new is_not_found_error() helper replaces ad-hoc string matching for 404s in the two latest-version lookups.
- cli/commands/mod.rs: new fetch_all_projects() helper as the single transport-aware entry point for 'list projects'.
- module/stack: HTTP paths for get/list/versions/deprecate via http_get_*_version, http_get_all_*, http_deprecate_*.
- policy/provider/project: HTTP paths for list/get (project get is rejected in HTTP mode since there is no equivalent API call).
- deployment: HTTP paths for describe/get-claim/get-logs and a new fetch_deployments_across_projects() that iterates over projects and regions when either is unspecified. The list output gains Project and Region columns — a format change for anything parsing the output.
- Handler signatures unchanged except deployment::handle_list, which now takes Option<&str> project and region; the main.rs call site passes None/None until the flag-parsing PR lands.
- Tightens error handling throughout with exit_on_err / exit_on_none, replacing several `.unwrap()` and explicit `match { Err => exit }` blocks.

No new CLI flags in this PR — those are in the follow-up.