### PR TITLE
feat: add InfraWeave agent tool registry crate

### DIFF
--- a/infraweave-tools/Cargo.toml
+++ b/infraweave-tools/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "infraweave-tools"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+diffy = "0.4"
+log = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+env_defs = { path = "../defs" }
+semver = "1.0"
+zip = "0.6.6"

--- a/infraweave-tools/README.md
+++ b/infraweave-tools/README.md
@@ -1,0 +1,57 @@
+# infraweave-tools
+
+Agent tool registry for InfraWeave.
+
+Each tool is intent-shaped (`debug_deployment`, `diff_module_versions`, ...) instead of a thin wrapper over a REST endpoint, and returns markdown-formatted summaries optimised for LLM consumption rather than raw API JSON.
+
+The same registry is consumed by:
+
+- [`infraweave-chat`](../infraweave-chat) - Bedrock / Anthropic / OpenAI tool use in the website chat backend.
+- [`infraweave-mcp`](../infraweave-mcp) - stdio MCP server for IDE clients.
+
+## Tools
+
+| Name | Purpose |
+|---|---|
+| `list_modules` | Latest version of every published module, optionally filtered by track or name substring. |
+| `describe_module` | Inputs, outputs, required providers for a specific module version. |
+| `diff_module_versions` | Added / removed / changed manifest fields between two versions. |
+| `list_stacks` | Latest version of every published stack. |
+| `describe_stack` | Component modules + inputs/outputs of a stack. |
+| `list_deployments` | Deployments in a project/region; optionally filter by module or failure state. |
+| `debug_deployment` | Status + recent events + error text in one shot. |
+| `list_projects` | Projects visible to the caller. |
+
+Add a new tool by creating it under [`src/tools/`](src/tools), implementing `Tool`, and registering it in [`src/tools/mod.rs`](src/tools/mod.rs).
+
+## Library usage
+
+```rust
+use infraweave_tools::{registry, ApiClient, ToolContext};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Endpoint + bearer token are passed in explicitly - no file-based config.
+    // The `infraweave-chat` backend forwards the user's JWT here so that
+    // existing project-level authorization in `internal-api` still applies.
+    let api = ApiClient::new("http://127.0.0.1:9090", "local")?;
+    let ctx = ToolContext::new(api).with_track("dev");
+
+    let tools = registry();
+    let tool = tools.iter().find(|t| t.def().name == "list_modules").unwrap();
+    let output = tool.execute(&ctx, json!({})).await?;
+    println!("{output}");
+    Ok(())
+}
+```
+
+## Running against a local API
+
+Start the in-tree scaffold (DynamoDB Local + MinIO + LocalStack via Docker, JWT auth disabled) - see [`internal-api/README.md`](../internal-api/README.md):
+
+```bash
+PORT=9090 cargo run -p internal-api --features local --bin internal-api-scaffold
+```
+
+Then point `ApiClient::new` at `http://127.0.0.1:9090` with any token (the scaffold sets `INFRAWEAVE_SKIP_AUTH=true`).

--- a/infraweave-tools/src/client.rs
+++ b/infraweave-tools/src/client.rs
@@ -1,0 +1,102 @@
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+use std::time::Duration;
+
+/// Thin authenticated HTTP client for the InfraWeave internal-api.
+///
+/// Unlike `http_client` in this workspace, the endpoint and bearer token are
+/// passed in explicitly - there is no file-based config lookup. This is what
+/// lets the chat backend run as a service and pass through the caller's JWT,
+/// so existing project-level authorization in internal-api still applies.
+#[derive(Clone)]
+pub struct ApiClient {
+    endpoint: String,
+    token: String,
+    http: reqwest::Client,
+}
+
+impl ApiClient {
+    pub fn new(endpoint: impl Into<String>, token: impl Into<String>) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("failed to build reqwest client")?;
+        Ok(Self {
+            endpoint: endpoint.into().trim_end_matches('/').to_string(),
+            token: token.into(),
+            http,
+        })
+    }
+
+    pub async fn get_json(&self, path: &str) -> Result<Value> {
+        let url = format!("{}{}", self.endpoint, path);
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .with_context(|| format!("GET {url} failed"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("GET {url} -> {status}: {body}"));
+        }
+        resp.json().await.context("invalid JSON response")
+    }
+
+    pub async fn get_bytes(&self, path: &str) -> Result<Vec<u8>> {
+        let url = format!("{}{}", self.endpoint, path);
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/octet-stream")
+            .send()
+            .await
+            .with_context(|| format!("GET {url} failed"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("GET {url} -> {status}: {body}"));
+        }
+        Ok(resp
+            .bytes()
+            .await
+            .context("invalid bytes response")?
+            .to_vec())
+    }
+
+    /// Returns `Ok(None)` for 404 instead of an error - convenient for
+    /// "describe this thing if it exists" tools.
+    pub async fn get_optional(&self, path: &str) -> Result<Option<Value>> {
+        let url = format!("{}{}", self.endpoint, path);
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .with_context(|| format!("GET {url} failed"))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("GET {url} -> {status}: {body}"));
+        }
+        let value: Value = resp.json().await.context("invalid JSON response")?;
+        if value.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+}

