### PR TITLE
feat(cli): HTTP-mode plan follow, drift streaming, opt-out follow

### DIFF
--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -1,28 +1,17 @@
+use colored::Colorize;
 use env_common::interface::GenericCloudHandler;
 use env_common::logic::{destroy_infra, driftcheck_infra};
-use env_defs::{CloudProvider, DeploymentManifest, ExtraData};
+use env_defs::{pretty_print_resource_changes, CloudProvider, DeploymentManifest, ExtraData};
 use log::{error, info};
 use serde::Deserialize;
 use std::path::Path;
 
 use crate::run::run_claim_file;
 use crate::utils::current_region_handler;
-use crate::{follow_execution, ClaimJobStruct};
+use crate::{follow_driftcheck, follow_execution, ClaimJobStruct};
 
-pub async fn handle_plan(
-    environment: &str,
-    claim: &str,
-    store_files: bool,
-    destroy: bool,
-    follow: bool,
-) {
-    if !follow {
-        eprintln!("Error: Plan operations require --follow flag to be enabled.");
-        eprintln!("Usage: infraweave plan {} {} --follow", environment, claim);
-        std::process::exit(1);
-    }
-
-    match run_claim_file(environment, claim, "plan", store_files, destroy, follow).await {
+pub async fn handle_plan(environment: &str, claim: &str, store_files: bool, destroy: bool) {
+    match run_claim_file(environment, claim, "plan", store_files, destroy, true).await {
         Ok(_) => {}
         Err(e) => {
             eprintln!("Plan failed: {}", e);
@@ -32,7 +21,7 @@ pub async fn handle_plan(
 }
 
 pub async fn handle_driftcheck(deployment_id: &str, environment: &str, remediate: bool) {
-    match driftcheck_infra(
+    let (job_id, region) = match driftcheck_infra(
         &current_region_handler().await,
         deployment_id,
         environment,
@@ -41,14 +30,61 @@ pub async fn handle_driftcheck(deployment_id: &str, environment: &str, remediate
     )
     .await
     {
-        Ok(_) => {
-            info!("Successfully requested drift check");
-        }
+        Ok(result) => result,
         Err(e) => {
             error!("Failed to request drift check: {}", e);
             std::process::exit(1);
         }
     };
+    info!("Successfully requested drift check (job id: {})", job_id);
+
+    let short_job = job_id.split('/').last().unwrap_or(&job_id);
+    println!(
+        "Checking drift for {} in {} ({})...",
+        deployment_id.cyan().bold(),
+        environment.cyan().bold(),
+        short_job.dimmed()
+    );
+
+    let job = ClaimJobStruct {
+        job_id,
+        deployment_id: deployment_id.to_string(),
+        environment: environment.to_string(),
+        region,
+    };
+
+    let outcome = match follow_driftcheck(&job, remediate).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            error!("Drift check failed: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let drifted: Vec<_> = outcome
+        .resource_changes
+        .iter()
+        .filter(|c| c.action != env_defs::ResourceAction::NoOp)
+        .cloned()
+        .collect();
+
+    if drifted.is_empty() {
+        println!(
+            "\n{} {} ({})",
+            "✓".green().bold(),
+            "No drift detected".green().bold(),
+            deployment_id
+        );
+    } else {
+        println!(
+            "\n{} {} ({})",
+            "!".yellow().bold(),
+            "Drift detected".yellow().bold(),
+            deployment_id
+        );
+        println!("\n{}", pretty_print_resource_changes(&drifted));
+        std::process::exit(2);
+    }
 }
 
 pub async fn handle_apply(environment: &str, claim: &str, store_files: bool, follow: bool) {
@@ -72,12 +108,11 @@ pub async fn handle_destroy(
 ) {
     let region_handler = current_region_handler().await;
 
-    // Warn if user wants to store files but didn't enable following
+    // Warn if user wants to store files but opted out of following
     if store_files && !follow {
         eprintln!(
-            "Warning: --store-files requires --follow to be enabled. Files will not be stored."
+            "Warning: --store-files requires streaming progress (don't pass --no-follow). Files will not be stored."
         );
-        eprintln!("Add --follow to enable file storage.");
     }
 
     // Check if input is a file and extract deployment IDs if so
@@ -167,15 +202,15 @@ pub async fn handle_destroy(
             .collect();
 
         match follow_execution(&job_structs, "destroy").await {
-            Ok((overview, std_output, _violations)) => {
+            Ok(tables) => {
                 info!("Successfully followed destroy operation");
 
                 if store_files {
-                    std::fs::write("overview.txt", overview)
+                    std::fs::write("overview.txt", tables.overview)
                         .expect("Failed to write overview file");
                     println!("Overview written to overview.txt");
 
-                    std::fs::write("std_output.txt", std_output)
+                    std::fs::write("std_output.txt", tables.std_output)
                         .expect("Failed to write std output file");
                     println!("Std output written to std_output.txt");
                 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,9 +6,10 @@ pub mod tui;
 mod utils;
 
 pub use defs::ClaimJobStruct;
-pub use plan::follow_execution;
+pub use plan::{follow_driftcheck, follow_execution, DriftOutcome, SummaryTables};
 pub use run::run_claim_file;
 pub use utils::{
     current_region_handler, get_environment, resolve_deployment_id,
     resolve_environment_and_deployment, resolve_environment_id,
+    resolve_environment_id_for_new_deployment,
 };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,8 @@
 use clap::{Args, Parser, Subcommand};
-use cli::{commands, get_environment, resolve_environment_and_deployment, resolve_environment_id};
+use cli::{
+    commands, get_environment, resolve_environment_and_deployment, resolve_environment_id,
+    resolve_environment_id_for_new_deployment,
+};
 use env_common::interface::initialize_project_id_and_region;
 use env_utils::setup_logging;
 
@@ -68,7 +71,7 @@ enum Commands {
     Plan {
         /// Claim file to deploy, e.g. claim.yaml
         claim: String,
-        /// Environment id used when planning, e.g. cli/default (optional, will prompt if not provided)
+        /// Environment id used when planning, e.g. `default` (prompts with `default` as the default if not provided)
         #[arg(short, long)]
         environment_id: Option<String>,
         /// Project ID (AWS account ID) for HTTP mode
@@ -80,9 +83,6 @@ enum Commands {
         /// Flag to plan a destroy operation
         #[arg(long)]
         destroy: bool,
-        /// Follow the plan operation progress
-        #[arg(long)]
-        follow: bool,
     },
     /// Check drift of a deployment in a specific environment
     Driftcheck {
@@ -105,7 +105,7 @@ enum Commands {
     Apply {
         /// Claim file to apply, e.g. claim.yaml
         claim: String,
-        /// Environment id used when applying, e.g. cli/default (optional, will prompt if not provided)
+        /// Environment id used when applying, e.g. `default` (prompts with `default` as the default if not provided)
         #[arg(short, long)]
         environment_id: Option<String>,
         /// Project ID (AWS account ID) for HTTP mode
@@ -114,9 +114,9 @@ enum Commands {
         /// Flag to indicate if output files should be stored
         #[arg(long)]
         store_files: bool,
-        /// Follow the apply operation progress
+        /// Do not stream progress; return immediately after the job is submitted
         #[arg(long)]
-        follow: bool,
+        no_follow: bool,
     },
     /// Delete resources in cloud
     Destroy {
@@ -137,9 +137,9 @@ enum Commands {
         /// Flag to indicate if output files should be stored
         #[arg(long)]
         store_files: bool,
-        /// Follow the destroy operation progress
+        /// Do not stream progress; return immediately after the job is submitted
         #[arg(long)]
-        follow: bool,
+        no_follow: bool,
     },
     /// Get YAML claim from a deployment
     GetClaim {
@@ -881,11 +881,10 @@ async fn main() {
             project: _,
             store_files,
             destroy,
-            follow,
         } => {
-            let environment_id = resolve_environment_id(environment_id).await;
+            let environment_id = resolve_environment_id_for_new_deployment(environment_id).await;
             let env = get_environment(&environment_id);
-            commands::claim::handle_plan(&env, &claim, store_files, destroy, follow).await;
+            commands::claim::handle_plan(&env, &claim, store_files, destroy).await;
         }
         Commands::Driftcheck {
             environment_id,
@@ -904,11 +903,11 @@ async fn main() {
             claim,
             project: _,
             store_files,
-            follow,
+            no_follow,
         } => {
-            let environment_id = resolve_environment_id(environment_id).await;
+            let environment_id = resolve_environment_id_for_new_deployment(environment_id).await;
             let env = get_environment(&environment_id);
-            commands::claim::handle_apply(&env, &claim, store_files, follow).await;
+            commands::claim::handle_apply(&env, &claim, store_files, !no_follow).await;
         }
         Commands::Destroy {
             environment_id,
@@ -917,7 +916,7 @@ async fn main() {
             region: _,
             version,
             store_files,
-            follow,
+            no_follow,
         } => {
             let (environment_id, deployment_id) =
                 resolve_environment_and_deployment(environment_id, deployment_id).await;
@@ -927,7 +926,7 @@ async fn main() {
                 &env,
                 version.as_deref(),
                 store_files,
-                follow,
+                !no_follow,
             )
             .await;
         }

--- a/cli/src/plan.rs
+++ b/cli/src/plan.rs
@@ -1,202 +1,425 @@
-use std::{collections::HashMap, thread, time::Duration, vec};
+use std::{collections::HashMap, time::Duration};
 
 use anyhow::Result;
 use colored::Colorize;
 use env_common::{
     interface::{get_region_env_var, GenericCloudHandler},
-    logic::{is_deployment_in_progress, is_deployment_plan_in_progress},
+    logic::{is_deployment_in_progress, is_deployment_plan_in_progress, PROJECT_ID},
 };
-use env_defs::{pretty_print_resource_changes, CloudProvider, DeploymentResp, DeploymentStatus};
+use env_defs::{
+    pretty_print_resource_changes, CloudProvider, DeploymentResp, DeploymentStatus,
+    InfraChangeRecord,
+};
+use http_client::{
+    http_check_deployment_progress as http_check_progress, http_get_change_record,
+    http_is_deployment_plan_in_progress as http_is_plan_in_progress, is_http_mode_enabled,
+};
+use log::{debug, error};
 use prettytable::{row, Table};
-
-use log::error;
 
 use crate::ClaimJobStruct;
 
-pub async fn follow_execution(
-    job_ids: &Vec<ClaimJobStruct>,
-    operation: &str, // "plan", "apply", or "destroy"
-) -> Result<(String, String, String), anyhow::Error> {
-    // Keep track of statuses in a hashmap
+fn require_project_id() -> Result<&'static str> {
+    PROJECT_ID
+        .get()
+        .map(|s| s.as_str())
+        .ok_or_else(|| anyhow::anyhow!("PROJECT_ID is not set - pass --project in HTTP mode"))
+}
+
+fn short_id(job_id: &str) -> &str {
+    job_id.split('/').last().unwrap_or(job_id)
+}
+
+const POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+pub struct SummaryTables {
+    pub overview: String,
+    pub std_output: String,
+    pub violations: String,
+}
+
+async fn fetch_progress(
+    operation: &str,
+    http_mode: bool,
+    cj: &ClaimJobStruct,
+) -> Result<(bool, Option<DeploymentResp>)> {
+    let is_plan = operation == "plan";
+    if http_mode {
+        let project_id = require_project_id()?;
+        let ClaimJobStruct {
+            region,
+            deployment_id,
+            environment,
+            job_id,
+        } = cj;
+        let (in_progress, _, deployment) = if is_plan {
+            http_is_plan_in_progress(project_id, region, deployment_id, environment, job_id).await
+        } else {
+            http_check_progress(project_id, region, deployment_id, environment, job_id).await
+        };
+        return Ok((in_progress, deployment));
+    }
+    let handler = GenericCloudHandler::region(&cj.region).await;
+    if is_plan {
+        let (in_progress, _, deployment) = is_deployment_plan_in_progress(
+            &handler,
+            &cj.deployment_id,
+            &cj.environment,
+            &cj.job_id,
+        )
+        .await;
+        return Ok((in_progress, deployment));
+    }
+    let (in_progress, _, _, deployment) =
+        is_deployment_in_progress(&handler, &cj.deployment_id, &cj.environment, false, false).await;
+    Ok((in_progress, deployment))
+}
+
+async fn fetch_change_record(
+    http_mode: bool,
+    region: &str,
+    environment: &str,
+    deployment_id: &str,
+    job_id: &str,
+    record_type: &str,
+) -> Result<InfraChangeRecord> {
+    if http_mode {
+        let project_id = require_project_id()?;
+        let value = http_get_change_record(
+            project_id,
+            region,
+            environment,
+            deployment_id,
+            job_id,
+            record_type,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+        serde_json::from_value::<InfraChangeRecord>(value).map_err(|e| anyhow::anyhow!(e))
+    } else {
+        GenericCloudHandler::region(region)
+            .await
+            .get_change_record(environment, deployment_id, job_id, record_type)
+            .await
+    }
+}
+
+/// Prints the status line (only on transitions) and returns whether the job failed.
+///
+/// When `quiet` is true, progress prints for in-progress and successful jobs are
+/// suppressed - the caller is expected to render its own summary. Failures are
+/// still surfaced so errors aren't hidden.
+fn report_job(
+    in_progress: bool,
+    job_id: &str,
+    deployment: Option<&DeploymentResp>,
+    last_status: &mut HashMap<String, DeploymentStatus>,
+    failure_errors: &mut Vec<String>,
+    quiet: bool,
+) -> bool {
+    let short = short_id(job_id);
+
+    // Synthesize a status for the observation. When no deployment is returned we
+    // fall back to a sentinel: Initiated (non-final) if still in progress,
+    // otherwise Failed (final). These are only used for `is_final()` branching
+    // and dedup - never shown to the user.
+    let observed = deployment
+        .map(|d| d.status.clone())
+        .unwrap_or(if in_progress {
+            DeploymentStatus::Initiated
+        } else {
+            DeploymentStatus::Failed
+        });
+
+    if !observed.is_final() {
+        if !last_status.contains_key(job_id) {
+            if !quiet {
+                println!("Job {} is {}...", short.cyan(), "running".cyan().bold());
+            }
+            last_status.insert(job_id.to_string(), observed);
+        }
+        return false;
+    }
+
+    let (failed, message) = match deployment {
+        Some(dep) if dep.status == DeploymentStatus::Successful => (
+            false,
+            format!(
+                "Job {} {}",
+                short.green(),
+                "completed successfully".green().bold()
+            ),
+        ),
+        Some(dep) => {
+            let mut msg = format!("Job {} {}", short.red(), "failed".red().bold());
+            if !dep.error_text.is_empty() {
+                msg.push_str(&format!(
+                    "\n   {}: {}",
+                    "Error".red().bold(),
+                    dep.error_text.red()
+                ));
+                if !failure_errors.iter().any(|e| e == &dep.error_text) {
+                    failure_errors.push(dep.error_text.clone());
+                }
+            }
+            (true, msg)
+        }
+        None => (
+            true,
+            format!("Job {} {}", short.red(), "failed".red().bold()),
+        ),
+    };
+
+    let already_final = last_status
+        .get(job_id)
+        .is_some_and(DeploymentStatus::is_final);
+    if !already_final {
+        if failed || !quiet {
+            println!("{}", message);
+        }
+        last_status.insert(job_id.to_string(), observed);
+    }
+    failed
+}
+
+async fn poll_until_done(
+    job_ids: &[ClaimJobStruct],
+    operation: &str,
+    http_mode: bool,
+    quiet: bool,
+) -> Result<HashMap<String, DeploymentResp>> {
     let mut statuses: HashMap<String, DeploymentResp> = HashMap::new();
+    let mut last_status: HashMap<String, DeploymentStatus> = HashMap::new();
+    let mut failure_errors: Vec<String> = Vec::new();
 
-    // Polling loop to check job statuses periodically until all are finished
     loop {
-        let mut all_successful = true;
+        let mut all_finished = true;
+        let mut any_failed = false;
 
-        for claim_job in job_ids {
-            if operation == "plan" {
-                let (in_progress, job_id, deployment) = is_deployment_plan_in_progress(
-                    &GenericCloudHandler::region(&claim_job.region).await,
-                    &claim_job.deployment_id,
-                    &claim_job.environment,
-                    &claim_job.job_id,
-                )
-                .await;
-
-                if in_progress {
-                    println!(
-                        "Status of job {}: {}",
-                        job_id,
-                        if in_progress {
-                            "in progress"
-                        } else {
-                            "completed"
-                        }
-                    );
-                    all_successful = false;
-                }
-
-                statuses.insert(job_id.clone(), deployment.unwrap().clone());
-            } else {
-                let (in_progress, job_id, status, deployment) = is_deployment_in_progress(
-                    &GenericCloudHandler::region(&claim_job.region).await,
-                    &claim_job.deployment_id,
-                    &claim_job.environment,
-                    false,
-                    false,
-                )
-                .await;
-
-                if in_progress {
-                    println!(
-                        "Status of job {}: {} ({})",
-                        job_id,
-                        if in_progress {
-                            "in progress"
-                        } else {
-                            "completed"
-                        },
-                        status
-                    );
-                    all_successful = false;
-                }
-
-                if let Some(dep) = deployment {
-                    statuses.insert(job_id.clone(), dep);
-                }
+        for cj in job_ids {
+            let (in_progress, deployment) = fetch_progress(operation, http_mode, cj).await?;
+            if report_job(
+                in_progress,
+                &cj.job_id,
+                deployment.as_ref(),
+                &mut last_status,
+                &mut failure_errors,
+                quiet,
+            ) {
+                any_failed = true;
+            }
+            if in_progress {
+                all_finished = false;
+            }
+            if let Some(dep) = deployment {
+                statuses.insert(cj.job_id.clone(), dep);
             }
         }
 
-        if all_successful {
-            println!("All {} jobs are successful!", operation);
-            break;
+        if all_finished {
+            if any_failed {
+                println!(
+                    "\n{}",
+                    format!("Some {} jobs failed!", operation).red().bold()
+                );
+                if !failure_errors.is_empty() {
+                    println!("\n{}", "Failure reasons:".red().bold());
+                    for (i, error) in failure_errors.iter().enumerate() {
+                        println!("  {}. {}", i + 1, error.red());
+                    }
+                }
+                return Err(anyhow::anyhow!("One or more jobs failed"));
+            }
+            if !quiet {
+                println!(
+                    "\n{}",
+                    format!("All {} jobs completed successfully!", operation)
+                        .green()
+                        .bold()
+                );
+            }
+            return Ok(statuses);
         }
 
-        thread::sleep(Duration::from_secs(10));
+        tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
 
-    // Build table strings for store_files feature (for plan) and backward compatibility
-    let mut overview_table = Table::new();
-    overview_table.add_row(row![
+async fn render_summary(
+    job_ids: &[ClaimJobStruct],
+    operation: &str,
+    http_mode: bool,
+    statuses: &HashMap<String, DeploymentResp>,
+) -> SummaryTables {
+    let mut overview = Table::new();
+    overview.add_row(row![
         "Deployment id\n(Environment)".purple().bold(),
         "Status".blue().bold(),
         "Job id".green().bold(),
         "Description".red().bold(),
     ]);
+    let mut overview_has_rows = false;
 
-    let mut std_output_table = Table::new();
-    std_output_table.add_row(row![
+    let mut std_output = Table::new();
+    std_output.add_row(row![
         "Deployment id\n(Environment)".purple().bold(),
         "Std output".blue().bold()
     ]);
+    let mut std_output_has_rows = false;
 
-    let mut violations_table = Table::new();
-    violations_table.add_row(row![
+    let mut violations = Table::new();
+    violations.add_row(row![
         "Deployment id\n(Environment)".purple().bold(),
         "Policy".blue().bold(),
         "Violations".red().bold()
     ]);
+    let mut violations_has_rows = false;
 
-    // Print results for each job
-    for claim_job in job_ids {
-        let deployment_id = &claim_job.deployment_id;
-        let environment = &claim_job.environment;
-        let job_id = &claim_job.job_id;
-        let region = &claim_job.region;
+    for cj in job_ids {
+        let Some(deployment) = statuses.get(&cj.job_id) else {
+            continue;
+        };
+        let (deployment_id, environment, job_id, region) =
+            (&cj.deployment_id, &cj.environment, &cj.job_id, &cj.region);
 
-        if let Some(deployment) = statuses.get(job_id) {
-            println!("\n{}", "=".repeat(80));
-            println!(
-                "Deployment: {} (Environment: {})",
-                deployment_id, environment
+        println!("\n{}", "=".repeat(80));
+        println!(
+            "Deployment: {} (Environment: {})",
+            deployment_id, environment
+        );
+        println!("Job ID: {}", deployment.job_id);
+        println!("Status: {}", deployment.status);
+
+        let violation_count = deployment
+            .policy_results
+            .iter()
+            .filter(|p| p.failed)
+            .count();
+        println!("Policy Violations: {}", violation_count);
+
+        overview.add_row(row![
+            format!("{}\n({})", deployment_id, environment),
+            deployment.status,
+            deployment.job_id,
+            format!("{} policy violations", violation_count)
+        ]);
+        overview_has_rows = true;
+
+        println!("{}", "=".repeat(80));
+
+        if deployment.status != DeploymentStatus::FailedInit {
+            let record_type = operation.to_uppercase();
+            debug!(
+                "Fetching change record for job {} in region {} (type: {})",
+                job_id, region, record_type
             );
-            println!("Job ID: {}", deployment.job_id);
-            println!("Status: {}", deployment.status);
-
-            let violation_count = deployment
-                .policy_results
-                .iter()
-                .filter(|p| p.failed)
-                .count();
-            println!("Policy Violations: {}", violation_count);
-
-            overview_table.add_row(row![
-                format!("{}\n({})", deployment_id, environment),
-                deployment.status,
-                deployment.job_id,
-                format!("{} policy violations", violation_count)
-            ]);
-
-            println!("{}", "=".repeat(80));
-
-            // Get change record for the operation (only if job didn't fail during init)
-            if deployment.status != DeploymentStatus::FailedInit {
-                let record_type = operation.to_uppercase();
-                match GenericCloudHandler::region(region)
-                    .await
-                    .get_change_record(environment, deployment_id, job_id, &record_type)
-                    .await
-                {
-                    Ok(change_record) => {
-                        println!("\nOutput:\n{}", change_record.plan_std_output);
-                        std_output_table.add_row(row![
-                            format!("{}\n({})", deployment_id, environment),
-                            change_record.plan_std_output
-                        ]);
-                        println!(
-                            "Changes: \n{}",
-                            pretty_print_resource_changes(&change_record.resource_changes)
-                        );
-                    }
-                    Err(e) => {
-                        error!("Failed to get change record: {}", e);
-                    }
-                }
-            } else {
-                println!("\nJob failed during initialization. Check job logs for details:");
-                println!(
-                    "  {}={} infraweave get-logs {}",
-                    get_region_env_var(),
-                    region,
-                    job_id
-                );
-            }
-
-            // Display policy violations for all operations
-            if deployment.status == DeploymentStatus::FailedPolicy {
-                println!("\nPolicy Validation Failed:");
-                for result in deployment.policy_results.iter().filter(|p| p.failed) {
-                    println!("  Policy: {}", result.policy);
-                    println!(
-                        "  Violations: {}",
-                        serde_json::to_string_pretty(&result.violations).unwrap()
-                    );
-                    violations_table.add_row(row![
+            match fetch_change_record(
+                http_mode,
+                region,
+                environment,
+                deployment_id,
+                job_id,
+                &record_type,
+            )
+            .await
+            {
+                Ok(change_record) => {
+                    println!("\nOutput:\n{}", change_record.plan_std_output);
+                    std_output.add_row(row![
                         format!("{}\n({})", deployment_id, environment),
-                        result.policy,
-                        serde_json::to_string_pretty(&result.violations).unwrap()
+                        change_record.plan_std_output
                     ]);
+                    std_output_has_rows = true;
+                    println!(
+                        "Changes: \n{}",
+                        pretty_print_resource_changes(&change_record.resource_changes)
+                    );
                 }
-            } else if !deployment.policy_results.is_empty() {
-                println!("\nPolicy Validation: Passed");
+                Err(e) => error!("Failed to get change record: {}", e),
             }
+        } else {
+            println!("\nJob failed during initialization. Check job logs for details:");
+            println!(
+                "  {}={} infraweave get-logs {}",
+                get_region_env_var(),
+                region,
+                job_id
+            );
+        }
+
+        if deployment.status == DeploymentStatus::FailedPolicy {
+            println!("\nPolicy Validation Failed:");
+            for result in deployment.policy_results.iter().filter(|p| p.failed) {
+                println!("  Policy: {}", result.policy);
+                println!(
+                    "  Violations: {}",
+                    serde_json::to_string_pretty(&result.violations).unwrap()
+                );
+                violations.add_row(row![
+                    format!("{}\n({})", deployment_id, environment),
+                    result.policy,
+                    serde_json::to_string_pretty(&result.violations).unwrap()
+                ]);
+                violations_has_rows = true;
+            }
+        } else if !deployment.policy_results.is_empty() {
+            println!("\nPolicy Validation: Passed");
         }
     }
 
-    Ok((
-        overview_table.to_string(),
-        std_output_table.to_string(),
-        violations_table.to_string(),
-    ))
+    let render = |table: Table, has_rows: bool| {
+        if has_rows {
+            table.to_string()
+        } else {
+            String::new()
+        }
+    };
+    SummaryTables {
+        overview: render(overview, overview_has_rows),
+        std_output: render(std_output, std_output_has_rows),
+        violations: render(violations, violations_has_rows),
+    }
+}
+
+pub async fn follow_execution(
+    job_ids: &[ClaimJobStruct],
+    operation: &str, // "plan", "apply", or "destroy"
+) -> Result<SummaryTables> {
+    let http_mode = is_http_mode_enabled();
+    let statuses = poll_until_done(job_ids, operation, http_mode, false).await?;
+    Ok(render_summary(job_ids, operation, http_mode, &statuses).await)
+}
+
+pub struct DriftOutcome {
+    pub deployment_status: DeploymentStatus,
+    pub resource_changes: Vec<env_defs::SanitizedResourceChange>,
+}
+
+/// Follow a driftcheck job to completion and return its compact change record.
+///
+/// Driftcheck runs a `plan -refresh-only` (or `apply` when remediating) under
+/// the hood, but callers typically want the compact sanitized diff rather than
+/// the full plan summary tables produced by `follow_execution`.
+pub async fn follow_driftcheck(job: &ClaimJobStruct, remediate: bool) -> Result<DriftOutcome> {
+    let operation = if remediate { "apply" } else { "plan" };
+    let http_mode = is_http_mode_enabled();
+    let statuses = poll_until_done(std::slice::from_ref(job), operation, http_mode, true).await?;
+    let deployment = statuses
+        .get(&job.job_id)
+        .ok_or_else(|| anyhow::anyhow!("No deployment record returned for drift check"))?;
+
+    let change_record = fetch_change_record(
+        http_mode,
+        &job.region,
+        &job.environment,
+        &job.deployment_id,
+        &job.job_id,
+        &operation.to_uppercase(),
+    )
+    .await?;
+
+    Ok(DriftOutcome {
+        deployment_status: deployment.status.clone(),
+        resource_changes: change_record.resource_changes,
+    })
 }

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -84,17 +84,16 @@ pub async fn run_claim_file(
         return Ok(());
     }
 
-    // Warn if user wants to store files but disabled following
+    // Warn if user wants to store files but opted out of following
     if store_files && !follow {
         eprintln!(
-            "Warning: --store-files requires --follow to be enabled. Files will not be stored."
+            "Warning: --store-files requires streaming progress (don't pass --no-follow). Files will not be stored."
         );
-        eprintln!("Add --follow to enable file storage.");
     }
 
     if follow {
-        let (overview, std_output, violations) = match follow_execution(&job_ids, command).await {
-            Ok((overview, std_output, violations)) => (overview, std_output, violations),
+        let tables = match follow_execution(&job_ids, command).await {
+            Ok(tables) => tables,
             Err(e) => {
                 println!("Failed to follow {}: {}", command, e);
                 return Err(e);
@@ -102,14 +101,20 @@ pub async fn run_claim_file(
         };
 
         if store_files {
-            std::fs::write("overview.txt", overview).expect("Failed to write overview file");
-            println!("Overview written to overview.txt");
+            if !tables.overview.is_empty() {
+                std::fs::write("overview.txt", tables.overview)
+                    .expect("Failed to write overview file");
+                println!("Overview written to overview.txt");
+            }
 
-            std::fs::write("std_output.txt", std_output).expect("Failed to write std output file");
-            println!("Std output written to std_output.txt");
+            if !tables.std_output.is_empty() {
+                std::fs::write("std_output.txt", tables.std_output)
+                    .expect("Failed to write std output file");
+                println!("Std output written to std_output.txt");
+            }
 
-            if command == "plan" {
-                std::fs::write("violations.txt", violations)
+            if command == "plan" && !tables.violations.is_empty() {
+                std::fs::write("violations.txt", tables.violations)
                     .expect("Failed to write violations file");
                 println!("Violations written to violations.txt");
             }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,7 +1,36 @@
 use env_common::interface::GenericCloudHandler;
+use env_common::logic::{PROJECT_ID, REGION};
 use env_defs::CloudProvider;
-use inquire::Select;
+use http_client::{http_get_deployments, is_http_mode_enabled};
+use inquire::{Select, Text};
 use std::collections::HashSet;
+
+async fn fetch_all_deployment_summaries() -> anyhow::Result<Vec<(String, String)>> {
+    if is_http_mode_enabled() {
+        let project = PROJECT_ID
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("--project is required in HTTP mode"))?;
+        let region = REGION
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("--region is required in HTTP mode"))?;
+        let items = http_get_deployments(project, region).await?;
+        Ok(items
+            .into_iter()
+            .filter_map(|v| {
+                let env = v.get("environment")?.as_str()?.to_string();
+                let dep = v.get("deployment_id")?.as_str()?.to_string();
+                Some((env, dep))
+            })
+            .collect())
+    } else {
+        let handler = current_region_handler().await;
+        let deployments = handler.get_all_deployments("", false).await?;
+        Ok(deployments
+            .into_iter()
+            .map(|d| (d.environment, d.deployment_id))
+            .collect())
+    }
+}
 
 pub fn get_environment(environment_arg: &str) -> String {
     if !environment_arg.contains('/') {
@@ -18,30 +47,24 @@ pub async fn current_region_handler() -> GenericCloudHandler {
 }
 
 pub async fn get_available_environments() -> anyhow::Result<Vec<String>> {
-    let handler = current_region_handler().await;
-    let deployments = handler.get_all_deployments("", false).await?;
-
-    let mut environments: Vec<String> = deployments
-        .iter()
-        .map(|d| d.environment.clone())
+    let summaries = fetch_all_deployment_summaries().await?;
+    let mut environments: Vec<String> = summaries
+        .into_iter()
+        .map(|(env, _)| env)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
-
     environments.sort();
     Ok(environments)
 }
 
 pub async fn get_available_deployments(environment: &str) -> anyhow::Result<Vec<String>> {
-    let handler = current_region_handler().await;
-    let deployments = handler.get_all_deployments("", false).await?;
-
-    let mut deployment_ids: Vec<String> = deployments
-        .iter()
-        .filter(|d| d.environment == environment)
-        .map(|d| d.deployment_id.clone())
+    let summaries = fetch_all_deployment_summaries().await?;
+    let mut deployment_ids: Vec<String> = summaries
+        .into_iter()
+        .filter(|(env, _)| env == environment)
+        .map(|(_, dep)| dep)
         .collect();
-
     deployment_ids.sort();
     Ok(deployment_ids)
 }
@@ -84,6 +107,23 @@ pub async fn resolve_environment_id(environment_id: Option<String>) -> String {
                 std::process::exit(1);
             }
         },
+    }
+}
+
+pub async fn resolve_environment_id_for_new_deployment(environment_id: Option<String>) -> String {
+    if let Some(id) = environment_id {
+        return id;
+    }
+    match Text::new("Environment id (namespace):")
+        .with_default("default")
+        .with_help_message("Used as the `cli/<namespace>` environment for this deployment")
+        .prompt()
+    {
+        Ok(env) => env,
+        Err(e) => {
+            eprintln!("Error reading environment: {}", e);
+            std::process::exit(1);
+        }
     }
 }
 
@@ -144,13 +184,11 @@ pub async fn resolve_environment_and_deployment(
 }
 
 async fn prompt_select_environment_for_deployment(deployment_id: &str) -> anyhow::Result<String> {
-    let handler = current_region_handler().await;
-    let deployments = handler.get_all_deployments("", false).await?;
-
-    let mut environments: Vec<String> = deployments
-        .iter()
-        .filter(|d| d.deployment_id == deployment_id)
-        .map(|d| d.environment.clone())
+    let summaries = fetch_all_deployment_summaries().await?;
+    let mut environments: Vec<String> = summaries
+        .into_iter()
+        .filter(|(_, dep)| dep == deployment_id)
+        .map(|(env, _)| env)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();

--- a/env_common/src/logic/api_infra.rs
+++ b/env_common/src/logic/api_infra.rs
@@ -462,7 +462,7 @@ pub async fn driftcheck_infra(
     environment: &str,
     remediate: bool,
     extra_data: ExtraData,
-) -> Result<String, anyhow::Error> {
+) -> Result<(String, String), anyhow::Error> {
     let name = "".to_string();
 
     // In HTTP mode, fetch the existing deployment via the HTTP API.
@@ -492,7 +492,7 @@ pub async fn driftcheck_infra(
         anyhow::anyhow!("Failed to describe deployment, deployment was not found")
     })?;
 
-    println!("Deployment exists");
+    debug!("Deployment exists");
     let module = deployment.module;
     let environment = deployment.environment;
     let variables: serde_json::Value = serde_json::to_value(&deployment.variables).unwrap();
@@ -542,8 +542,9 @@ pub async fn driftcheck_infra(
         variables: variables,
     };
 
+    let region = payload_with_variables.payload.region.clone();
     let job_id: String = submit_claim_job(handler, &payload_with_variables).await?;
-    Ok(job_id)
+    Ok((job_id, region))
 }
 
 pub async fn submit_claim_job(

--- a/integration-tests/tests/cli_http.rs
+++ b/integration-tests/tests/cli_http.rs
@@ -4,7 +4,6 @@
 /// by testcontainers DynamoDB + MinIO), then all tests reuse the same server.
 /// This validates the full round-trip from the CLI's HTTP transport helpers
 /// through the internal-api HTTP endpoints and back.
-mod utils;
 
 #[cfg(test)]
 #[allow(deprecated)] // set_var/remove_var: safe here because all writes happen inside OnceCell::get_or_init before any test runs.


### PR DESCRIPTION
- plan/follow_execution: rewritten to support HTTP mode in addition to direct cloud handlers; new SummaryTables return type.
- driftcheck: streams progress via follow_driftcheck and prints drifted resources with pretty_print_resource_changes; driftcheck_infra now returns (job_id, region) so the cli can poll the right region.
- follow flag flip: apply/destroy switch from --follow opt-in to --no-follow opt-out (breaking). plan always streams (the summary requires it), so it has no follow flag.
- new resolve_environment_id_for_new_deployment prompt with "default" as default; HTTP-aware deployment listing in get_available_*.
- integration-tests: drop orphan utils mod from cli_http.