### PR TITLE
chore(internal-api): integrate with build_image.sh

### DIFF
--- a/.github/vars/default.binaries.json
+++ b/.github/vars/default.binaries.json
@@ -17,6 +17,13 @@
         ]
     },
     {
+        "bin": "internal-api-aws-unified",
+        "targets": [
+            "linux-amd64-musl",
+            "linux-arm64-musl"
+        ]
+    },
+    {
         "bin": "operator",
         "targets": [
             "linux-amd64-musl",

--- a/.github/vars/default.docker.json
+++ b/.github/vars/default.docker.json
@@ -16,6 +16,14 @@
         ]
     },
     {
+        "bin": "internal-api-aws-unified",
+        "bake-file": "internal-api/bake.hcl",
+        "platforms": [
+            "linux/amd64",
+            "linux/arm64"
+        ]
+    },
+    {
         "bin": "operator",
         "bake-file": "operator/bake.hcl",
         "platforms": [

--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,3 @@ test: unit-tests integration-tests
 clear-docker:
 	@echo "Clearing Docker images..."
 	@docker stop $$(docker ps -q) && docker rm $$(docker ps -aq) || true
-
-IMAGE_COMPONENTS := cli operator gitops reconciler prometheus_exporter terraform_runner
-
-build-images:
-	cross build --release --locked --target aarch64-unknown-linux-musl $(foreach c,$(IMAGE_COMPONENTS),--bin $(c))
-	mkdir -p binaries
-	for bin in $(IMAGE_COMPONENTS); do \
-		cp target/aarch64-unknown-linux-musl/release/$$bin binaries/$$bin-linux-arm64-musl; \
-	done
-	for c in $(IMAGE_COMPONENTS); do \
-		REGISTRY=local VERSION=dev docker buildx bake -f $$c/bake.hcl; \
-	done

--- a/internal-api/Dockerfile.azure.debian
+++ b/internal-api/Dockerfile.azure.debian
@@ -1,0 +1,51 @@
+FROM mcr.microsoft.com/azure-functions/python:4-python3.11
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY binaries/internal-api-azure-unified-${TARGETOS}-${TARGETARCH}-musl /home/site/wwwroot/internal-api-azure
+
+RUN echo '{ \
+  "version": "2.0", \
+  "extensionBundle": { \
+    "id": "Microsoft.Azure.Functions.ExtensionBundle", \
+    "version": "[4.*, 5.0.0)" \
+  }, \
+  "customHandler": { \
+    "description": { \
+      "defaultExecutablePath": "internal-api-azure", \
+      "workingDirectory": "", \
+      "arguments": [] \
+    }, \
+    "enableForwardingHttpRequest": true \
+  }, \
+  "logging": { \
+    "logLevel": { \
+      "default": "Information" \
+    } \
+  } \
+}' > /home/site/wwwroot/host.json
+
+RUN mkdir -p /home/site/wwwroot/api && \
+    echo '{ \
+  "bindings": [ \
+    { \
+      "authLevel": "function", \
+      "type": "httpTrigger", \
+      "direction": "in", \
+      "name": "req", \
+      "methods": ["get", "post", "put", "delete", "options"], \
+      "route": "{*route}" \
+    }, \
+    { \
+      "type": "http", \
+      "direction": "out", \
+      "name": "res" \
+    } \
+  ] \
+}' > /home/site/wwwroot/api/function.json
+
+RUN chmod +x /home/site/wwwroot/internal-api-azure
+
+ENV CLOUD_PROVIDER=azure
+
+EXPOSE 80

--- a/internal-api/Dockerfile.lambda.debian
+++ b/internal-api/Dockerfile.lambda.debian
@@ -1,0 +1,12 @@
+FROM gcr.io/distroless/cc-debian12
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY binaries/internal-api-aws-unified-${TARGETOS}-${TARGETARCH}-musl /usr/local/bin/bootstrap
+
+ENV AWS_LAMBDA_RUNTIME_API="aws-runtime-interface.emulator"
+ENV CLOUD_PROVIDER=aws_direct
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/bootstrap"]

--- a/internal-api/bake.hcl
+++ b/internal-api/bake.hcl
@@ -1,0 +1,20 @@
+variable "REGISTRY" {}
+variable "VERSION" {}
+
+target "internal-api-aws" {
+  context = "."
+  dockerfile = "internal-api/Dockerfile.lambda.debian"
+  tags = ["${REGISTRY}/internal-api-aws:${VERSION}"]
+  platforms = ["linux/arm64"]
+}
+
+target "internal-api-azure" {
+  context = "."
+  dockerfile = "internal-api/Dockerfile.azure.debian"
+  tags = ["${REGISTRY}/internal-api-azure:${VERSION}"]
+  platforms = ["linux/amd64"]
+}
+
+group "default" {
+  targets = ["internal-api-aws"]
+}


### PR DESCRIPTION
Add bake.hcl with aws/azure targets, lightweight .debian Dockerfiles that copy prebuilt musl binaries, and register internal-api-aws-unified in default.docker.json.

Remove make build-images, since this is more complex for internal-api, and script is better, e.g. ./build_image.sh internal-api-aws-unified linux/arm64