--- a/infraweave-tools/src/context.rs
+++ b/infraweave-tools/src/context.rs
@@ -1,0 +1,47 @@
+use crate::ApiClient;
+
+/// Per-request context handed to every tool invocation.
+///
+/// `default_*` fields let the chat layer inject sensible defaults so the LLM
+/// doesn't have to ask "what project?" on every turn - the user's session
+/// already knows. Tools should still accept explicit overrides in their args.
+#[derive(Clone)]
+pub struct ToolContext {
+    pub api: ApiClient,
+    pub default_project: Option<String>,
+    pub default_region: Option<String>,
+    pub default_environment: Option<String>,
+    pub default_track: Option<String>,
+}
+
+impl ToolContext {
+    pub fn new(api: ApiClient) -> Self {
+        Self {
+            api,
+            default_project: None,
+            default_region: None,
+            default_environment: None,
+            default_track: None,
+        }
+    }
+
+    pub fn with_project(mut self, project: impl Into<String>) -> Self {
+        self.default_project = Some(project.into());
+        self
+    }
+
+    pub fn with_region(mut self, region: impl Into<String>) -> Self {
+        self.default_region = Some(region.into());
+        self
+    }
+
+    pub fn with_environment(mut self, environment: impl Into<String>) -> Self {
+        self.default_environment = Some(environment.into());
+        self
+    }
+
+    pub fn with_track(mut self, track: impl Into<String>) -> Self {
+        self.default_track = Some(track.into());
+        self
+    }
+}

--- a/infraweave-tools/src/lib.rs
+++ b/infraweave-tools/src/lib.rs
@@ -1,0 +1,19 @@
+//! Curated, chatbot-friendly tools for InfraWeave.
+//!
+//! Each tool is intent-shaped (e.g. "debug_deployment", "diff_module_versions")
+//! rather than a thin wrapper over a REST endpoint. Tool outputs are concise
+//! markdown strings, optimised for LLM consumption rather than raw API JSON.
+//!
+//! The same registry is consumed by:
+//!   - `infraweave-chat` (Bedrock / Anthropic / OpenAI tool use)
+//!   - `infraweave-mcp` (stdio MCP server for IDE clients)
+
+mod client;
+mod context;
+mod tool;
+mod tools;
+
+pub use client::ApiClient;
+pub use context::ToolContext;
+pub use tool::{Tool, ToolDef};
+pub use tools::registry;

--- a/infraweave-tools/src/tool.rs
+++ b/infraweave-tools/src/tool.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::ToolContext;
+
+/// JSON-schema-shaped tool definition. The schema follows the Anthropic
+/// `input_schema` format (`{"type":"object", "properties":{...}, "required":[...]}`),
+/// which is also what Bedrock Converse and Vertex's Anthropic API accept verbatim.
+/// OpenAI/Gemini callers can map this with a small mechanical adapter.
+#[derive(Debug, Clone)]
+pub struct ToolDef {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: Value,
+}
+
+/// A single curated tool. `execute` returns a markdown string - narrative,
+/// already-summarised output is far more token-efficient than raw API JSON
+/// for an LLM to read back.
+#[async_trait]
+pub trait Tool: Send + Sync {
+    fn def(&self) -> ToolDef;
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String>;
+}

