### PR TITLE
fix: route AWS clients through cached central-assumed config

### DIFF
--- a/env_aws_direct/src/api.rs
+++ b/env_aws_direct/src/api.rs
@@ -21,7 +21,7 @@ pub async fn assume_role(
     session_name: &str,
     duration_seconds: i32,
 ) -> Result<Credentials, anyhow::Error> {
-    let shared_config = aws_config::from_env().load().await;
+    let shared_config = crate::direct_impl::get_aws_config(None).await;
     let client = aws_sdk_sts::Client::new(&shared_config);
 
     let resp = client
@@ -78,11 +78,8 @@ async fn get_s3_client_direct(region: &str) -> aws_sdk_s3::Client {
 
         aws_sdk_s3::Client::from_conf(config_builder.build())
     } else {
-        // Production mode - use real AWS S3 with specified region
-        let config = aws_config::from_env()
-            .region(aws_config::Region::new(region.to_string()))
-            .load()
-            .await;
+        // Production mode - use central-assumed credentials when initialized.
+        let config = crate::direct_impl::get_aws_config(Some(region)).await;
         get_s3_client(&config)
     }
 }
@@ -97,7 +94,7 @@ pub async fn run_function(
         get_environment_variables_direct, get_job_status_direct, insert_db_direct,
         publish_notification_direct, read_db_direct, read_logs_direct, transact_write_direct,
     };
-    use crate::utils::get_bucket_name_from_env;
+    use crate::utils::get_bucket_name_for_region;
     use aws_sdk_s3::primitives::ByteStream;
     use base64::Engine;
 
@@ -185,7 +182,7 @@ pub async fn run_function(
                 })?;
 
             let actual_bucket =
-                get_bucket_name_from_env(bucket, region).unwrap_or_else(|| bucket.to_string());
+                get_bucket_name_for_region(bucket, region).unwrap_or_else(|_| bucket.to_string());
 
             let client = get_s3_client_direct(region).await;
 
@@ -239,7 +236,7 @@ pub async fn run_function(
                 })?;
 
             let actual_bucket =
