### PR TITLE
fix: update deployment payload handling in set_deployment function

### DIFF
--- a/env_common/src/logic/api_deployment.rs
+++ b/env_common/src/logic/api_deployment.rs
@@ -230,7 +230,8 @@ pub async fn set_deployment(
 
     if is_plan && deployment.has_drifted {
         let updated_deployment_payload = get_payload(deployment, false);
-        match handler.run_function(&updated_deployment_payload).await {
+        let event = env_defs::insert_db_event("deployments", &updated_deployment_payload);
+        match handler.run_function(&event).await {
             Ok(_) => Ok(()),
             Err(e) => Err(anyhow::anyhow!("Failed to update deployment: {}", e)),
         }?;


### PR DESCRIPTION
This fixes a bug where the deployment used the incorrect structure of deployment during a plan

Deployment event handling:

* Updated `set_deployment` to wrap the deployment payload in a database event before passing it to `handler.run_function`, ensuring more consistent event processing.