--- a/infraweave-tools/src/tools/archive_diff.rs
+++ b/infraweave-tools/src/tools/archive_diff.rs
@@ -1,0 +1,250 @@
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::fmt::Write;
+use std::io::{Cursor, Read};
+use zip::ZipArchive;
+
+const MAX_RENDERED_FILES: usize = 20;
+const MAX_DIFF_BYTES_PER_FILE: usize = 16 * 1024;
+const MAX_FILE_BYTES: usize = 256 * 1024;
+
+pub fn render_zip_diff(
+    kind: &str,
+    name: &str,
+    track: &str,
+    previous_version: &str,
+    version: &str,
+    old_zip: &[u8],
+    new_zip: &[u8],
+) -> Result<String> {
+    let old_files = extract_zip_text_files(old_zip)
+        .with_context(|| format!("could not read `{name}` {previous_version} zip"))?;
+    let new_files = extract_zip_text_files(new_zip)
+        .with_context(|| format!("could not read `{name}` {version} zip"))?;
+
+    Ok(render_file_diff(
+        kind,
+        name,
+        track,
+        previous_version,
+        version,
+        &old_files,
+        &new_files,
+    ))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ZipFileContent {
+    Text(String),
+    Binary { bytes: usize },
+    TooLarge { bytes: usize },
+}
+
+fn extract_zip_text_files(bytes: &[u8]) -> Result<BTreeMap<String, ZipFileContent>> {
+    let cursor = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(cursor).context("invalid zip archive")?;
+    let mut files = BTreeMap::new();
+
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        if file.is_dir() {
+            continue;
+        }
+
+        let name = file.name().trim_start_matches("./").to_string();
+        if name.is_empty() {
+            continue;
+        }
+
+        let size = file.size() as usize;
+        if size > MAX_FILE_BYTES {
+            files.insert(name, ZipFileContent::TooLarge { bytes: size });
+            continue;
+        }
+
+        let mut content = Vec::with_capacity(size);
+        file.read_to_end(&mut content)?;
+        let content = match String::from_utf8(content) {
+            Ok(text) if is_text_like(&text) => ZipFileContent::Text(text),
+            Ok(text) => ZipFileContent::Binary { bytes: text.len() },
+            Err(e) => ZipFileContent::Binary {
+                bytes: e.into_bytes().len(),
+            },
+        };
+        files.insert(name, content);
+    }
+
+    Ok(files)
+}
+
+fn render_file_diff(
+    kind: &str,
+    name: &str,
+    track: &str,
+    previous_version: &str,
+    version: &str,
+    old_files: &BTreeMap<String, ZipFileContent>,
+    new_files: &BTreeMap<String, ZipFileContent>,
+) -> String {
+    let added: Vec<_> = new_files
+        .keys()
+        .filter(|path| !old_files.contains_key(*path))
+        .cloned()
+        .collect();
+    let removed: Vec<_> = old_files
+        .keys()
+        .filter(|path| !new_files.contains_key(*path))
+        .cloned()
+        .collect();
+    let changed: Vec<_> = old_files
+        .iter()
+        .filter_map(|(path, old)| {
+            new_files
+                .get(path)
+                .filter(|new| *new != old)
+                .map(|new| (path.clone(), old, new))
+        })
+        .collect();
+
+    let mut out =
+        format!("## Diff: {kind} `{name}` {previous_version} -> {version} (track: {track})\n\n");
+    let n_add = added.len();
+    let n_rm = removed.len();
+    let n_ch = changed.len();
+    let _ = writeln!(
+        out,
+        "**Summary:** {n_add} file(s) added, {n_rm} removed, {n_ch} changed.\n"
+    );
+
+    if added.is_empty() && removed.is_empty() && changed.is_empty() {
+        out.push_str("No file content changes found between the downloaded zips.");
+        return out;
+    }
+
+    if !added.is_empty() {
+        out.push_str("### Added files\n");
+        for path in added.iter().take(MAX_RENDERED_FILES) {
+            let content = &new_files[path];
+            let _ = writeln!(out, "#### `{path}` ({})\n", describe_content(content));
+            match content {
+                ZipFileContent::Text(new_text) => {
+                    render_text_diff(&mut out, "/dev/null", &format!("new/{path}"), "", new_text);
+                }
+                _ => {
+                    out.push_str("- content omitted; not a text file that can be diffed inline\n");
+                }
+            }
+            out.push('\n');
+        }
+        write_truncation_note(&mut out, added.len());
+        out.push('\n');
+    }
+
+    if !removed.is_empty() {
+        out.push_str("### Removed files\n");
+        for path in removed.iter().take(MAX_RENDERED_FILES) {
+            let content = &old_files[path];
+            let _ = writeln!(out, "#### `{path}` ({})\n", describe_content(content));
+            match content {
+                ZipFileContent::Text(old_text) => {
+                    render_text_diff(&mut out, &format!("old/{path}"), "/dev/null", old_text, "");
+                }
+                _ => {
+                    out.push_str("- content omitted; not a text file that can be diffed inline\n");
+                }
+            }
+            out.push('\n');
+        }
+        write_truncation_note(&mut out, removed.len());
+        out.push('\n');
+    }
+
+    if !changed.is_empty() {
+        out.push_str("### Changed files\n");
+        for (path, old, new) in changed.iter().take(MAX_RENDERED_FILES) {
+            let _ = writeln!(out, "#### `{path}`\n");
+            match (old, new) {
+                (ZipFileContent::Text(old_text), ZipFileContent::Text(new_text)) => {
+                    render_text_diff(
+                        &mut out,
+                        &format!("old/{path}"),
+                        &format!("new/{path}"),
+                        old_text,
+                        new_text,
+                    );
+                }
+                _ => {
+                    let _ = writeln!(
+                        out,
+                        "- changed from {} to {}",
+                        describe_content(old),
+                        describe_content(new)
+                    );
+                }
+            }
+            out.push('\n');
+        }
+        write_truncation_note(&mut out, changed.len());
+    }
+    out
+}
+
+fn render_text_diff(
+    out: &mut String,
+    old_filename: &str,
+    new_filename: &str,
+    old: &str,
+    new: &str,
+) {
+    let mut options = diffy::DiffOptions::new();
+    options
+        .set_original_filename(old_filename.to_string())
+        .set_modified_filename(new_filename.to_string());
+    let patch = options.create_patch(old, new).to_string();
+    let patch = truncate_diff(&patch);
+    out.push_str("```diff\n");
+    out.push_str(&patch);
+    if !patch.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str("```\n");
+}
+
+fn truncate_diff(diff: &str) -> String {
+    if diff.len() <= MAX_DIFF_BYTES_PER_FILE {
+        return diff.to_string();
+    }
+
+    let mut truncated = String::with_capacity(MAX_DIFF_BYTES_PER_FILE + 32);
+    for line in diff.lines() {
+        if truncated.len() + line.len() + 1 > MAX_DIFF_BYTES_PER_FILE {
+            break;
+        }
+        truncated.push_str(line);
+        truncated.push('\n');
+    }
+    truncated.push_str("... diff truncated ...\n");
+    truncated
+}
+
+fn describe_content(content: &ZipFileContent) -> String {
+    match content {
+        ZipFileContent::Text(text) => format!("text, {} bytes", text.len()),
+        ZipFileContent::Binary { bytes } => format!("binary, {bytes} bytes"),
+        ZipFileContent::TooLarge { bytes } => {
+            format!("too large to diff inline, {bytes} bytes")
+        }
+    }
+}
+
+fn write_truncation_note(out: &mut String, count: usize) {
+    if count > MAX_RENDERED_FILES {
+        let omitted = count - MAX_RENDERED_FILES;
+        let _ = writeln!(out, "- ... {omitted} more file(s) omitted");
+    }
+}
+
+fn is_text_like(text: &str) -> bool {
+    text.chars()
+        .all(|c| c == '\n' || c == '\r' || c == '\t' || !c.is_control())
+}