-                get_bucket_name_from_env(bucket, region).unwrap_or_else(|| bucket.to_string());
+                get_bucket_name_for_region(bucket, region).unwrap_or_else(|_| bucket.to_string());
             log::info!(
                 "Uploading {} to {}/{} (region: {})",
                 key,
@@ -293,7 +290,7 @@ pub async fn run_function(
                 .ok_or_else(|| CloudHandlerError::OtherError("Missing url field".to_string()))?;
 
             let actual_bucket =
-                get_bucket_name_from_env(bucket, region).unwrap_or_else(|| bucket.to_string());
+                get_bucket_name_for_region(bucket, region).unwrap_or_else(|_| bucket.to_string());
             log::info!(
                 "Downloading from {} and uploading to {}/{}",
                 url,
@@ -344,7 +341,7 @@ pub async fn run_function(
                 })?;
 
             let actual_bucket =
-                get_bucket_name_from_env(bucket, region).unwrap_or_else(|| bucket.to_string());
+                get_bucket_name_for_region(bucket, region).unwrap_or_else(|_| bucket.to_string());
 
             log::info!(
                 "Downloading {} from bucket {} (resolved to {})",
@@ -471,7 +468,7 @@ pub async fn start_runner(event: &Value) -> Result<Value, anyhow::Error> {
         .get("data")
         .ok_or_else(|| anyhow::anyhow!("Missing data"))?;
 
-    let shared_config = aws_config::from_env().load().await;
+    let shared_config = crate::direct_impl::get_aws_config(None).await;
     let client = aws_sdk_ecs::Client::new(&shared_config);
 
     let ecs_cluster_name = std::env::var("ECS_CLUSTER_NAME")

--- a/env_aws_direct/src/central_creds.rs
+++ b/env_aws_direct/src/central_creds.rs
@@ -1,0 +1,58 @@
+use anyhow::{anyhow, Result};
+use aws_config::sts::AssumeRoleProvider;
+use aws_config::{BehaviorVersion, Region, SdkConfig};
+use aws_credential_types::provider::SharedCredentialsProvider;
+use std::sync::OnceLock;
+
+static CENTRAL_CONFIG: OnceLock<SdkConfig> = OnceLock::new();
+
+pub fn central_config() -> Option<&'static SdkConfig> {
+    CENTRAL_CONFIG.get()
+}
+
+pub async fn init_central_credentials(region: &str) -> Result<()> {
+    if CENTRAL_CONFIG.get().is_some() {
+        return Ok(());
+    }
+    let role_arn = match std::env::var("INFRAWEAVE_CENTRAL_ROLE_ARN") {
+        Ok(v) if !v.is_empty() => v,
+        _ => return Ok(()),
+    };
+
+    let bootstrap = aws_config::from_env()
+        .region(Region::new(region.to_string()))
+        .load()
+        .await;
+
+    let provider = AssumeRoleProvider::builder(role_arn.clone())
+        .session_name("infraweave-central-session")
+        .configure(&bootstrap)
+        .build()
+        .await;
+
+    let assumed = bootstrap
+        .into_builder()
+        .credentials_provider(SharedCredentialsProvider::new(provider))
+        .behavior_version(BehaviorVersion::latest())
+        .build();
+
+    let sts = aws_sdk_sts::Client::new(&assumed);
+    let identity = sts.get_caller_identity().send().await.map_err(|e| {
+        anyhow!(
+            "Failed to verify central role assumption {}: {:?}",
+            role_arn,
+            e
+        )
+    })?;
+    log::info!(
+        "Assumed central role {} (arn={:?}, account={:?})",
+        role_arn,
+        identity.arn(),
+        identity.account()
+    );
+
+    CENTRAL_CONFIG
+        .set(assumed)
+        .map_err(|_| anyhow!("central config already initialized"))?;
+    Ok(())
+}

--- a/env_aws_direct/src/direct_impl.rs
+++ b/env_aws_direct/src/direct_impl.rs
@@ -41,12 +41,8 @@ async fn get_dynamodb_client(region_opt: Option<&str>) -> aws_sdk_dynamodb::Clie
 
         aws_sdk_dynamodb::Client::from_conf(config)
     } else {
-        // Production mode - use real AWS credentials and DynamoDB service
-        let mut config_loader = aws_config::from_env();
-        if let Some(region) = region_opt {
-            config_loader = config_loader.region(Region::new(region.to_string()));
-        }
-        let config = config_loader.load().await;
+        // Production mode - use central-assumed credentials when initialized.
+        let config = get_aws_config(region_opt).await;
         aws_sdk_dynamodb::Client::new(&config)
     }
 }
@@ -660,11 +656,7 @@ async fn get_s3_client(region_opt: Option<&str>) -> aws_sdk_s3::Client {
                 .build(),
         )
     } else {
-        let mut loader = aws_config::from_env();
-        if let Some(region) = region_opt {
-            loader = loader.region(aws_config::Region::new(region.to_string()));
-        }
-        let config = loader.load().await;
+        let config = get_aws_config(region_opt).await;
 
         let mut builder = aws_sdk_s3::config::Builder::from(&config);
         if std::env::var("AWS_S3_FORCE_PATH_STYLE")
@@ -806,7 +798,17 @@ pub async fn download_file_as_bytes_direct(
 
 // ============= Cross-account operations =============
 
-async fn get_aws_config(region: Option<&str>) -> aws_config::SdkConfig {
+pub(crate) async fn get_aws_config(region: Option<&str>) -> aws_config::SdkConfig {
+    if let Some(cached) = crate::central_creds::central_config() {
+        return match region {
+            Some(r) if cached.region().map(|reg| reg.as_ref()) != Some(r) => cached
+                .clone()
+                .into_builder()
+                .region(aws_config::Region::new(r.to_string()))
+                .build(),
+            _ => cached.clone(),
+        };
+    }
     let mut loader = aws_config::from_env();
     if let Some(r) = region {
         loader = loader.region(aws_config::Region::new(r.to_string()));
@@ -1242,13 +1244,19 @@ pub async fn publish_notification_direct(message: &str, subject: Option<&str>) -
     let config = get_aws_config(None).await;
     let sns_client = aws_sdk_sns::Client::new(&config);
 
-    let mut request = sns_client.publish().topic_arn(topic_arn).message(message);
+    let mut request = sns_client.publish().topic_arn(&topic_arn).message(message);
 
     if let Some(subj) = subject {
         request = request.subject(subj);
     }
 
-    let result = request.send().await?;
+    let result = request.send().await.map_err(|e| {
+        anyhow!(
+            "SNS publish to {} failed: {}",
+            topic_arn,
+            aws_smithy_types::error::display::DisplayErrorContext(&e),
+        )
+    })?;
 
     Ok(json!({
         "message_id": result.message_id().unwrap_or("")

--- a/env_aws_direct/src/lib.rs
+++ b/env_aws_direct/src/lib.rs
@@ -1,11 +1,14 @@
 mod api;
 mod backend;
+mod central_creds;
 pub mod direct_impl;
 mod http_auth;
 mod job_id;
 pub mod local_bootstrap;
 mod provider;
 pub mod utils;
+
+pub use central_creds::init_central_credentials;
 
 pub use api::{
     // Alphabetical order and newlines between each function

--- a/env_aws_direct/src/provider.rs
+++ b/env_aws_direct/src/provider.rs
@@ -531,10 +531,7 @@ impl CloudProvider for AwsCloudProvider {
             .and_then(|v| v.as_str())
             .unwrap_or(&self.region);
 
-        let config = aws_config::from_env()
-            .region(aws_config::Region::new(region.to_string()))
-            .load()
-            .await;
+        let config = crate::direct_impl::get_aws_config(Some(region)).await;
         let client = aws_sdk_s3::Client::new(&config);
 
         let resp = client.get_object().bucket(bucket).key(key).send().await?;

--- a/env_aws_direct/src/utils.rs
+++ b/env_aws_direct/src/utils.rs
@@ -21,12 +21,6 @@ pub const DEFAULT_BUCKET_NAMES: &[(&str, &str)] = &[
 
 #[allow(dead_code)]
 pub async fn get_region() -> String {
-    // // Check if HTTP mode is enabled via config file
-    // if crate::http_client::is_http_mode_enabled() {
-    //     // In HTTP API mode, return dummy region - we don't use AWS SDK
-    //     return "us-east-1".to_string();
-    // }
-
     if let Ok(region_env) = std::env::var("AWS_REGION") {
         return region_env;
     }
@@ -34,45 +28,6 @@ pub async fn get_region() -> String {
     {
         panic!("AWS_REGION environment variable must be set");
     }
-}
-
-/// Get S3 bucket name from environment variable and adjust for target region
-pub fn get_bucket_name_from_env(bucket_type: &str, target_region: &str) -> Option<String> {
-    let env_var = match bucket_type {
-        "modules" => "MODULE_S3_BUCKET",
-        "policies" => "POLICY_S3_BUCKET",
-        "providers" => "PROVIDERS_S3_BUCKET",
-        _ => return None,
-    };
-
-    // Try environment variable, fall back to default bucket name for local mode
-    let base_bucket = std::env::var(env_var).unwrap_or_else(|_| {
-        let default_name = DEFAULT_BUCKET_NAMES
-            .iter()
-            .find(|(env, _)| *env == env_var)
-            .map(|(_, name)| name.to_string())
-            .unwrap_or_else(|| bucket_type.to_string());
-        info!(
-            "Using default bucket name for local development: {}",
-            default_name
-        );
-        default_name
-    });
-
-    let current_region = std::env::var("AWS_REGION").ok();
-
-    let result = match current_region {
-        Some(curr_region) if curr_region != target_region => {
-            base_bucket.replace(&curr_region, target_region)
-        }
-        _ => base_bucket,
-    };
-
-    info!(
-        "Resolved bucket for '{}' in region '{}': {}",
-        bucket_type, target_region, result
-    );
-    Some(result)
 }
 
 /// Get DynamoDB table name from environment variable
@@ -128,7 +83,7 @@ pub fn get_table_name_for_region(table_type: &str, region: Option<&str>) -> Resu
     Ok(table_name)
 }
 
-/// Get S3 bucket name from environment variable (simple lookup, no region adjustment)
+/// Get S3 bucket name from environment variable, falling back to defaults for local dev
 pub fn get_bucket_name(bucket_type: &str) -> Result<String> {
     let env_var = match bucket_type.to_lowercase().as_str() {
         "modules" => "MODULE_S3_BUCKET",
@@ -137,13 +92,29 @@ pub fn get_bucket_name(bucket_type: &str) -> Result<String> {
         "providers" => "PROVIDERS_S3_BUCKET",
         _ => return Err(anyhow!("Unknown bucket type: {}", bucket_type)),
     };
-    std::env::var(env_var).map_err(|_| anyhow!("Environment variable {} not set", env_var))
+
+    match std::env::var(env_var) {
+        Ok(bucket_name) => Ok(bucket_name),
+        Err(_) => {
+            let default_name = DEFAULT_BUCKET_NAMES
+                .iter()
+                .find(|(env, _)| *env == env_var)
+                .map(|(_, name)| *name)
+                .ok_or_else(|| anyhow!("Unknown bucket type: {}", bucket_type))?;
+
+            info!(
+                "Using default bucket name for local development: {}",
+                default_name
+            );
+            Ok(default_name.to_string())
+        }
+    }
 }
 
 /// Get S3 bucket name with region adjustment
 pub fn get_bucket_name_for_region(bucket_type: &str, region: &str) -> Result<String> {
     let bucket_name = get_bucket_name(bucket_type)?;
-    let current_region = std::env::var("REGION").unwrap_or_else(|_| "us-west-2".to_string());
+    let current_region = std::env::var("AWS_REGION").unwrap_or_else(|_| "us-west-2".to_string());
     let updated = bucket_name.replace(&format!("-{}-", current_region), &format!("-{}-", region));
     info!(
         "Bucket name for region '{}': {} -> {}",


### PR DESCRIPTION
* Add central_creds module with init_central_credentials() that assumes INFRAWEAVE_CENTRAL_ROLE_ARN once and caches the resulting SdkConfig. (preparation for worker specific roles in central project)
* Route api.rs, provider.rs, and direct_impl.rs through a shared get_aws_config() so every SDK client picks up the assumed identity when initialized; falls back to aws_config::from_env() otherwise.
* Drop the unused get_bucket_name_from_env in favor of get_bucket_name_for_region, align it on AWS_REGION, and wrap SNS publish errors with DisplayErrorContext for clearer failures.