### PR TITLE
chore: disable default aws sdk tls features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,23 +948,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
  "h2 0.4.13",
- "http 0.2.12",
  "http 1.3.1",
- "http-body 0.4.6",
- "hyper 0.14.31",
  "hyper 1.7.0",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.3",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.2",
  "tracing",
 ]
@@ -1319,11 +1313,11 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1603,14 +1597,14 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-named-pipe",
- "hyper-rustls 0.27.3",
+ "hyper-rustls",
  "hyper-util",
  "hyperlocal",
  "log",
  "num",
  "pin-project-lite",
  "rand 0.9.1",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -3159,7 +3153,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "reqwest 0.11.27",
- "rustls 0.23.38",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -4295,12 +4289,12 @@ dependencies = [
  "headers",
  "http 1.3.1",
  "hyper 1.7.0",
- "hyper-rustls 0.27.3",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -4321,21 +4315,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.31",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
@@ -4345,11 +4324,11 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "log",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 0.26.11",
 ]
@@ -4799,7 +4778,7 @@ dependencies = [
  "operator",
  "pretty_assertions",
  "rand 0.8.5",
- "rustls 0.23.38",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -5226,14 +5205,14 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-http-proxy",
- "hyper-rustls 0.27.3",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
@@ -6342,14 +6321,14 @@ dependencies = [
  "log",
  "openssl",
  "pretty_assertions",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pemfile 2.2.0",
  "schemars 0.8.21",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.2",
 ]
 
@@ -7232,7 +7211,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls",
  "socket2 0.5.8",
  "thiserror 2.0.6",
  "tokio",
@@ -7252,7 +7231,7 @@ dependencies = [
  "rand 0.9.1",
  "ring",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.6",
@@ -7643,7 +7622,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.7.0",
- "hyper-rustls 0.27.3",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
@@ -7654,7 +7633,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -7663,7 +7642,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
  "tower-http 0.6.6",
@@ -7901,18 +7880,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
@@ -7922,7 +7889,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -7978,16 +7945,6 @@ checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8133,16 +8090,6 @@ dependencies = [
  "pbkdf2 0.12.2",
  "salsa20",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8581,7 +8528,7 @@ dependencies = [
  "reqwest 0.12.24",
  "rsa",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "scrypt",
  "serde",
  "serde_json",
@@ -9269,21 +9216,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls",
  "tokio",
 ]
 
@@ -9403,7 +9340,7 @@ dependencies = [
  "pem",
  "percent-encoding",
  "reqwest 0.12.24",
- "rustls 0.23.38",
+ "rustls",
  "serde",
  "serde_json",
  "serde_plain",
@@ -9828,7 +9765,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
@@ -10273,7 +10210,7 @@ dependencies = [
  "log",
  "openssl",
  "reqwest 0.12.24",
- "rustls 0.23.38",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,15 @@ testcontainers = "0.27.3"
 testcontainers-modules = "0.15.0"
 bollard = "0.20.1"
 mockall = "0.13"
+aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }
+aws-sdk-cloudwatchlogs = { version = "1.128.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-dynamodb = { version = "1.111.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-ecs = { version = "1.124.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-lambda = { version = "1.122.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-s3 = { version = "1.131.0", default-features = false, features = ["rt-tokio", "default-https-client", "sigv4a"] }
+aws-sdk-sns = { version = "1.99.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-ssm = { version = "1.109.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-sts = { version = "1.103.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
 
 [profile.ci-tests]
 inherits = "test"

--- a/env_aws/Cargo.toml
+++ b/env_aws/Cargo.toml
@@ -7,11 +7,11 @@ publish.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"
-aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }
-aws-sdk-lambda = "1.122.0"
-aws-sdk-ssm = "1.109.0"
-aws-sdk-sts = "1.103.0"
-aws-sdk-s3 = "1.131.0"
+aws-config.workspace = true
+aws-sdk-lambda.workspace = true
+aws-sdk-ssm.workspace = true
+aws-sdk-sts.workspace = true
+aws-sdk-s3.workspace = true
 serde_json = "1.0"
 serde_yaml = "0.8"
 chrono = "0.4"

--- a/env_aws_direct/Cargo.toml
+++ b/env_aws_direct/Cargo.toml
@@ -7,16 +7,16 @@ publish.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"
-aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }
+aws-config.workspace = true
 aws-credential-types = "1.2"
-aws-sdk-cloudwatchlogs = "1.128.0"
-aws-sdk-dynamodb = "1.111.0"
-aws-sdk-ecs = "1.124.0"
-aws-sdk-lambda = "1.122.0"
-aws-sdk-sns = "1.99.0"
-aws-sdk-ssm = "1.109.0"
-aws-sdk-sts = "1.103.0"
-aws-sdk-s3 = "1.131.0"
+aws-sdk-cloudwatchlogs.workspace = true
+aws-sdk-dynamodb.workspace = true
+aws-sdk-ecs.workspace = true
+aws-sdk-lambda.workspace = true
+aws-sdk-sns.workspace = true
+aws-sdk-ssm.workspace = true
+aws-sdk-sts.workspace = true
+aws-sdk-s3.workspace = true
 aws-sigv4 = "1.2"
 aws-smithy-runtime-api = "1.7"
 http = "1.0"

--- a/gitops/Cargo.toml
+++ b/gitops/Cargo.toml
@@ -30,8 +30,8 @@ chrono = "0.4"
 regex = "1.5"
 
 # AWS SDK
-aws-sdk-ssm = "1.109.0"
-aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }
+aws-sdk-ssm.workspace = true
+aws-config.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"


### PR DESCRIPTION
Set aws dependencies in workspace instead, remove rustls feature by disabling default and only set what is used. This also removes the need of an old version of rustls 0.21.12

Reference: https://github.com/awslabs/aws-sdk-rust/discussions/1257