### PR TITLE
feat: ECS liveness, refresh-only plans, HTTP polling fixes

### DIFF
--- a/defs/src/lib.rs
+++ b/defs/src/lib.rs
@@ -56,8 +56,8 @@ pub use policy::{
 };
 pub use resource::ResourceResp;
 pub use resource_change::{
-    pretty_print_resource_changes, sanitize_resource_changes, sanitize_resource_changes_from_plan,
-    ResourceAction, ResourceMode, SanitizedResourceChange,
+    pretty_print_resource_changes, sanitize_resource_changes_from_plan, ResourceAction,
+    ResourceMode, SanitizedResourceChange,
 };
 pub use stack::StackManifest;
 pub use tfoutput::TfOutput;

--- a/defs/src/resource_change.rs
+++ b/defs/src/resource_change.rs
@@ -459,20 +459,28 @@ impl SanitizedResourceChange {
     }
 }
 
-/// Extract sanitized resource changes from full Terraform plan JSON
+/// Extract sanitized resource changes from full Terraform plan JSON.
+///
+/// In `-refresh-only` plans, `resource_changes` is all no-op and the real
+/// delta lives under `resource_drift`; pass `refresh_only = true` to pick
+/// that key instead.
 pub fn sanitize_resource_changes_from_plan(
     plan_json: &serde_json::Value,
+    refresh_only: bool,
 ) -> Vec<SanitizedResourceChange> {
+    let key = if refresh_only {
+        "resource_drift"
+    } else {
+        "resource_changes"
+    };
     plan_json
-        .get("resource_changes")
+        .get(key)
         .map(sanitize_resource_changes)
         .unwrap_or_default()
 }
 
 /// Extract sanitized resource changes from resource_changes array
-pub fn sanitize_resource_changes(
-    resource_changes: &serde_json::Value,
-) -> Vec<SanitizedResourceChange> {
+fn sanitize_resource_changes(resource_changes: &serde_json::Value) -> Vec<SanitizedResourceChange> {
     resource_changes
         .as_array()
         .map(|changes| {
@@ -1075,7 +1083,7 @@ mod tests {
             "prior_state": {}
         });
 
-        let sanitized = sanitize_resource_changes_from_plan(&plan_json);
+        let sanitized = sanitize_resource_changes_from_plan(&plan_json, false);
         assert_eq!(sanitized.len(), 2);
         assert_eq!(sanitized[0].address, "aws_s3_bucket.example");
         assert_eq!(sanitized[0].action, ResourceAction::Create);
@@ -1091,7 +1099,7 @@ mod tests {
             "terraform_version": "1.5.0"
         });
 
-        let sanitized = sanitize_resource_changes_from_plan(&plan_json);
+        let sanitized = sanitize_resource_changes_from_plan(&plan_json, false);
         assert_eq!(sanitized.len(), 0);
     }
 
@@ -1104,8 +1112,58 @@ mod tests {
             "resource_changes": []
         });
 
-        let sanitized = sanitize_resource_changes_from_plan(&plan_json);
+        let sanitized = sanitize_resource_changes_from_plan(&plan_json, false);
         assert_eq!(sanitized.len(), 0);
+    }
+
+    #[test]
+    fn test_sanitize_resource_changes_from_plan_refresh_only() {
+        // In -refresh-only plans, real drift lives in `resource_drift`;
+        // `resource_changes` is all no-op.
+        let plan_json = json!({
+            "format_version": "1.2",
+            "terraform_version": "1.5.0",
+            "resource_drift": [
+                {
+                    "address": "aws_s3_bucket.example",
+                    "type": "aws_s3_bucket",
+                    "name": "example",
+                    "mode": "managed",
+                    "change": {
+                        "actions": ["update"],
+                        "before": {"bucket": "my-bucket"},
+                        "after": {"bucket": "my-bucket", "tags": {"Test": "override-me22"}},
+                        "before_sensitive": {},
+                        "after_sensitive": {}
+                    }
+                }
+            ],
+            "resource_changes": [
+                {
+                    "address": "aws_s3_bucket.example",
+                    "type": "aws_s3_bucket",
+                    "name": "example",
+                    "mode": "managed",
+                    "change": {
+                        "actions": ["no-op"],
+                        "before": {"bucket": "my-bucket"},
+                        "after": {"bucket": "my-bucket"},
+                        "before_sensitive": {},
+                        "after_sensitive": {}
+                    }
+                }
+            ]
+        });
+
+        // refresh_only = true reads from resource_drift
+        let drift = sanitize_resource_changes_from_plan(&plan_json, true);
+        assert_eq!(drift.len(), 1);
+        assert_eq!(drift[0].action, ResourceAction::Update);
+
+        // refresh_only = false reads from resource_changes (no-op)
+        let changes = sanitize_resource_changes_from_plan(&plan_json, false);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].action, ResourceAction::NoOp);
     }
 
     #[test]