--- a/infraweave-tools/src/tools/common.rs
+++ b/infraweave-tools/src/tools/common.rs
@@ -1,0 +1,146 @@
+use anyhow::{anyhow, Result};
+use env_defs::ProjectData;
+use semver::Version;
+use serde_json::Value;
+use std::cmp::Ordering;
+
+use crate::ToolContext;
+
+/// Read a string field from the tool args, falling back to a context default.
+pub fn arg_or_default(
+    args: &Value,
+    field: &str,
+    default: Option<&String>,
+    field_pretty: &str,
+) -> Result<String> {
+    if let Some(v) = args
+        .get(field)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return Ok(v.to_string());
+    }
+    if let Some(d) = default {
+        return Ok(d.clone());
+    }
+    Err(anyhow!(
+        "missing required argument `{field}` ({field_pretty}) and no session default is set"
+    ))
+}
+
+pub fn opt_str<'a>(args: &'a Value, field: &str) -> Option<&'a str> {
+    args.get(field)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+}
+
+pub fn project(args: &Value, ctx: &ToolContext) -> Result<String> {
+    arg_or_default(
+        args,
+        "project_id",
+        ctx.default_project.as_ref(),
+        "exact InfraWeave project_id",
+    )
+    .or_else(|_| arg_or_default(args, "project", ctx.default_project.as_ref(), "project id"))
+}
+
+pub fn region(args: &Value, ctx: &ToolContext) -> Result<String> {
+    arg_or_default(
+        args,
+        "region",
+        ctx.default_region.as_ref(),
+        "exact cloud provider region id (for AWS, use values like us-west-2 or eu-central-1)",
+    )
+}
+
+pub async fn validate_project_region(
+    ctx: &ToolContext,
+    project_id: &str,
+    region: &str,
+) -> Result<()> {
+    let projects: Vec<ProjectData> =
+        serde_json::from_value(ctx.api.get_json("/api/v1/projects").await?)?;
+    let Some(project) = projects.iter().find(|p| p.project_id == project_id) else {
+        return Err(anyhow!(
+            "unknown project_id `{project_id}`. Call `list_projects` and use the exact project_id."
+        ));
+    };
+    if project.regions.iter().any(|r| r == region) {
+        return Ok(());
+    }
+    let regions = if project.regions.is_empty() {
+        "no configured regions".to_string()
+    } else {
+        project.regions.join(", ")
+    };
+    Err(anyhow!(
+        "invalid region `{region}` for project_id `{project_id}`. Use one of the exact configured cloud provider region ids: {regions}"
+    ))
+}
+
+pub fn environment(args: &Value, ctx: &ToolContext) -> Result<String> {
+    arg_or_default(
+        args,
+        "environment_id",
+        ctx.default_environment.as_ref(),
+        "exact InfraWeave environment_id",
+    )
+    .or_else(|_| {
+        arg_or_default(
+            args,
+            "environment",
+            ctx.default_environment.as_ref(),
+            "environment id",
+        )
+    })
+}
+
+pub fn track(args: &Value, ctx: &ToolContext) -> Result<String> {
+    arg_or_default(
+        args,
+        "track",
+        ctx.default_track.as_ref(),
+        "release track (e.g. dev, stable)",
+    )
+}
+
+pub fn latest_by_semver<T, F>(items: Vec<T>, version: F) -> Option<T>
+where
+    F: Fn(&T) -> &str,
+{
+    items
+        .into_iter()
+        .max_by(|a, b| compare_versions(version(a), version(b)))
+}
+
+fn compare_versions(a: &str, b: &str) -> Ordering {
+    match (Version::parse(a), Version::parse(b)) {
+        (Ok(a_semver), Ok(b_semver)) => a_semver.cmp(&b_semver).then_with(|| a.cmp(b)),
+        (Ok(_), Err(_)) => Ordering::Greater,
+        (Err(_), Ok(_)) => Ordering::Less,
+        (Err(_), Err(_)) => a.cmp(b),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::latest_by_semver;
+
+    #[test]
+    fn latest_by_semver_handles_multi_digit_components() {
+        let versions = vec!["1.9.0", "1.10.0", "1.2.0"];
+
+        let latest = latest_by_semver(versions, |v| v).unwrap();
+
+        assert_eq!(latest, "1.10.0");
+    }
+
+    #[test]
+    fn latest_by_semver_prefers_valid_semver_over_invalid_versions() {
+        let versions = vec!["banana", "1.0.0"];
+
+        let latest = latest_by_semver(versions, |v| v).unwrap();
+
+        assert_eq!(latest, "1.0.0");
+    }
+}

--- a/infraweave-tools/src/tools/deployments.rs
+++ b/infraweave-tools/src/tools/deployments.rs
@@ -1,0 +1,204 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use env_defs::{DeploymentResp, EventData};
+use serde_json::{json, Value};
+use std::fmt::Write;
+
+use super::common::{environment, opt_str, project, region, validate_project_region};
+use crate::{Tool, ToolContext, ToolDef};
+
+pub struct ListDeployments;
+
+#[async_trait]
+impl Tool for ListDeployments {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "list_deployments",
+            description: "List deployments in a project/region. Optionally filter by module name \
+                or only show deployments in a failure state. Use this when the user asks \
+                'what's deployed in project X' or 'which deployments of module Y exist'.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "project_id": {
+                        "type": "string",
+                        "description": "Exact InfraWeave project_id from list_projects. Do not use the project display name or account alias."
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Exact configured cloud provider region id for the project. For AWS, use values like us-west-2 or eu-central-1; never broad aliases like us, eu, west, or production."
+                    },
+                    "module": { "type": "string", "description": "Optional: only deployments using this module." },
+                    "failures_only": { "type": "boolean", "description": "Optional: only return deployments in a failure state." }
+                }
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let project = project(&args, ctx)?;
+        let region = region(&args, ctx)?;
+        validate_project_region(ctx, &project, &region).await?;
+        let module_filter = opt_str(&args, "module").map(|s| s.to_string());
+        let failures_only = args
+            .get("failures_only")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let path = match module_filter.as_ref() {
+            Some(m) => format!("/api/v1/deployments/module/{project}/{region}/{m}"),
+            None => format!("/api/v1/deployments/{project}/{region}"),
+        };
+        let deployments: Vec<DeploymentResp> =
+            serde_json::from_value(ctx.api.get_json(&path).await?)?;
+
+        let filtered: Vec<&DeploymentResp> = deployments
+            .iter()
+            .filter(|d| !failures_only || d.status.is_failure())
+            .collect();
+
+        if filtered.is_empty() {
+            return Ok(format!(
+                "No deployments matched in `{project}` / `{region}`{}.",
+                if failures_only {
+                    " (failures only)"
+                } else {
+                    ""
+                }
+            ));
+        }
+
+        let mut out = format!(
+            "Found {} deployment(s) in `{project}` / `{region}`:\n\n",
+            filtered.len()
+        );
+        for d in filtered {
+            let _ = writeln!(
+                out,
+                "- `{}` (project_id: `{}`, region: `{}`, environment_id: `{}`) - module `{}` v{} - **{}**{}",
+                d.deployment_id,
+                d.project_id,
+                d.region,
+                d.environment,
+                d.module,
+                d.module_version,
+                d.status,
+                if d.has_drifted {
+                    " - drift detected"
+                } else {
+                    ""
+                }
+            );
+        }
+        Ok(out)
+    }
+}
+
+pub struct DebugDeployment;
+
+#[async_trait]
+impl Tool for DebugDeployment {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "debug_deployment",
+            description: "Get a focused failure-debugging view of a deployment: current status, \
+                the error text, and the most recent events. Use this whenever the user is asking \
+                'why did X fail' or 'what's going on with deployment Y'.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "deployment_id": { "type": "string" },
+                    "environment_id": {
+                        "type": "string",
+                        "description": "Exact InfraWeave environment_id from a previous deployment result. Do not use a display name or conversational alias."
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "description": "Exact InfraWeave project_id from list_projects or a previous deployment result. Do not use the project display name or account alias."
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Exact configured cloud provider region id for the project. For AWS, use values like us-west-2 or eu-central-1; never broad aliases like us, eu, west, or production."
+                    }
+                },
+                "required": ["deployment_id", "environment_id"]
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let deployment_id =
+            opt_str(&args, "deployment_id").context("`deployment_id` is required")?;
+        let environment = environment(&args, ctx)?;
+        let project = project(&args, ctx)?;
+        let region = region(&args, ctx)?;
+        validate_project_region(ctx, &project, &region).await?;
+
+        let dep_path =
+            format!("/api/v1/deployment/{project}/{region}/{environment}/{deployment_id}");
+        let Some(dep_value) = ctx.api.get_optional(&dep_path).await? else {
+            return Ok(format!(
+                "No deployment `{deployment_id}` found in `{project}` / `{region}` / `{environment}`."
+            ));
+        };
+        let dep: DeploymentResp =
+            serde_json::from_value(dep_value).context("could not parse deployment")?;
+
+        let events: Vec<EventData> = ctx
+            .api
+            .get_json(&format!(
+                "/api/v1/events/{project}/{region}/{environment}/{deployment_id}"
+            ))
+            .await
+            .ok()
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default();
+
+        let mut out = format!(
+            "## Deployment `{}` ({} / {} / {})\n\n",
+            dep.deployment_id, dep.project_id, dep.region, dep.environment
+        );
+        let _ = writeln!(out, "- **Status:** {}", dep.status);
+        let _ = writeln!(
+            out,
+            "- **Module:** `{}` v{} (track: {})",
+            dep.module, dep.module_version, dep.module_track
+        );
+        let _ = writeln!(out, "- **Initiated by:** {}", dep.initiated_by);
+        if dep.has_drifted {
+            let _ = writeln!(out, "- **Drift detected**");
+        }
+        if !dep.error_text.is_empty() {
+            let _ = writeln!(out, "\n### Error\n```\n{}\n```", dep.error_text);
+        }
+
+        if !events.is_empty() {
+            // Show the most recent ~6 events.
+            let mut recent: Vec<&EventData> = events.iter().collect();
+            recent.sort_by(|a, b| b.epoch.cmp(&a.epoch));
+            recent.truncate(6);
+            out.push_str("\n### Recent events\n");
+            for e in recent {
+                let _ = write!(out, "- `{}` - **{}**", e.timestamp, e.status);
+                if !e.event.is_empty() {
+                    let _ = write!(out, " ({})", e.event);
+                }
+                if !e.error_text.is_empty() {
+                    let snippet: String = e.error_text.chars().take(200).collect();
+                    let _ = write!(out, " - {snippet}");
+                }
+                out.push('\n');
+            }
+            out.push_str("\nTo dig deeper, you can request logs for the failing job_id from the most recent event.\n");
+        }
+
+        if !dep.policy_results.is_empty() {
+            out.push_str("\n### Policy results\n");
+            for p in &dep.policy_results {
+                let _ = writeln!(out, "- {p:?}");
+            }
+        }
+
+        Ok(out)
+    }
+}

