### PR TITLE
fix: remove unused get_current_identity function

### DIFF
--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -605,11 +605,6 @@ pub async fn initialize_project_id_and_region() -> String {
     crate::logic::PROJECT_ID.get().unwrap().clone()
 }
 
-pub async fn get_current_identity() -> String {
-    let current_identity = env_aws::get_user_id().await.unwrap();
-    current_identity
-}
-
 pub fn get_region_env_var() -> &'static str {
     match provider_name().as_str() {
         "aws" => "AWS_REGION",

--- a/env_common/src/interface/mod.rs
+++ b/env_common/src/interface/mod.rs
@@ -5,7 +5,7 @@ mod mock_cloud_provider;
 mod no_cloud_provider;
 
 pub use cloud_handlers::{
-    get_current_identity, get_region_env_var, initialize_project_id_and_region, GenericCloudHandler,
+    get_region_env_var, initialize_project_id_and_region, GenericCloudHandler,
 };
 pub use deployment_status_handler::DeploymentStatusHandler;
 


### PR DESCRIPTION
This pull request removes the `get_current_identity` function from both the `cloud_handlers` module and its public interface. This streamlines the code by eliminating an unused or unnecessary function.
