### PR TITLE
chore: address RUSTSEC-2026-0104 rustls-webpki CRL panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7819,7 +7819,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7889,9 +7889,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -8456,7 +8456,7 @@ dependencies = [
  "reqwest 0.12.24",
  "rsa",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "scrypt",
  "serde",
  "serde_json",

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ ignore = [
     { id = "RUSTSEC-2026-0097", reason = "rand: unsound with custom logger - pending upgrade" },
     { id = "RUSTSEC-2026-0098", reason = "webpki: URI name constraints bug - pending upgrade" },
     { id = "RUSTSEC-2026-0099", reason = "webpki: wildcard name constraints bug - pending upgrade" },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic: only reachable when parsing CRLs, which we don't do. Transitive via aws-smithy-http-client's legacy-rustls-ring feature (rustls 0.21); no patched 0.101.x exists." },
     # Unmaintained crates (transitive dependencies, no direct fix available)
     { id = "RUSTSEC-2024-0384", reason = "instant is unmaintained" },
     { id = "RUSTSEC-2025-0012", reason = "backoff is unmaintained" },


### PR DESCRIPTION
Bump rustls-webpki 0.103.12 → 0.103.13 to pick up the patched version. 

The 0.101.7 copy pulled in transitively via rustls 0.21 (aws-smithy-http-client's legacy-rustls-ring feature) has no patched 0.101.x release; ignore it in deny.toml since the panic is only reachable when parsing CRLs, which we don't do.