--- a/infraweave-tools/src/tools/mod.rs
+++ b/infraweave-tools/src/tools/mod.rs
@@ -1,0 +1,24 @@
+use crate::Tool;
+
+mod archive_diff;
+mod common;
+mod deployments;
+mod modules;
+mod projects;
+mod stacks;
+
+/// The full curated tool registry used by both the chat backend and the MCP
+/// server. Add new tools here as they're implemented.
+pub fn registry() -> Vec<Box<dyn Tool>> {
+    vec![
+        Box::new(modules::ListModules),
+        Box::new(modules::DescribeModule),
+        Box::new(modules::DiffModuleVersions),
+        Box::new(stacks::ListStacks),
+        Box::new(stacks::DescribeStack),
+        Box::new(stacks::DiffStackVersions),
+        Box::new(deployments::ListDeployments),
+        Box::new(deployments::DebugDeployment),
+        Box::new(projects::ListProjects),
+    ]
+}

--- a/infraweave-tools/src/tools/modules.rs
+++ b/infraweave-tools/src/tools/modules.rs
@@ -1,0 +1,266 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use env_defs::ModuleResp;
+use serde_json::{json, Value};
+use std::fmt::Write;
+
+use super::archive_diff;
+use super::common::{latest_by_semver, opt_str, track};
+use crate::{Tool, ToolContext, ToolDef};
+
+pub struct ListModules;
+
+#[async_trait]
+impl Tool for ListModules {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "list_modules",
+            description: "List the latest version of every published InfraWeave module. \
+                Optionally filter by track (e.g. 'dev', 'stable') or substring search on the module name. \
+                Returns name, latest version, and short description for each.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "track": { "type": "string", "description": "Optional release track to filter by (e.g. 'dev', 'stable')." },
+                    "search": { "type": "string", "description": "Optional case-insensitive substring to filter module names by." }
+                }
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let modules: Vec<ModuleResp> =
+            serde_json::from_value(ctx.api.get_json("/api/v1/modules").await?)
+                .context("could not parse modules list")?;
+
+        let track_filter = opt_str(&args, "track").map(|s| s.to_string());
+        let search = opt_str(&args, "search").map(|s| s.to_lowercase());
+
+        let mut filtered: Vec<&ModuleResp> = modules
+            .iter()
+            .filter(|m| {
+                track_filter
+                    .as_deref()
+                    .map(|t| m.track == t)
+                    .unwrap_or(true)
+            })
+            .filter(|m| {
+                search
+                    .as_deref()
+                    .map(|q| {
+                        m.module.to_lowercase().contains(q)
+                            || m.module_name.to_lowercase().contains(q)
+                    })
+                    .unwrap_or(true)
+            })
+            .collect();
+        filtered.sort_by(|a, b| a.module.cmp(&b.module));
+
+        if filtered.is_empty() {
+            return Ok("No modules matched.".into());
+        }
+
+        let mut out = format!("Found {} module(s):\n\n", filtered.len());
+        for m in filtered {
+            let desc = if m.description.is_empty() {
+                "(no description)"
+            } else {
+                m.description.as_str()
+            };
+            let _ = writeln!(
+                out,
+                "- **{}** `{}` (track: {}, version: {}) - {}",
+                m.module_name, m.module, m.track, m.version, desc
+            );
+        }
+        Ok(out)
+    }
+}
+
+pub struct DescribeModule;
+
+#[async_trait]
+impl Tool for DescribeModule {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "describe_module",
+            description: "Describe a specific module version: required and optional inputs, outputs, \
+                and required Terraform providers. Use this when the user asks 'what does module X take' \
+                or 'what does it output'. If `version` is omitted, the latest version on the track is used.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "module": { "type": "string", "description": "Module name (required)." },
+                    "track": { "type": "string", "description": "Release track. Falls back to session default." },
+                    "version": { "type": "string", "description": "Optional specific version; omit for latest." }
+                },
+                "required": ["module"]
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let module = opt_str(&args, "module")
+            .context("`module` is required")?
+            .to_string();
+        let track = track(&args, ctx)?;
+
+        let module_resp: ModuleResp = if let Some(v) = opt_str(&args, "version") {
+            serde_json::from_value(
+                ctx.api
+                    .get_json(&format!("/api/v1/module/{track}/{module}/{v}"))
+                    .await?,
+            )?
+        } else {
+            let versions: Vec<ModuleResp> = serde_json::from_value(
+                ctx.api
+                    .get_json(&format!("/api/v1/modules/versions/{track}/{module}"))
+                    .await?,
+            )?;
+            latest_by_semver(versions, |m| &m.version)
+                .context("module has no published versions")?
+        };
+
+        Ok(render_module(&module_resp))
+    }
+}
+
+pub struct DiffModuleVersions;
+
+#[async_trait]
+impl Tool for DiffModuleVersions {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "diff_module_versions",
+            description:
+                "Show what changed between two versions of a module: added/removed/changed \
+                files by downloading both module zips and diffing their contents. Returns \
+                unified diffs that should be interpreted into a semantic summary of \
+                infrastructure/code changes, not just repeated as file metadata. Use this \
+                when the user asks 'what's different in v1.3 vs v1.2' or 'what would I \
+                have to change to upgrade'.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "module": { "type": "string" },
+                    "track": { "type": "string" },
+                    "version": { "type": "string", "description": "The newer version." },
+                    "previous_version": { "type": "string", "description": "The older version to compare against." }
+                },
+                "required": ["module", "previous_version", "version"]
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let module = opt_str(&args, "module").context("`module` is required")?;
+        let previous_version =
+            opt_str(&args, "previous_version").context("`previous_version` is required")?;
+        let version = opt_str(&args, "version").context("`version` is required")?;
+        let track = track(&args, ctx)?;
+
+        let old_zip = download_module_zip(ctx, &track, module, previous_version).await?;
+        let new_zip = download_module_zip(ctx, &track, module, version).await?;
+
+        archive_diff::render_zip_diff(
+            "module",
+            module,
+            &track,
+            previous_version,
+            version,
+            &old_zip,
+            &new_zip,
+        )
+    }
+}
+
+fn render_module(m: &ModuleResp) -> String {
+    let mut out = format!(
+        "## {} `{}` v{} (track: {})\n\n{}\n\n",
+        m.module_name,
+        m.module,
+        m.version,
+        m.track,
+        if m.description.is_empty() {
+            "(no description)"
+        } else {
+            m.description.as_str()
+        }
+    );
+
+    let (required, optional): (Vec<_>, Vec<_>) = m.tf_variables.iter().partition(|v| v.required());
+    if !required.is_empty() {
+        out.push_str("### Required inputs\n");
+        for v in &required {
+            let _ = writeln!(
+                out,
+                "- `{}` ({}) - {}",
+                v.name,
+                v._type,
+                default_or_dash(&v.description)
+            );
+        }
+        out.push('\n');
+    }
+    if !optional.is_empty() {
+        out.push_str("### Optional inputs\n");
+        for v in &optional {
+            let default = v
+                .default
+                .as_ref()
+                .map(|d| serde_json::to_string(d).unwrap_or_default())
+                .unwrap_or_else(|| "-".into());
+            let _ = writeln!(
+                out,
+                "- `{}` ({}, default: `{}`) - {}",
+                v.name,
+                v._type,
+                default,
+                default_or_dash(&v.description)
+            );
+        }
+        out.push('\n');
+    }
+
+    if !m.tf_outputs.is_empty() {
+        out.push_str("### Outputs\n");
+        for o in &m.tf_outputs {
+            let _ = writeln!(out, "- `{}` - {}", o.name, default_or_dash(&o.description));
+        }
+        out.push('\n');
+    }
+
+    if !m.tf_required_providers.is_empty() {
+        out.push_str("### Required providers\n");
+        for p in &m.tf_required_providers {
+            let _ = writeln!(
+                out,
+                "- `{}` (`{}`) version `{}`",
+                p.name, p.source, p.version
+            );
+        }
+    }
+    out
+}
+
+async fn download_module_zip(
+    ctx: &ToolContext,
+    track: &str,
+    module: &str,
+    version: &str,
+) -> Result<Vec<u8>> {
+    ctx.api
+        .get_bytes(&format!(
+            "/api/v1/module/{track}/{module}/{version}/download"
+        ))
+        .await
+        .with_context(|| format!("could not download `{module}` {version} on track `{track}`"))
+}
+
+fn default_or_dash(s: &str) -> &str {
+    if s.trim().is_empty() {
+        "-"
+    } else {
+        s
+    }
+}

