### PR TITLE
chore(make): build all component images via build-images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: integration-tests # Always run, disregard if files have been updated or not
+.PHONY: integration-tests build-images # Always run, disregard if files have been updated or not
 
 generate-cli-docs:
 	@echo "Generating CLI documentation..."
@@ -52,3 +52,15 @@ test: unit-tests integration-tests
 clear-docker:
 	@echo "Clearing Docker images..."
 	@docker stop $$(docker ps -q) && docker rm $$(docker ps -aq) || true
+
+IMAGE_COMPONENTS := cli operator gitops reconciler prometheus_exporter webserver-openapi terraform_runner
+
+build-images:
+	cross build --release --locked --target aarch64-unknown-linux-musl $(foreach c,$(IMAGE_COMPONENTS),--bin $(c))
+	mkdir -p binaries
+	for bin in $(IMAGE_COMPONENTS); do \
+		cp target/aarch64-unknown-linux-musl/release/$$bin binaries/$$bin-linux-arm64-musl; \
+	done
+	for c in $(IMAGE_COMPONENTS); do \
+		REGISTRY=local VERSION=dev docker buildx bake -f $$c/bake.hcl; \
+	done


### PR DESCRIPTION
This pull request updates the `Makefile` to add a new target for building container images for multiple components. It also improves the organization of phony targets. The main focus is to streamline the process of building release binaries and Docker images for various services.

Build process improvements:

* Added a `build-images` target that compiles release binaries for all major components (`cli`, `operator`, `gitops`, `reconciler`, `prometheus_exporter`, `webserver-openapi`, `terraform_runner`) for the `aarch64-unknown-linux-musl` target, copies them to a `binaries` directory, and builds Docker images for each using `docker buildx bake`.
* Updated the `.PHONY` declaration to include `build-images` alongside `integration-tests`, ensuring both are always executed when called.