### PR TITLE
feat: add infraweave-chat crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.130.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2f7bca252e3c5c8f0ed12c5501bf8b0fbadb937cd9fdd71a0ebd9d7526540f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body-util",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-cloudwatchlogs"
 version = "1.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +2691,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "diffy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
+dependencies = [
+ "nu-ansi-term",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,6 +4662,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
+name = "infraweave-chat"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-bedrockruntime",
+ "aws-smithy-types",
+ "axum 0.7.9",
+ "futures",
+ "infraweave-tools",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "infraweave-mcp"
 version = "0.1.0"
 dependencies = [
@@ -4638,6 +4694,22 @@ dependencies = [
  "url",
  "utoipa",
  "webserver-openapi",
+]
+
+[[package]]
+name = "infraweave-tools"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "diffy",
+ "env_defs",
+ "log",
+ "reqwest 0.12.24",
+ "semver",
+ "serde",
+ "serde_json",
+ "zip 0.6.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "http_client",
     "gitops",
     "infraweave_py",
+    "infraweave-chat",
     "infraweave-mcp",
     "internal-api",
     "operator",

--- a/infraweave-chat/Cargo.toml
+++ b/infraweave-chat/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "infraweave-chat"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[features]
+default = ["bedrock"]
+bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types"]
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+axum = { version = "0.7", features = ["json"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+futures = "0.3"
+infraweave-tools = { path = "../infraweave-tools" }
+
+# Bedrock backend (default)
+aws-config = { workspace = true, optional = true }
+aws-sdk-bedrockruntime = { version = "1.95", default-features = false, features = ["rt-tokio", "default-https-client"], optional = true }
+aws-smithy-types = { version = "1", optional = true }
+
+[[bin]]
+name = "infraweave-chat"
+path = "src/main.rs"

--- a/infraweave-chat/Dockerfile.lambda
+++ b/infraweave-chat/Dockerfile.lambda
@@ -1,0 +1,48 @@
+ARG LAMBDA_WEB_ADAPTER_VERSION=1.0.0
+
+FROM rust:slim-bullseye AS chef
+RUN apt-get update && apt-get install -y pkg-config libssl-dev git && rm -rf /var/lib/apt/lists/* && \
+    cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+RUN apt-get update && apt-get install -y wget unzip make && rm -rf /var/lib/apt/lists/*
+
+# Build dependencies - this layer is cached unless Cargo.toml/Cargo.lock changes
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --package infraweave-chat --recipe-path recipe.json
+
+# Build application - only this runs when source code changes
+COPY . /app/
+RUN cargo build --release -p infraweave-chat
+
+# Create empty directory to copy to final image
+RUN mkdir /app/app
+
+FROM public.ecr.aws/awsguru/aws-lambda-adapter:${LAMBDA_WEB_ADAPTER_VERSION} AS lambda-adapter
+
+FROM gcr.io/distroless/cc-debian12
+
+# Copy empty directory since mkdir doesn't work in distroless
+COPY --from=builder /app/app /app
+
+WORKDIR /app
+
+COPY --from=lambda-adapter /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=builder /app/target/release/infraweave-chat /usr/local/bin/infraweave-chat
+
+# Lambda Web Adapter forwards Lambda invocations to this local HTTP server.
+ENV PORT=8090
+ENV AWS_LWA_PORT=8090
+ENV AWS_LWA_INVOKE_MODE=buffered
+ENV AWS_LWA_ASYNC_INIT=false
+ENV AWS_LWA_READINESS_CHECK_PROTOCOL=tcp
+ENV AWS_LWA_PASS_THROUGH_PATH=/events
+
+EXPOSE 8090
+
+CMD ["infraweave-chat"]

--- a/infraweave-chat/README.md
+++ b/infraweave-chat/README.md
@@ -1,0 +1,131 @@
+# infraweave-chat
+
+HTTP chat backend for an InfraWeave website chatbot.
+
+```
+browser -> POST /chat (SSE) -> infraweave-chat
+                                |
+                                +-> Bedrock Converse
+                                |
+                                +-> infraweave-tools -> internal-api
+```
+
+The same tool registry powers [`infraweave-mcp`](../infraweave-mcp) for IDE clients.
+
+## Endpoint
+
+`POST /chat` - Server-Sent Events.
+
+Request body:
+
+```json
+{
+  "message": "describe the s3bucket-simple module on the dev track",
+  "history": [],
+  "project": "...",
+  "region": "...",
+  "environment": "...",
+  "track": "dev"
+}
+```
+
+Headers: `Authorization: Bearer <user-jwt>`. The token is forwarded to `internal-api`, where project authorization is enforced.
+
+SSE event payloads (one JSON object per `data:` line):
+
+| `type` | Fields | When |
+|---|---|---|
+| `tool_call` | `name`, `input` | LLM decided to call a tool (before execution). |
+| `tool_result` | `name`, `output_preview`, `is_error` | Tool finished. Full output is fed back to the LLM. |
+| `text` | `text` | Assistant text chunk. |
+| `truncated` | `reason` | Iteration cap hit. |
+| `error` | `message` | Fatal error. |
+| `done` | - | Stream closed. |
+
+## Local run
+
+### 1. Local InfraWeave API
+
+See [`internal-api/README.md`](../internal-api/README.md). With Docker running:
+
+```bash
+PORT=9090 cargo run -p internal-api --features local --bin internal-api-scaffold
+```
+
+Auth is skipped, so any bearer token works. The scaffold seeds a sample provider and `s3bucket-simple` module.
+
+### 2. Bedrock prerequisites
+
+- AWS credentials available to the SDK (`aws sso login` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`).
+- Enable model access in the Bedrock console. Without this, the first call returns `AccessDeniedException`.
+- Pick a model ID you actually have access to in your region. Confirm with:
+  ```bash
+  aws bedrock list-foundation-models --region us-west-2 \
+    --query 'modelSummaries[?contains(modelId, `anthropic`)].modelId' --output text
+  ```
+
+### 3. Start the chat backend
+
+```bash
+INFRAWEAVE_API_ENDPOINT=http://127.0.0.1:9090 \
+BEDROCK_MODEL_ID=us.amazon.nova-pro-v1:0 \
+AWS_REGION=us-west-2 \
+RUST_LOG=infraweave_chat=info \
+cargo run -p infraweave-chat
+```
+
+### 4. Hit it
+
+```bash
+curl -N -H "Authorization: Bearer local" \
+     -H "Content-Type: application/json" \
+     http://localhost:8090/chat \
+     -d '{"message":"what modules are published?"}'
+```
+
+`-N` disables curl buffering so SSE frames stream as they arrive. Expected: one or more `tool_call` / `tool_result` events, then `text`, then `done`.
+
+A second test that exercises a tool requiring a session default:
+
+```bash
+curl -N -H "Authorization: Bearer local" \
+     -H "Content-Type: application/json" \
+     http://localhost:8090/chat \
+     -d '{
+       "message": "describe the s3bucketsimple module",
+       "track": "stable"
+     }'
+```
+
+## Lambda image
+
+`infraweave-chat/Dockerfile.lambda` builds a Lambda container image for the chat backend.
+
+Build from the workspace root:
+
+```bash
+docker build -f infraweave-chat/Dockerfile.lambda -t infraweave-chat-lambda .
+```
+
+Runtime environment:
+
+| Var | Notes |
+|---|---|
+| `INFRAWEAVE_API_ENDPOINT` | Required. URL of `internal-api` / API Gateway. |
+| `BEDROCK_MODEL_ID` | Optional. Override to a model the chat Lambda role can invoke. |
+| `AWS_REGION` | Region for Bedrock calls. |
+| `RUST_LOG` | e.g. `infraweave_chat=info`. |
+
+The Lambda needs Bedrock invoke permissions and network access to `internal-api`. The caller's bearer token is still passed through to `internal-api`; chat does not need direct InfraWeave data-plane permissions.
+
+The image defaults the Lambda Web Adapter to `AWS_LWA_INVOKE_MODE=buffered`, which works with API Gateway HTTP APIs. For Lambda response streaming, override this to `response_stream` and configure the gateway or Function URL accordingly.
+
+## Environment variables
+
+| Var | Default | Notes |
+|---|---|---|
+| `INFRAWEAVE_API_ENDPOINT` | *(required)* | URL of `internal-api` (local scaffold or API Gateway). |
+| `BEDROCK_MODEL_ID` | `us.amazon.nova-pro-v1:0` | Override to a model you have access to in your region. |
+| `AWS_REGION` | *(SDK default)* | Region for Bedrock calls. |
+| `PORT` | `8090` | HTTP port for `/chat`. |
+| `RUST_LOG` | - | e.g. `infraweave_chat=debug`. |

--- a/infraweave-chat/src/agent.rs
+++ b/infraweave-chat/src/agent.rs
@@ -1,0 +1,168 @@
+//! Tool-use loop.
+
+use anyhow::Result;
+use infraweave_tools::{Tool, ToolContext};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+
+use crate::llm::{LlmClient, LlmContent, LlmMessage, Role, StopReason, ToolDef};
+
+const MAX_TOOL_ITERATIONS: usize = 10;
+
+/// Events surfaced to the chat handler. The handler maps these onto SSE frames.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentEvent {
+    /// LLM has decided to call a tool. Emitted *before* execution so the UI
+    /// can show "Looking up modules..." etc.
+    ToolCall {
+        name: String,
+        input: Value,
+    },
+    /// Tool finished. `output_preview` is truncated; full output is fed back
+    /// to the LLM but not necessarily forwarded to the browser.
+    ToolResult {
+        name: String,
+        output_preview: String,
+        is_error: bool,
+    },
+    /// Final assistant text.
+    Text {
+        text: String,
+    },
+    /// Iteration cap hit - bail out cleanly.
+    Truncated {
+        reason: String,
+    },
+    Done,
+    Error {
+        message: String,
+    },
+}
+
+pub struct AgentRequest {
+    pub system: String,
+    pub history: Vec<LlmMessage>,
+    pub user_message: String,
+}
+
+pub async fn run(
+    llm: &dyn LlmClient,
+    tool_ctx: ToolContext,
+    tools: &[Box<dyn Tool>],
+    req: AgentRequest,
+    tx: mpsc::Sender<AgentEvent>,
+) {
+    if let Err(e) = run_inner(llm, tool_ctx, tools, req, &tx).await {
+        // `{:#}` walks the anyhow context chain so the SSE consumer sees the
+        // root cause (e.g. Bedrock SDK error) instead of just the wrapper.
+        let _ = tx
+            .send(AgentEvent::Error {
+                message: format!("{e:#}"),
+            })
+            .await;
+    }
+    let _ = tx.send(AgentEvent::Done).await;
+}
+
+async fn run_inner(
+    llm: &dyn LlmClient,
+    tool_ctx: ToolContext,
+    tools: &[Box<dyn Tool>],
+    req: AgentRequest,
+    tx: &mpsc::Sender<AgentEvent>,
+) -> Result<()> {
+    let tool_defs: Vec<ToolDef> = tools
+        .iter()
+        .map(|t| {
+            let d = t.def();
+            ToolDef {
+                name: d.name.to_string(),
+                description: d.description.to_string(),
+                input_schema: d.input_schema,
+            }
+        })
+        .collect();
+    let by_name: HashMap<String, &Box<dyn Tool>> = tools
+        .iter()
+        .map(|t| (t.def().name.to_string(), t))
+        .collect();
+
+    let mut messages = req.history;
+    messages.push(LlmMessage::user_text(req.user_message));
+
+    for iter in 0..MAX_TOOL_ITERATIONS {
+        let resp = llm.converse(&req.system, &messages, &tool_defs).await?;
+
+        for block in &resp.content {
+            if let LlmContent::Text { text } = block {
+                if !text.is_empty() {
+                    let _ = tx.send(AgentEvent::Text { text: text.clone() }).await;
+                }
+            }
+        }
+
+        // Record the assistant turn before we attach tool results.
+        messages.push(LlmMessage {
+            role: Role::Assistant,
+            content: resp.content.clone(),
+        });
+
+        if resp.stop_reason != StopReason::ToolUse {
+            return Ok(());
+        }
+
+        let mut tool_result_blocks = Vec::new();
+        for block in &resp.content {
+            let LlmContent::ToolUse { id, name, input } = block else {
+                continue;
+            };
+            let _ = tx
+                .send(AgentEvent::ToolCall {
+                    name: name.clone(),
+                    input: input.clone(),
+                })
+                .await;
+
+            let (output, is_error) = match by_name.get(name) {
+                Some(tool) => match tool.execute(&tool_ctx, input.clone()).await {
+                    Ok(s) => (s, false),
+                    Err(e) => (format!("tool execution failed: {e}"), true),
+                },
+                None => (format!("unknown tool: `{name}`"), true),
+            };
+
+            let preview: String = output.chars().take(400).collect();
+            let _ = tx
+                .send(AgentEvent::ToolResult {
+                    name: name.clone(),
+                    output_preview: preview,
+                    is_error,
+                })
+                .await;
+
+            tool_result_blocks.push(LlmContent::ToolResult {
+                tool_use_id: id.clone(),
+                content: output,
+                is_error,
+            });
+        }
+
+        // Tool results are sent back as a single user-role message.
+        messages.push(LlmMessage {
+            role: Role::User,
+            content: tool_result_blocks,
+        });
+
+        if iter == MAX_TOOL_ITERATIONS - 1 {
+            let _ = tx
+                .send(AgentEvent::Truncated {
+                    reason: format!("hit MAX_TOOL_ITERATIONS={MAX_TOOL_ITERATIONS}"),
+                })
+                .await;
+        }
+    }
+    Ok(())
+}

--- a/infraweave-chat/src/handler.rs
+++ b/infraweave-chat/src/handler.rs
@@ -1,0 +1,143 @@
+//! POST /chat - SSE-streaming chat endpoint.
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, Method, StatusCode, Uri},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse,
+    },
+    Json,
+};
+use futures::stream::Stream;
+use infraweave_tools::{ApiClient, Tool, ToolContext};
+use serde::Deserialize;
+use std::{convert::Infallible, sync::Arc};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::{
+    agent::{self, AgentEvent, AgentRequest},
+    llm::{LlmClient, LlmMessage},
+    system_prompt::SYSTEM_PROMPT,
+};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub llm: Arc<dyn LlmClient>,
+    pub tools: Arc<Vec<Box<dyn Tool>>>,
+    pub api_endpoint: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChatRequest {
+    pub message: String,
+    #[serde(default)]
+    pub history: Vec<LlmMessage>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub region: Option<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+    #[serde(default)]
+    pub track: Option<String>,
+}
+
+pub async fn chat(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<ChatRequest>,
+) -> impl IntoResponse {
+    info!("received chat request");
+
+    // Extract the user's bearer token from the incoming Authorization header
+    // and pass it through to internal-api. This keeps the existing JWT
+    // project-level auth in internal-api as the single source of truth -
+    // the chat backend doesn't need to re-validate.
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("")
+        .to_string();
+
+    let api = match ApiClient::new(&state.api_endpoint, token) {
+        Ok(c) => c,
+        Err(e) => return sse_error(format!("could not build API client: {e}")),
+    };
+
+    let mut tool_ctx = ToolContext::new(api);
+    if let Some(p) = body.project {
+        tool_ctx = tool_ctx.with_project(p);
+    }
+    if let Some(r) = body.region {
+        tool_ctx = tool_ctx.with_region(r);
+    }
+    if let Some(e) = body.environment {
+        tool_ctx = tool_ctx.with_environment(e);
+    }
+    if let Some(t) = body.track {
+        tool_ctx = tool_ctx.with_track(t);
+    }
+
+    let (tx, rx) = mpsc::channel::<AgentEvent>(32);
+
+    let llm = state.llm.clone();
+    let tools = state.tools.clone();
+    let req = AgentRequest {
+        system: SYSTEM_PROMPT.to_string(),
+        history: body.history,
+        user_message: body.message,
+    };
+
+    tokio::spawn(async move {
+        agent::run(llm.as_ref(), tool_ctx, tools.as_ref(), req, tx).await;
+    });
+
+    Sse::new(EventStream { rx }).keep_alive(KeepAlive::default())
+}
+
+pub async fn not_found(method: Method, uri: Uri) -> impl IntoResponse {
+    warn!(%method, %uri, "request did not match a chat route");
+    (StatusCode::NOT_FOUND, "not found")
+}
+
+pub async fn non_http_event(method: Method, uri: Uri) -> impl IntoResponse {
+    warn!(%method, %uri, "received non-HTTP Lambda event; call POST /chat through API Gateway or a Function URL instead");
+    (
+        StatusCode::BAD_REQUEST,
+        "infraweave-chat expects an HTTP POST /chat request",
+    )
+}
+
+struct EventStream {
+    rx: mpsc::Receiver<AgentEvent>,
+}
+
+impl Stream for EventStream {
+    type Item = Result<Event, Infallible>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match self.rx.poll_recv(cx) {
+            std::task::Poll::Ready(Some(ev)) => {
+                let json = serde_json::to_string(&ev).unwrap_or_else(|_| "{}".into());
+                std::task::Poll::Ready(Some(Ok(Event::default().data(json))))
+            }
+            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}
+
+fn sse_error(message: String) -> Sse<EventStream> {
+    let (tx, rx) = mpsc::channel(1);
+    tokio::spawn(async move {
+        let _ = tx.send(AgentEvent::Error { message }).await;
+        let _ = tx.send(AgentEvent::Done).await;
+    });
+    Sse::new(EventStream { rx })
+}

--- a/infraweave-chat/src/lib.rs
+++ b/infraweave-chat/src/lib.rs
@@ -1,0 +1,6 @@
+//! HTTP chat backend for InfraWeave.
+
+pub mod agent;
+pub mod handler;
+pub mod llm;
+pub mod system_prompt;

--- a/infraweave-chat/src/llm/bedrock.rs
+++ b/infraweave-chat/src/llm/bedrock.rs
@@ -1,0 +1,204 @@
+//! Bedrock Converse implementation of `LlmClient`.
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::{
+    types::{
+        ContentBlock, ConversationRole, Message, StopReason as BedrockStopReason,
+        SystemContentBlock, Tool as BedrockTool, ToolConfiguration, ToolInputSchema,
+        ToolResultBlock, ToolResultContentBlock, ToolResultStatus, ToolSpecification, ToolUseBlock,
+    },
+    Client,
+};
+use aws_smithy_types::Document;
+use serde_json::{Map, Value};
+
+use super::{LlmClient, LlmContent, LlmMessage, LlmResponse, Role, StopReason, ToolDef};
+
+pub struct BedrockClient {
+    client: Client,
+    model_id: String,
+}
+
+impl BedrockClient {
+    pub async fn from_env(model_id: impl Into<String>) -> Self {
+        let config = aws_config::load_from_env().await;
+        Self {
+            client: Client::new(&config),
+            model_id: model_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClient for BedrockClient {
+    async fn converse(
+        &self,
+        system: &str,
+        messages: &[LlmMessage],
+        tools: &[ToolDef],
+    ) -> Result<LlmResponse> {
+        let mut req = self
+            .client
+            .converse()
+            .model_id(&self.model_id)
+            .system(SystemContentBlock::Text(system.to_string()));
+
+        for m in messages {
+            req = req.messages(to_bedrock_message(m)?);
+        }
+
+        if !tools.is_empty() {
+            let mut tool_config = ToolConfiguration::builder();
+            for t in tools {
+                let spec = ToolSpecification::builder()
+                    .name(t.name.clone())
+                    .description(t.description.clone())
+                    .input_schema(ToolInputSchema::Json(value_to_document(&t.input_schema)))
+                    .build()
+                    .map_err(|e| anyhow!("invalid tool spec for `{}`: {e}", t.name))?;
+                tool_config = tool_config.tools(BedrockTool::ToolSpec(spec));
+            }
+            req = req.tool_config(
+                tool_config
+                    .build()
+                    .map_err(|e| anyhow!("invalid tool config: {e}"))?,
+            );
+        }
+
+        let resp = req.send().await.map_err(|e| {
+            use std::error::Error as _;
+            let mut detail = format!("{e}");
+            let mut source: Option<&dyn std::error::Error> = e.source();
+            while let Some(s) = source {
+                detail.push_str(" | ");
+                detail.push_str(&s.to_string());
+                source = s.source();
+            }
+            anyhow!("Bedrock Converse failed: {detail}")
+        })?;
+
+        let stop_reason = match resp.stop_reason() {
+            BedrockStopReason::EndTurn => StopReason::EndTurn,
+            BedrockStopReason::ToolUse => StopReason::ToolUse,
+            BedrockStopReason::MaxTokens => StopReason::MaxTokens,
+            other => StopReason::Other(format!("{other:?}")),
+        };
+
+        let output = resp
+            .output()
+            .ok_or_else(|| anyhow!("Bedrock response has no output"))?;
+        let msg = output
+            .as_message()
+            .map_err(|_| anyhow!("Bedrock output was not a message"))?;
+
+        let mut content = Vec::with_capacity(msg.content().len());
+        for block in msg.content() {
+            match block {
+                ContentBlock::Text(t) => content.push(LlmContent::Text { text: t.clone() }),
+                ContentBlock::ToolUse(tu) => content.push(LlmContent::ToolUse {
+                    id: tu.tool_use_id().to_string(),
+                    name: tu.name().to_string(),
+                    input: document_to_value(tu.input()),
+                }),
+                _ => {
+                    // Ignore reasoning/guardrail/etc. blocks for now.
+                }
+            }
+        }
+
+        Ok(LlmResponse {
+            content,
+            stop_reason,
+        })
+    }
+}
+
+fn to_bedrock_message(m: &LlmMessage) -> Result<Message> {
+    let role = match m.role {
+        Role::User => ConversationRole::User,
+        Role::Assistant => ConversationRole::Assistant,
+    };
+    let mut builder = Message::builder().role(role);
+    for block in &m.content {
+        let cb = match block {
+            LlmContent::Text { text } => ContentBlock::Text(text.clone()),
+            LlmContent::ToolUse { id, name, input } => ContentBlock::ToolUse(
+                ToolUseBlock::builder()
+                    .tool_use_id(id)
+                    .name(name)
+                    .input(value_to_document(input))
+                    .build()
+                    .map_err(|e| anyhow!("invalid tool_use block: {e}"))?,
+            ),
+            LlmContent::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => ContentBlock::ToolResult(
+                ToolResultBlock::builder()
+                    .tool_use_id(tool_use_id)
+                    .content(ToolResultContentBlock::Text(content.clone()))
+                    .status(if *is_error {
+                        ToolResultStatus::Error
+                    } else {
+                        ToolResultStatus::Success
+                    })
+                    .build()
+                    .map_err(|e| anyhow!("invalid tool_result block: {e}"))?,
+            ),
+        };
+        builder = builder.content(cb);
+    }
+    builder
+        .build()
+        .map_err(|e| anyhow!("invalid Bedrock message: {e}"))
+}
+
+fn value_to_document(v: &Value) -> Document {
+    match v {
+        Value::Null => Document::Null,
+        Value::Bool(b) => Document::Bool(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Document::Number(aws_smithy_types::Number::NegInt(i))
+            } else if let Some(u) = n.as_u64() {
+                Document::Number(aws_smithy_types::Number::PosInt(u))
+            } else {
+                Document::Number(aws_smithy_types::Number::Float(n.as_f64().unwrap_or(0.0)))
+            }
+        }
+        Value::String(s) => Document::String(s.clone()),
+        Value::Array(a) => Document::Array(a.iter().map(value_to_document).collect()),
+        Value::Object(o) => {
+            let mut map = std::collections::HashMap::with_capacity(o.len());
+            for (k, v) in o {
+                map.insert(k.clone(), value_to_document(v));
+            }
+            Document::Object(map)
+        }
+    }
+}
+
+fn document_to_value(d: &Document) -> Value {
+    match d {
+        Document::Null => Value::Null,
+        Document::Bool(b) => Value::Bool(*b),
+        Document::Number(n) => match n {
+            aws_smithy_types::Number::PosInt(u) => Value::Number((*u).into()),
+            aws_smithy_types::Number::NegInt(i) => Value::Number((*i).into()),
+            aws_smithy_types::Number::Float(f) => serde_json::Number::from_f64(*f)
+                .map(Value::Number)
+                .unwrap_or(Value::Null),
+        },
+        Document::String(s) => Value::String(s.clone()),
+        Document::Array(a) => Value::Array(a.iter().map(document_to_value).collect()),
+        Document::Object(o) => {
+            let mut map = Map::with_capacity(o.len());
+            for (k, v) in o {
+                map.insert(k.clone(), document_to_value(v));
+            }
+            Value::Object(map)
+        }
+    }
+}

--- a/infraweave-chat/src/llm/mod.rs
+++ b/infraweave-chat/src/llm/mod.rs
@@ -1,0 +1,82 @@
+//! LLM-provider abstraction.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[cfg(feature = "bedrock")]
+pub mod bedrock;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    User,
+    Assistant,
+}
+
+/// One block inside a chat message. The same shape covers user input,
+/// assistant text, model-issued tool calls, and tool results coming back.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LlmContent {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        is_error: bool,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmMessage {
+    pub role: Role,
+    pub content: Vec<LlmContent>,
+}
+
+impl LlmMessage {
+    pub fn user_text(text: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: vec![LlmContent::Text { text: text.into() }],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolDef {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopReason {
+    EndTurn,
+    ToolUse,
+    MaxTokens,
+    Other(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct LlmResponse {
+    pub content: Vec<LlmContent>,
+    pub stop_reason: StopReason,
+}
+
+#[async_trait]
+pub trait LlmClient: Send + Sync {
+    async fn converse(
+        &self,
+        system: &str,
+        messages: &[LlmMessage],
+        tools: &[ToolDef],
+    ) -> Result<LlmResponse>;
+}

--- a/infraweave-chat/src/main.rs
+++ b/infraweave-chat/src/main.rs
@@ -1,0 +1,61 @@
+use anyhow::{Context, Result};
+use axum::{routing::get, routing::post, Router};
+use infraweave_chat::{handler, llm::LlmClient};
+use std::sync::Arc;
+use tower_http::{cors::CorsLayer, trace::TraceLayer};
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "infraweave_chat=info,tower_http=info".into()),
+        )
+        .init();
+
+    let api_endpoint = std::env::var("INFRAWEAVE_API_ENDPOINT")
+        .context("INFRAWEAVE_API_ENDPOINT is required (e.g. https://api.infraweave.example.com)")?;
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8090);
+
+    let llm = build_llm().await?;
+    let tools = Arc::new(infraweave_tools::registry());
+
+    let state = handler::AppState {
+        llm,
+        tools,
+        api_endpoint,
+    };
+
+    let app = Router::new()
+        .route("/health", get(|| async { "ok" }))
+        .route("/chat", post(handler::chat))
+        .route("/events", post(handler::non_http_event))
+        .fallback(handler::not_found)
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+        .with_state(state);
+
+    let addr = format!("0.0.0.0:{port}");
+    info!("infraweave-chat listening on {addr}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+#[cfg(feature = "bedrock")]
+async fn build_llm() -> Result<Arc<dyn LlmClient>> {
+    let model_id =
+        std::env::var("BEDROCK_MODEL_ID").unwrap_or_else(|_| "us.amazon.nova-pro-v1:0".to_string());
+    info!("using Bedrock model `{model_id}`");
+    let client = infraweave_chat::llm::bedrock::BedrockClient::from_env(model_id).await;
+    Ok(Arc::new(client))
+}
+
+#[cfg(not(feature = "bedrock"))]
+async fn build_llm() -> Result<Arc<dyn LlmClient>> {
+    anyhow::bail!("no LLM backend feature is enabled; rebuild with --features bedrock")
+}

--- a/infraweave-chat/src/system_prompt.rs
+++ b/infraweave-chat/src/system_prompt.rs
@@ -1,0 +1,56 @@
+//! System prompt for the chat agent.
+
+pub const SYSTEM_PROMPT: &str = r#"
+You are an InfraWeave assistant. You help users understand and debug their
+infrastructure-as-code deployments managed by InfraWeave.
+
+## InfraWeave concepts
+
+- **Module**: a reusable Terraform module published to InfraWeave with a
+  manifest, inputs (`tf_variables`), and outputs (`tf_outputs`).
+- **Stack**: a bundle of modules wired together as a unit; published like a
+  module and has its own inputs/outputs.
+- **Track**: release channel a module/stack is published on (e.g. `dev`,
+  `stable`). The same name can exist on multiple tracks at different versions.
+- **Project**: tenant/account scope for deployments.
+- **Region**: exact cloud provider region id configured for a project (for AWS,
+  values look like `us-west-2` or `eu-central-1`; never broad geography like
+  `us` or `eu`).
+- **Environment**: logical environment within a project, identified in tools as
+  an exact `environment_id` (e.g. `prod`, `staging`).
+- **Deployment**: a running instantiation of a module/stack in a project +
+  region + environment, identified by a `deployment_id`.
+
+## How to answer
+
+- Prefer calling tools to ground answers in real data over guessing.
+- When debugging deployment failures, call `debug_deployment` first - it
+  bundles status + recent events + error text in one shot.
+- Project-scoped tool calls must use the exact InfraWeave `project_id`, never a
+  project display name, account alias, or conversational phrase. If the user
+  gives an alias such as "developer account" or "development account", call
+  `list_projects` first and use the matching `project_id` from that result. If
+  there is no clear match, ask the user to choose a project.
+- Environment-scoped tool calls must use the exact InfraWeave `environment_id`,
+  never an environment display name or conversational phrase. Prefer the
+  `environment_id` shown in a previous deployment result; otherwise use the
+  session default when available or ask the user.
+- Region-scoped tool calls must use an exact configured cloud provider region
+  id from `list_projects`, a previous deployment result, or a session default.
+  Do not convert user phrases like "US", "Europe", "west", or "Frankfurt" into
+  broad aliases; if the exact region id is unclear, ask the user.
+- For follow-up requests about a deployment shown by `list_deployments`, reuse
+  the exact `project_id`, `region`, `environment_id`, and `deployment_id` from
+  the listed deployment.
+- If a required value is missing and there is no session default, ask once
+  rather than calling list_projects on every turn.
+- Be concise. Show IDs, versions, and statuses verbatim - don't paraphrase
+  them. Use markdown lists/tables sparingly.
+- When answering from `diff_module_versions` or `diff_stack_versions`, do not
+  merely repeat file counts or filenames. Read the unified diff hunks and give
+  a semantic summary of the actual infrastructure/code changes: new resources,
+  removed resources, changed inputs/outputs, provider/version changes, policy
+  or permission changes, behavior changes, and likely upgrade impact. Mention
+  file names only when they clarify the explanation.
+- If a tool returns an error, surface it; don't pretend it succeeded.
+"#;


### PR DESCRIPTION
Adds a new infraweave-chat crate with a Bedrock-backed SSE chat endpoint, tool-use loop via infraweave-tools, Lambda container image, and local/Lambda usage docs.