--- a/infraweave-tools/src/tools/projects.rs
+++ b/infraweave-tools/src/tools/projects.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use env_defs::ProjectData;
+use serde_json::{json, Value};
+use std::fmt::Write;
+
+use crate::{Tool, ToolContext, ToolDef};
+
+pub struct ListProjects;
+
+#[async_trait]
+impl Tool for ListProjects {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "list_projects",
+            description: "List all InfraWeave projects the caller has access to. \
+                Use this when the user asks 'what projects do I have' or needs to disambiguate \
+                a project before another tool can run.",
+            input_schema: json!({ "type": "object", "properties": {} }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, _args: Value) -> Result<String> {
+        let projects: Vec<ProjectData> =
+            serde_json::from_value(ctx.api.get_json("/api/v1/projects").await?)?;
+        if projects.is_empty() {
+            return Ok("No projects visible.".into());
+        }
+        let mut out = format!("Found {} project(s):\n\n", projects.len());
+        for p in &projects {
+            let regions = if p.regions.is_empty() {
+                "-".to_string()
+            } else {
+                p.regions.join(", ")
+            };
+            let desc = if p.description.is_empty() {
+                "(no description)"
+            } else {
+                p.description.as_str()
+            };
+            let _ = writeln!(
+                out,
+                "- **{}** `{}` (regions: {}) - {}",
+                p.name, p.project_id, regions, desc
+            );
+        }
+        Ok(out)
+    }
+}