--- a/http_client/src/client.rs
+++ b/http_client/src/client.rs
@@ -803,39 +803,53 @@ pub async fn http_is_deployment_plan_in_progress(
         );
 
         let fetch_plan_deployment = async {
-            http_get_plan_deployment(project_id, region, environment, deployment_id, job_id_short)
-                .await
-                .ok()
-                .and_then(|v| serde_json::from_value::<DeploymentResp>(v).ok())
+            match http_get_plan_deployment(
+                project_id,
+                region,
+                environment,
+                deployment_id,
+                job_id_short,
+            )
+            .await
+            {
+                Ok(v) => match serde_json::from_value::<DeploymentResp>(v.clone()) {
+                    Ok(d) => Some(d),
+                    Err(e) => {
+                        log::warn!(
+                            "Plan deployment response could not be parsed for {}: {} (raw: {})",
+                            job_id_short,
+                            e,
+                            v
+                        );
+                        None
+                    }
+                },
+                Err(e) => {
+                    log::debug!("Plan deployment lookup for {} failed: {}", job_id_short, e);
+                    None
+                }
+            }
         };
 
         if status == "STOPPED" || status == "DEPROVISIONING" {
-            if exit_code != 0 {
-                log::error!(
-                    "ECS task failed with exit code {}: {}",
-                    exit_code,
-                    stopped_reason
-                );
-            } else if !stopped_reason.is_empty()
-                && stopped_reason != "Essential container in task exited"
-            {
-                log::warn!("ECS task stopped with reason: {}", stopped_reason);
-            }
-
             let deployment = fetch_plan_deployment.await;
             if let Some(ref d) = deployment {
+                // Trust the plan record: its status reflects what the runner
+                // actually wrote, independent of ECS lifecycle timing.
                 info!(
                     "Found deployment plan record for job {}: status={}",
                     job_id_short, d.status
                 );
-            } else {
-                log::warn!(
-                    "Job {} finished with exit code {} but no deployment plan record found yet",
-                    job_id_short,
-                    exit_code
-                );
+                let in_progress = d.status.is_busy();
+                return (in_progress, job_id_short.to_string(), Some(d.clone()));
             }
-            return (false, job_id_short.to_string(), deployment);
+            log::error!(
+                "Job {} stopped (exit_code={}, reason={}) without a plan record; treating as failed",
+                job_id_short,
+                exit_code,
+                stopped_reason
+            );
+            return (false, job_id_short.to_string(), None);
         } else if matches!(
             status,
             "RUNNING" | "PENDING" | "PROVISIONING" | "ACTIVATING"
@@ -875,6 +889,11 @@ pub async fn http_check_deployment_progress(
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
+        info!(
+            "ECS task status: {}, stopped_reason: {}, exit_code: {}",
+            status, stopped_reason, exit_code
+        );
+
         let fetch_deployment = async {
             http_describe_deployment(project_id, region, environment, deployment_id)
                 .await
@@ -889,20 +908,18 @@ pub async fn http_check_deployment_progress(
         };
 
         if status == "STOPPED" || status == "DEPROVISIONING" {
-            if exit_code != 0 {
-                log::error!(
-                    "ECS task failed with exit code {}: {}",
-                    exit_code,
-                    stopped_reason
-                );
-            } else if !stopped_reason.is_empty()
-                && stopped_reason != "Essential container in task exited"
-            {
-                log::warn!("ECS task stopped with reason: {}", stopped_reason);
-            }
-
             let deployment = fetch_deployment.await;
-            return (false, job_id_short.to_string(), deployment);
+            if let Some(ref d) = deployment {
+                let in_progress = d.status.is_busy();
+                return (in_progress, job_id_short.to_string(), Some(d.clone()));
+            }
+            log::error!(
+                "Job {} stopped (exit_code={}, reason={}) without a deployment record; treating as failed",
+                job_id_short,
+                exit_code,
+                stopped_reason
+            );
+            return (false, job_id_short.to_string(), None);
         } else if matches!(
             status,
             "RUNNING" | "PENDING" | "PROVISIONING" | "ACTIVATING"

--- a/internal-api/Dockerfile.lambda
+++ b/internal-api/Dockerfile.lambda
@@ -31,6 +31,7 @@ COPY --from=builder /app/target/release/internal-api-aws-unified /usr/local/bin/
 
 # Lambda requires this
 ENV AWS_LAMBDA_RUNTIME_API="aws-runtime-interface.emulator"
+ENV CLOUD_PROVIDER=aws_direct
 
 # Expose the Lambda runtime port
 EXPOSE 8080

--- a/internal-api/src/api_common.rs
+++ b/internal-api/src/api_common.rs
@@ -13,6 +13,10 @@ pub trait DatabaseQuery {
     ) -> Result<Value>;
 }
 
+pub trait JobRunner {
+    async fn liveness_check(&self, record: Value) -> Value;
+}
+
 // Helper macro to extract required parameters from payload
 #[macro_export]
 macro_rules! get_param {
@@ -74,12 +78,12 @@ async fn query_one<Q: DatabaseQuery>(
         .ok_or_else(|| anyhow!("Item not found"))
 }
 
-pub async fn describe_deployment_impl<Q: DatabaseQuery>(
+pub async fn describe_deployment_impl<Q: DatabaseQuery + JobRunner>(
     db: &Q,
     payload: &Value,
     qb: impl Fn(&str, &str, &str, &str, bool) -> Value,
 ) -> Result<Value> {
-    query_one(
+    let record = query_one(
         db,
         "deployments",
         qb(
@@ -92,15 +96,16 @@ pub async fn describe_deployment_impl<Q: DatabaseQuery>(
         payload.get("region").and_then(|v| v.as_str()),
     )
     .await
-    .map_err(|_| anyhow!("Deployment not found"))
+    .map_err(|_| anyhow!("Deployment not found"))?;
+    Ok(db.liveness_check(record).await)
 }
 
-pub async fn get_plan_deployment_impl<Q: DatabaseQuery>(
+pub async fn get_plan_deployment_impl<Q: DatabaseQuery + JobRunner>(
     db: &Q,
     payload: &Value,
     qb: impl Fn(&str, &str, &str, &str, &str) -> Value,
 ) -> Result<Value> {
-    query_one(
+    let record = query_one(
         db,
         "deployments",
         qb(
@@ -113,7 +118,8 @@ pub async fn get_plan_deployment_impl<Q: DatabaseQuery>(
         payload.get("region").and_then(|v| v.as_str()),
     )
     .await
-    .map_err(|_| anyhow!("Plan deployment not found"))
+    .map_err(|_| anyhow!("Plan deployment not found"))?;
+    Ok(db.liveness_check(record).await)
 }
 
 pub async fn get_deployments_impl<Q: DatabaseQuery>(

--- a/internal-api/src/aws_handlers.rs
+++ b/internal-api/src/aws_handlers.rs
@@ -1,11 +1,10 @@
 #![cfg(feature = "aws")]
 use anyhow::{anyhow, Result};
 use axum::{body::Body, http::header, response::Response};
-use log::info;
 use serde_json::{json, Value};
-use tracing::{event, instrument, Level};
+use tracing::{error, info, instrument, warn};
 
-use crate::api_common::DatabaseQuery;
+use crate::api_common::{DatabaseQuery, JobRunner};
 use crate::common::get_env_var;
 use crate::get_param;
 
@@ -13,10 +12,10 @@ pub use env_aws_direct::utils::{
     get_bucket_name, get_bucket_name_for_region, get_table_name_for_region,
 };
 
-// DatabaseQuery implementation for AWS (DynamoDB)
-pub struct AwsDatabase;
+// Backend implementation for AWS (DynamoDB + ECS)
+pub struct AwsBackend;
 
-impl DatabaseQuery for AwsDatabase {
+impl DatabaseQuery for AwsBackend {
     async fn query_table(
         &self,
         container: &str,
@@ -40,6 +39,12 @@ impl DatabaseQuery for AwsDatabase {
     }
 }
 
+impl JobRunner for AwsBackend {
+    async fn liveness_check(&self, record: Value) -> Value {
+        ecs_liveness_check(record).await
+    }
+}
+
 #[instrument(skip(payload), fields(table = tracing::field::Empty, items = tracing::field::Empty))]
 pub async fn insert_db(payload: &Value) -> Result<Value> {
     let table = get_param!(payload, "table");
@@ -55,7 +60,7 @@ pub async fn insert_db(payload: &Value) -> Result<Value> {
 
     env_aws_direct::insert_db_direct(table, data, region).await?;
 
-    event!(Level::INFO, "DynamoDB put_item completed");
+    info!("DynamoDB put_item completed");
 
     Ok(json!({
         "ResponseMetadata": {
@@ -105,8 +110,7 @@ pub async fn read_db(payload: &Value) -> Result<Value> {
     let response = env_aws_direct::read_db_direct(table, query_data, region).await?;
 
     let elapsed = start_time.elapsed();
-    event!(
-        Level::INFO,
+    info!(
         duration_ms = elapsed.as_millis() as f64,
         "DynamoDB query completed"
     );
@@ -149,7 +153,7 @@ pub async fn upload_file_base64(payload: &Value) -> Result<Value> {
 
     env_aws_direct::upload_file_base64_direct(&bucket_name, key, content_base64, region).await?;
 
-    event!(Level::INFO, "S3 upload from base64 completed");
+    info!("S3 upload from base64 completed");
 
     Ok(json!({
         "statusCode": 200,
@@ -193,11 +197,11 @@ pub async fn upload_file_url(payload: &Value) -> Result<Value> {
     span.record("already_exists", already_exists);
 
     if already_exists {
-        event!(Level::INFO, "S3 object already exists, skipping upload");
+        info!("S3 object already exists, skipping upload");
         return Ok(json!({"object_already_exists": true}));
     }
 
-    event!(Level::INFO, "S3 upload from URL completed");
+    info!("S3 upload from URL completed");
     Ok(json!({"object_already_exists": false}))
 }
 
@@ -230,7 +234,7 @@ pub async fn generate_presigned_url(payload: &Value) -> Result<Value> {
         env_aws_direct::generate_presigned_url_direct(&bucket_name, key, expires_in as u64, region)
             .await?;
 
-    event!(Level::INFO, "Presigned URL generated successfully");
+    info!("Presigned URL generated successfully");
 
     Ok(json!({"url": url}))
 }
@@ -240,7 +244,7 @@ pub async fn generate_presigned_url(payload: &Value) -> Result<Value> {
     fields(project_id, environment, region, task_definition)
 )]
 pub async fn start_runner(payload: &Value) -> Result<Value> {
-    log::info!(
+    info!(
         "start_runner called with payload keys: {:?}",
         payload.as_object().map(|o| o.keys().collect::<Vec<_>>())
     );
@@ -273,7 +277,7 @@ pub async fn start_runner(payload: &Value) -> Result<Value> {
         .unwrap_or("");
     let job_id = result.get("job_id").and_then(|v| v.as_str()).unwrap_or("");
 
-    event!(Level::INFO, task_arn = %task_arn, job_id = %job_id, "ECS task launched successfully");
+    info!(task_arn = %task_arn, job_id = %job_id, "ECS task launched successfully");
 
     Ok(result)
 }
@@ -314,13 +318,81 @@ pub async fn get_job_status(payload: &Value) -> Result<Value> {
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
 
-    event!(Level::INFO, status = %status, exit_code = exit_code, "ECS task status retrieved");
+    info!(status = %status, exit_code = exit_code, "ECS task status retrieved");
 
     Ok(result)
 }
 
+pub async fn ecs_liveness_check(record: Value) -> Value {
+    let mut deployment: env_defs::DeploymentResp = match serde_json::from_value(record.clone()) {
+        Ok(d) => d,
+        Err(e) => {
+            error!(
+                "Liveness check skipped: deployment record did not deserialize: {}",
+                e
+            );
+            return record;
+        }
+    };
+
+    if !deployment.status.is_busy() {
+        return record;
+    }
+    if deployment.job_id.is_empty()
+        || deployment.project_id.is_empty()
+        || deployment.region.is_empty()
+    {
+        return record;
+    }
+
+    let job_id_short = deployment
+        .job_id
+        .split('/')
+        .last()
+        .unwrap_or(&deployment.job_id);
+    let js = match env_aws_direct::get_job_status_cross_account(
+        job_id_short,
+        &deployment.project_id,
+        &deployment.region,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            error!(
+                "ECS liveness check lookup failed for {}: {}",
+                deployment.job_id, e
+            );
+            return record;
+        }
+    };
+
+    let task_status = js.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if !matches!(task_status, "STOPPED" | "DEPROVISIONING") {
+        return record;
+    }
+
+    let reason = js
+        .get("stopped_reason")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("task exited before writing final status");
+
+    warn!(
+        job_id = %deployment.job_id,
+        task_status = %task_status,
+        stopped_reason = %reason,
+        "ECS liveness check: flipping busy deployment to failed"
+    );
+
+    deployment.status = env_defs::DeploymentStatus::Failed;
+    deployment.error_text = format!("ECS task stopped: {}", reason);
+
+    serde_json::to_value(&deployment).unwrap_or(record)
+}
+
 pub async fn read_logs(payload: &Value) -> Result<Value> {
-    log::info!(
+    info!(
         "read_logs called with payload: {}",
         serde_json::to_string(payload).unwrap_or_else(|_| "invalid json".to_string())
     );

--- a/internal-api/src/azure_handlers.rs
+++ b/internal-api/src/azure_handlers.rs
@@ -8,7 +8,7 @@ use axum::{
 use log::info;
 use serde_json::{json, Value};
 
-use crate::api_common::{self, DatabaseQuery};
+use crate::api_common::{self, DatabaseQuery, JobRunner};
 use crate::common::get_env_var;
 use crate::get_param;
 use azure_core::credentials::TokenCredential;
@@ -56,9 +56,9 @@ fn get_id(item: &Value) -> Result<String> {
 }
 
 // DatabaseQuery implementation for Azure (Cosmos DB)
-pub struct AzureDatabase;
+pub struct AzureBackend;
 
-impl DatabaseQuery for AzureDatabase {
+impl DatabaseQuery for AzureBackend {
     async fn query_table(
         &self,
         container: &str,
@@ -73,6 +73,13 @@ impl DatabaseQuery for AzureDatabase {
         });
 
         read_db(&payload).await
+    }
+}
+
+impl JobRunner for AzureBackend {
+    async fn liveness_check(&self, record: Value) -> Value {
+        // TODO: implement Container Apps job liveness check.
+        record
     }
 }
 

--- a/internal-api/src/handlers.rs
+++ b/internal-api/src/handlers.rs
@@ -10,34 +10,34 @@ use serde_json::{json, Value};
 #[cfg(feature = "aws")]
 use crate::aws_handlers::{
     download_file, download_file_as_string, download_file_as_string_from_region, get_bucket_name,
-    get_bucket_name_for_region, AwsDatabase as Database,
+    get_bucket_name_for_region, AwsBackend as Backend,
 };
 
 #[cfg(feature = "azure")]
-use crate::azure_handlers::{download_file, download_file_as_string, AzureDatabase as Database};
+use crate::azure_handlers::{download_file, download_file_as_string, AzureBackend as Backend};
 #[cfg(feature = "azure")]
 use crate::common::get_env_var;
 
 pub async fn describe_deployment(payload: &Value) -> Result<Value> {
-    api_common::describe_deployment_impl(&Database, payload, get_deployment_and_dependents_query)
+    api_common::describe_deployment_impl(&Backend, payload, get_deployment_and_dependents_query)
         .await
 }
 
 pub async fn describe_plan_deployment(payload: &Value) -> Result<Value> {
-    api_common::get_plan_deployment_impl(&Database, payload, get_plan_deployment_query).await
+    api_common::get_plan_deployment_impl(&Backend, payload, get_plan_deployment_query).await
 }
 
 pub async fn get_deployments(payload: &Value) -> Result<Value> {
-    api_common::get_deployments_impl(&Database, payload, get_all_deployments_query).await
+    api_common::get_deployments_impl(&Backend, payload, get_all_deployments_query).await
 }
 
 pub async fn get_modules(payload: &Value) -> Result<Value> {
-    api_common::get_modules_impl(&Database, payload, get_all_latest_modules_query).await
+    api_common::get_modules_impl(&Backend, payload, get_all_latest_modules_query).await
 }
 
 pub async fn get_projects(payload: &Value) -> Result<Value> {
     let mut result =
-        api_common::get_projects_impl(&Database, payload, get_all_projects_query).await?;
+        api_common::get_projects_impl(&Backend, payload, get_all_projects_query).await?;
 
     // Filter projects based on user access
     let allowed_projects =
@@ -78,28 +78,28 @@ pub async fn get_projects(payload: &Value) -> Result<Value> {
 }
 
 pub async fn get_stacks(payload: &Value) -> Result<Value> {
-    api_common::get_stacks_impl(&Database, payload, get_all_latest_stacks_query).await
+    api_common::get_stacks_impl(&Backend, payload, get_all_latest_stacks_query).await
 }
 
 pub async fn get_providers(payload: &Value) -> Result<Value> {
-    api_common::get_providers_impl(&Database, payload, get_all_latest_providers_query).await
+    api_common::get_providers_impl(&Backend, payload, get_all_latest_providers_query).await
 }
 
 pub async fn get_policies(payload: &Value) -> Result<Value> {
-    api_common::get_policies_impl(&Database, payload, get_all_policies_query).await
+    api_common::get_policies_impl(&Backend, payload, get_all_policies_query).await
 }
 
 pub async fn get_policy_version(payload: &Value) -> Result<Value> {
-    api_common::get_policy_version_impl(&Database, payload, get_policy_query).await
+    api_common::get_policy_version_impl(&Backend, payload, get_policy_query).await
 }
 
 pub async fn get_module_version(payload: &Value) -> Result<Value> {
-    api_common::get_module_version_impl(&Database, payload, get_module_version_query).await
+    api_common::get_module_version_impl(&Backend, payload, get_module_version_query).await
 }
 
 pub async fn get_module_download_url(payload: &Value) -> Result<Response> {
     let module_version =
-        api_common::get_module_version_impl(&Database, payload, get_module_version_query).await?;
+        api_common::get_module_version_impl(&Backend, payload, get_module_version_query).await?;
     let s3_key = module_version
         .get("s3_key")
         .and_then(|v| v.as_str())
@@ -123,12 +123,12 @@ pub async fn get_module_download_url(payload: &Value) -> Result<Response> {
 }
 
 pub async fn get_provider_version(payload: &Value) -> Result<Value> {
-    api_common::get_provider_version_impl(&Database, payload, get_provider_version_query).await
+    api_common::get_provider_version_impl(&Backend, payload, get_provider_version_query).await
 }
 
 pub async fn get_provider_download_url(payload: &Value) -> Result<Response> {
     let provider_version =
-        api_common::get_provider_version_impl(&Database, payload, get_provider_version_query)
+        api_common::get_provider_version_impl(&Backend, payload, get_provider_version_query)
             .await?;
     let s3_key = provider_version
         .get("s3_key")
@@ -153,12 +153,12 @@ pub async fn get_provider_download_url(payload: &Value) -> Result<Response> {
 }
 
 pub async fn get_stack_version(payload: &Value) -> Result<Value> {
-    api_common::get_stack_version_impl(&Database, payload, get_stack_version_query).await
+    api_common::get_stack_version_impl(&Backend, payload, get_stack_version_query).await
 }
 
 pub async fn get_stack_download_url(payload: &Value) -> Result<Response> {
     let stack_version =
-        api_common::get_stack_version_impl(&Database, payload, get_stack_version_query).await?;
+        api_common::get_stack_version_impl(&Backend, payload, get_stack_version_query).await?;
     let s3_key = stack_version
         .get("s3_key")
         .and_then(|v| v.as_str())
@@ -173,18 +173,18 @@ pub async fn get_stack_download_url(payload: &Value) -> Result<Response> {
 }
 
 pub async fn get_all_versions_for_module(payload: &Value) -> Result<Value> {
-    api_common::get_all_versions_for_module_impl(&Database, payload, get_all_module_versions_query)
+    api_common::get_all_versions_for_module_impl(&Backend, payload, get_all_module_versions_query)
         .await
 }
 
 pub async fn get_all_versions_for_stack(payload: &Value) -> Result<Value> {
-    api_common::get_all_versions_for_stack_impl(&Database, payload, get_all_stack_versions_query)
+    api_common::get_all_versions_for_stack_impl(&Backend, payload, get_all_stack_versions_query)
         .await
 }
 
 pub async fn get_deployments_for_module(payload: &Value) -> Result<Value> {
     api_common::get_deployments_for_module_impl(
-        &Database,
+        &Backend,
         payload,
         get_deployments_using_module_query,
     )
@@ -192,16 +192,16 @@ pub async fn get_deployments_for_module(payload: &Value) -> Result<Value> {
 }
 
 pub async fn get_events(payload: &Value) -> Result<Value> {
-    api_common::get_events_impl(&Database, payload, get_events_query).await
+    api_common::get_events_impl(&Backend, payload, get_events_query).await
 }
 
 pub async fn get_change_record(payload: &Value) -> Result<Value> {
-    api_common::get_change_record_impl(&Database, payload, get_change_records_query).await
+    api_common::get_change_record_impl(&Backend, payload, get_change_records_query).await
 }
 
 pub async fn get_deployment_history(payload: &Value) -> Result<Value> {
     api_common::get_deployment_history_impl(
-        &Database,
+        &Backend,
         payload,
         get_deployment_history_plans_query,
         get_deployment_history_deleted_query,
@@ -211,19 +211,15 @@ pub async fn get_deployment_history(payload: &Value) -> Result<Value> {
 
 pub async fn get_change_record_graph(payload: &Value) -> Result<Response> {
     info!("get_change_record_graph payload: {:?}", payload);
-    let change_record = match api_common::get_change_record_impl(
-        &Database,
-        payload,
-        get_change_records_query,
-    )
-    .await
-    {
-        Ok(cr) => cr,
-        Err(e) => {
-            log::error!("Failed to fetch change record: {:?}", e);
-            return Err(e);
-        }
-    };
+    let change_record =
+        match api_common::get_change_record_impl(&Backend, payload, get_change_records_query).await
+        {
+            Ok(cr) => cr,
+            Err(e) => {
+                log::error!("Failed to fetch change record: {:?}", e);
+                return Err(e);
+            }
+        };
 
     let plan_key = change_record
         .get("plan_raw_json_key")
@@ -307,7 +303,7 @@ pub async fn get_deployment_graph(payload: &Value) -> Result<Response> {
         "MUTATE",
     );
 
-    let cr_resp = Database
+    let cr_resp = Backend
         .query_table("change_records", &cr_query, None)
         .await?;
     let change_record = cr_resp

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -458,7 +458,7 @@ pub async fn terraform_show(
             // Only create InfraChangeRecord for plan commands
             // For apply/destroy, the record is created after the operation in terraform_show_after_apply
             if command == "plan" {
-                let resource_changes = sanitize_resource_changes_from_plan(&content);
+                let resource_changes = sanitize_resource_changes_from_plan(&content, refresh_only);
 
                 let infra_change_record = InfraChangeRecord {
                     deployment_id: deployment_id.to_string(),
@@ -516,7 +516,7 @@ pub async fn record_apply_destroy_changes(
     {
         Ok(plan_content) => match serde_json::from_str::<Value>(&plan_content) {
             Ok(content) => {
-                let sanitized = sanitize_resource_changes_from_plan(&content);
+                let sanitized = sanitize_resource_changes_from_plan(&content, false);
                 (sanitized, plan_content)
             }
             Err(_) => {


### PR DESCRIPTION
- internal-api: add JobRunner trait; AWS backend flips busy deployments to Failed when the ECS task has stopped without writing a final status. Azure stub for now.
- http_client: when an ECS task stops, trust the deployment record's status instead of inferring from exit_code; surface "stopped without record" as an error rather than silent in-progress.
- defs: sanitize_resource_changes_from_plan now takes refresh_only so -refresh-only plans read from resource_drift instead of the all-no-op resource_changes; terraform_runner threads the flag through.