--- a/infraweave-tools/src/tools/stacks.rs
+++ b/infraweave-tools/src/tools/stacks.rs
@@ -1,0 +1,243 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use env_defs::ModuleResp;
+use serde_json::{json, Value};
+use std::fmt::Write;
+
+use super::archive_diff;
+use super::common::{latest_by_semver, opt_str, track};
+use crate::{Tool, ToolContext, ToolDef};
+
+pub struct ListStacks;
+
+#[async_trait]
+impl Tool for ListStacks {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "list_stacks",
+            description: "List the latest version of every published InfraWeave stack. \
+                Stacks are bundles of modules wired together. Optionally filter by track or name substring.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "track": { "type": "string" },
+                    "search": { "type": "string" }
+                }
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let stacks: Vec<ModuleResp> =
+            serde_json::from_value(ctx.api.get_json("/api/v1/stacks").await?)?;
+        let track_filter = opt_str(&args, "track").map(|s| s.to_string());
+        let search = opt_str(&args, "search").map(|s| s.to_lowercase());
+        let mut filtered: Vec<&ModuleResp> = stacks
+            .iter()
+            .filter(|m| {
+                track_filter
+                    .as_deref()
+                    .map(|t| m.track == t)
+                    .unwrap_or(true)
+            })
+            .filter(|m| {
+                search
+                    .as_deref()
+                    .map(|q| {
+                        m.module.to_lowercase().contains(q)
+                            || m.module_name.to_lowercase().contains(q)
+                    })
+                    .unwrap_or(true)
+            })
+            .collect();
+        filtered.sort_by(|a, b| a.module.cmp(&b.module));
+
+        if filtered.is_empty() {
+            return Ok("No stacks matched.".into());
+        }
+        let mut out = format!("Found {} stack(s):\n\n", filtered.len());
+        for s in filtered {
+            let component_count = s.stack_data.as_ref().map(|d| d.modules.len()).unwrap_or(0);
+            let desc = if s.description.is_empty() {
+                "(no description)"
+            } else {
+                s.description.as_str()
+            };
+            let _ = writeln!(
+                out,
+                "- **{}** `{}` (track: {}, version: {}, {} module(s)) - {}",
+                s.module_name, s.module, s.track, s.version, component_count, desc
+            );
+        }
+        Ok(out)
+    }
+}
+
+pub struct DescribeStack;
+
+#[async_trait]
+impl Tool for DescribeStack {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "describe_stack",
+            description:
+                "Describe a stack: which modules it contains (with versions), inputs and outputs. \
+                Use when the user asks 'what's in stack X' or 'what does stack X expose'.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "stack": { "type": "string" },
+                    "track": { "type": "string" },
+                    "version": { "type": "string", "description": "Omit for latest." }
+                },
+                "required": ["stack"]
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let stack = opt_str(&args, "stack").context("`stack` is required")?;
+        let track = track(&args, ctx)?;
+
+        let resp: ModuleResp = if let Some(v) = opt_str(&args, "version") {
+            serde_json::from_value(
+                ctx.api
+                    .get_json(&format!("/api/v1/stack/{track}/{stack}/{v}"))
+                    .await?,
+            )?
+        } else {
+            let versions: Vec<ModuleResp> = serde_json::from_value(
+                ctx.api
+                    .get_json(&format!("/api/v1/stacks/versions/{track}/{stack}"))
+                    .await?,
+            )?;
+            latest_by_semver(versions, |s| &s.version).context("stack has no published versions")?
+        };
+
+        let mut out = format!(
+            "## Stack {} `{}` v{} (track: {})\n\n{}\n\n",
+            resp.module_name,
+            resp.module,
+            resp.version,
+            resp.track,
+            if resp.description.is_empty() {
+                "(no description)"
+            } else {
+                resp.description.as_str()
+            }
+        );
+
+        if let Some(stack_data) = resp.stack_data.as_ref() {
+            out.push_str("### Contained modules\n");
+            for m in &stack_data.modules {
+                let _ = writeln!(out, "- `{}` v{} (track: {})", m.module, m.version, m.track);
+            }
+            out.push('\n');
+        }
+
+        if !resp.tf_variables.is_empty() {
+            let (required, optional): (Vec<_>, Vec<_>) =
+                resp.tf_variables.iter().partition(|v| v.required());
+            let _ = writeln!(
+                out,
+                "### Inputs\n{} required, {} optional\n",
+                required.len(),
+                optional.len()
+            );
+            for v in required.iter().chain(optional.iter()) {
+                let req = if v.required() { "required" } else { "optional" };
+                let _ = writeln!(
+                    out,
+                    "- `{}` ({}, {}) - {}",
+                    v.name,
+                    v._type,
+                    req,
+                    if v.description.is_empty() {
+                        "-"
+                    } else {
+                        &v.description
+                    }
+                );
+            }
+            out.push('\n');
+        }
+
+        if !resp.tf_outputs.is_empty() {
+            out.push_str("### Outputs\n");
+            for o in &resp.tf_outputs {
+                let _ = writeln!(
+                    out,
+                    "- `{}` - {}",
+                    o.name,
+                    if o.description.is_empty() {
+                        "-"
+                    } else {
+                        &o.description
+                    }
+                );
+            }
+        }
+        Ok(out)
+    }
+}
+
+pub struct DiffStackVersions;
+
+#[async_trait]
+impl Tool for DiffStackVersions {
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "diff_stack_versions",
+            description:
+                "Show what changed between two versions of a stack: added/removed/changed \
+                files by downloading both stack zips and diffing their contents. Returns \
+                unified diffs that should be interpreted into a semantic summary of \
+                infrastructure/code changes, not just repeated as file metadata. Use this \
+                when the user asks what's different between stack versions or what would \
+                change during a stack upgrade.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "stack": { "type": "string" },
+                    "track": { "type": "string" },
+                    "previous_version": { "type": "string", "description": "The older version to compare against." },
+                    "version": { "type": "string", "description": "The newer version." }
+                },
+                "required": ["stack", "previous_version", "version"]
+            }),
+        }
+    }
+
+    async fn execute(&self, ctx: &ToolContext, args: Value) -> Result<String> {
+        let stack = opt_str(&args, "stack").context("`stack` is required")?;
+        let previous_version =
+            opt_str(&args, "previous_version").context("`previous_version` is required")?;
+        let version = opt_str(&args, "version").context("`version` is required")?;
+        let track = track(&args, ctx)?;
+
+        let old_zip = download_stack_zip(ctx, &track, stack, previous_version).await?;
+        let new_zip = download_stack_zip(ctx, &track, stack, version).await?;
+
+        archive_diff::render_zip_diff(
+            "stack",
+            stack,
+            &track,
+            previous_version,
+            version,
+            &old_zip,
+            &new_zip,
+        )
+    }
+}
+
+async fn download_stack_zip(
+    ctx: &ToolContext,
+    track: &str,
+    stack: &str,
+    version: &str,
+) -> Result<Vec<u8>> {
+    ctx.api
+        .get_bytes(&format!("/api/v1/stack/{track}/{stack}/{version}/download"))
+        .await
+        .with_context(|| format!("could not download stack `{stack}` {version} on track `{track}`"))
+}


### PR DESCRIPTION
Add a shared infraweave-tools crate with curated tools for projects, modules, stacks, deployments, and archive diffs. The registry is intended for chat and MCP integrations and returns markdown-oriented tool output.