### PR TITLE
test(runner): add runner integration coverage for OPA policies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,5 +205,5 @@ jobs:
             echo "No tests found matching filter: $FILTER"
             exit 1
           fi
-          cargo nextest run --archive-file nextest-archive.tar.zst -E "$FILTER" -j 1 --no-tests=warn
+          cargo nextest run --archive-file nextest-archive.tar.zst -E "$FILTER" -j 8 --no-tests=warn
         env: ${{ matrix.provider }}

--- a/integration-tests/azure-function-code/function_app.py
+++ b/integration-tests/azure-function-code/function_app.py
@@ -159,7 +159,8 @@ def generate_presigned_url(req: func.HttpRequest) -> func.HttpResponse:
         account_key=account_key,
     )
 
-    blob_url = f"http://127.0.0.1:10000/{account_name}/{container_name}/{blob_name}?{sas_token}" # it will be pulled from the host machine in the test
+    azurite_host_endpoint = os.getenv("AZURITE_HOST_ENDPOINT", "http://127.0.0.1:10000")
+    blob_url = f"{azurite_host_endpoint}/{account_name}/{container_name}/{blob_name}?{sas_token}" # it will be pulled from the host machine in the test
 
     return func.HttpResponse(
         json.dumps({"url": blob_url}),

--- a/integration-tests/lambda-code/test-api.py
+++ b/integration-tests/lambda-code/test-api.py
@@ -196,7 +196,8 @@ def generate_presigned_url(event):
         },
         ExpiresIn=payload.get('expires_in')
     )
-    url = 'http://127.0.0.1:' + ':'.join(url.split(':')[2:]) # MinIO is running in a separate network and interfaces with lambda via 172.18.x.x and local rust app using 127.0.0.1
+    minio_host_endpoint = os.environ.get('MINIO_HOST_ENDPOINT', 'http://127.0.0.1:9000')
+    url = minio_host_endpoint + '/' + '/'.join(url.split('/')[3:])
     return {'url': url}
 
 def get_job_status(event):

--- a/integration-tests/policies/block-s3-bucket-name/block_s3_bucket_name.rego
+++ b/integration-tests/policies/block-s3-bucket-name/block_s3_bucket_name.rego
@@ -1,0 +1,13 @@
+package infraweave.terraform_plan
+
+deny[msg] {
+  resource := input.resource_changes[_]
+  resource.mode == "managed"
+  resource.type == "aws_s3_bucket"
+  resource.change.actions != ["delete"]
+
+  bucket_name := resource.change.after.bucket
+  bucket_name == data.blockedBucketName
+
+  msg := sprintf("S3 bucket name %q is blocked by policy", [bucket_name])
+}

--- a/integration-tests/policies/block-s3-bucket-name/policy.yaml
+++ b/integration-tests/policies/block-s3-bucket-name/policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: infraweave.io/v1
+kind: Policy
+metadata:
+  name: blocks3bucketname
+spec:
+  policyName: BlockS3BucketName
+  version: 0.1.0
+  description: Blocks S3 bucket names that are reserved by platform policy.
+  reference: https://github.com/infraweave-io/policies/blocks3bucketname
+  data:
+    blockedBucketName: dev-my-unique-bucket-name-1234-playground

--- a/integration-tests/policies/require-s3-dev-prefix/policy.yaml
+++ b/integration-tests/policies/require-s3-dev-prefix/policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: infraweave.io/v1
+kind: Policy
+metadata:
+  name: requires3devprefix
+spec:
+  policyName: RequireS3DevPrefix
+  version: 0.1.0
+  description: Requires managed S3 bucket names to start with the dev environment prefix.
+  reference: https://github.com/infraweave-io/policies/requires3devprefix
+  data:
+    requiredPrefix: dev-

--- a/integration-tests/policies/require-s3-dev-prefix/require_s3_dev_prefix.rego
+++ b/integration-tests/policies/require-s3-dev-prefix/require_s3_dev_prefix.rego
@@ -1,0 +1,14 @@
+package infraweave.terraform_plan
+
+deny[msg] {
+  resource := input.resource_changes[_]
+  resource.mode == "managed"
+  resource.type == "aws_s3_bucket"
+  resource.change.actions != ["delete"]
+
+  bucket_name := resource.change.after.bucket
+  required_prefix := data.requiredPrefix
+  not startswith(bucket_name, required_prefix)
+
+  msg := sprintf("S3 bucket %s must start with prefix %q", [resource.address, required_prefix])
+}

--- a/integration-tests/src/scaffold.rs
+++ b/integration-tests/src/scaffold.rs
@@ -58,19 +58,21 @@ where
     Fut: Future<Output = ()>,
 {
     let network = generate_random_network_name();
+    let dynamodb_container_name = service_container_name(&network, "dynamodb");
+    let minio_container_name = service_container_name(&network, "minio");
 
     // Start LocalStack for Terraform provider testing (independent of control plane)
-    let (_localstack, localstack_endpoint) = start_local_localstack(&network, 4566).await;
+    let (_localstack, localstack_endpoint) = start_local_localstack(&network).await;
     env::set_var("AWS_ENDPOINT_URL", &localstack_endpoint);
     println!("LocalStack started at: {}", localstack_endpoint);
 
     // Start DynamoDB locally
-    let (_db, dynamodb_endpoint) = start_local_dynamodb(&network, 8000).await;
-    let (_minio, minio_host_endpoint) = start_local_minio(&network, 9000).await;
+    let (_db, dynamodb_endpoint) = start_local_dynamodb(&network, &dynamodb_container_name).await;
+    let (_minio, minio_host_endpoint) = start_local_minio(&network, &minio_container_name).await;
 
     // Container endpoints for services on Docker network (use container names)
-    let minio_container_endpoint = "http://minio:9000";
-    let dynamodb_container_endpoint = "http://dynamodb:8000";
+    let minio_container_endpoint = format!("http://{}:9000", minio_container_name);
+    let dynamodb_container_endpoint = format!("http://{}:8000", dynamodb_container_name);
 
     // Set region for local development (required by direct DB access)
     env::set_var("AWS_REGION", "us-west-2");
@@ -89,20 +91,23 @@ where
         dynamodb_endpoint, dynamodb_container_endpoint
     );
 
-    let _lambda_8081 = start_lambda(
+    let (_lambda_8081, bootstrap_endpoint) = start_lambda(
         &network,
-        dynamodb_container_endpoint,
-        minio_container_endpoint,
-        8081,
+        &dynamodb_container_endpoint,
+        &minio_container_endpoint,
+        &minio_host_endpoint,
     )
     .await;
-    let _lambda_8080 = start_lambda(
+    env::set_var("BOOTSTRAP_LAMBDA_ENDPOINT_URL", &bootstrap_endpoint);
+
+    let (_lambda_8080, api_endpoint) = start_lambda(
         &network,
-        dynamodb_container_endpoint,
-        minio_container_endpoint,
-        8080,
+        &dynamodb_container_endpoint,
+        &minio_container_endpoint,
+        &minio_host_endpoint,
     )
     .await;
+    env::set_var("LAMBDA_ENDPOINT_URL", &api_endpoint);
     tokio::time::sleep(std::time::Duration::from_secs(5)).await; // TODO: Find a better way to wait for the lambda to start
 
     initialize_project_id_and_region().await;
@@ -119,13 +124,15 @@ where
     Fut: Future<Output = ()>,
 {
     let network = generate_random_network_name();
+    let cosmos_container_name = service_container_name(&network, "cosmos");
+    let azurite_container_name = service_container_name(&network, "azurite");
 
-    let _cosmos = start_local_cosmosdb(&network, 8000).await;
+    let _cosmos = start_local_cosmosdb(&network, &cosmos_container_name).await;
     let (_azurite, azurite_host_connection_string, azurite_container_connection_string) =
-        start_local_azurite(&network, 10000).await;
+        start_local_azurite(&network, &azurite_container_name).await;
 
     // Start LocalStack for AWS provider in test modules
-    let (_localstack, localstack_endpoint) = start_local_localstack(&network, 4566).await;
+    let (_localstack, localstack_endpoint) = start_local_localstack(&network).await;
     env::set_var("AWS_ENDPOINT_URL", &localstack_endpoint);
 
     env::set_var(
@@ -135,20 +142,23 @@ where
     env::set_var("ARM_SKIP_PROVIDER_REGISTRATION", "true");
     env::set_var("AZURE_HTTP_USER_AGENT", "azurite-test");
 
-    let _azure_8080: ContainerAsync<GenericImage> = start_azure_function(
+    let cosmos_container_endpoint = format!("http://{}:8081", cosmos_container_name);
+
+    let (_azure_8080, api_endpoint) = start_azure_function(
         &network,
-        "http://cosmos:8081",
+        &cosmos_container_endpoint,
         &azurite_container_connection_string,
-        8080,
     )
     .await;
-    let _azure_8081: ContainerAsync<GenericImage> = start_azure_function(
+    env::set_var("LAMBDA_ENDPOINT_URL", &api_endpoint);
+
+    let (_azure_8081, bootstrap_endpoint) = start_azure_function(
         &network,
-        "http://cosmos:8081",
+        &cosmos_container_endpoint,
         &azurite_container_connection_string,
-        8081,
     )
     .await;
+    env::set_var("BOOTSTRAP_LAMBDA_ENDPOINT_URL", &bootstrap_endpoint);
 
     // Set Azure authentication to use environment variables instead of Azure CLI for Terraform
     env::set_var("ARM_USE_CLI", "false");
@@ -182,8 +192,8 @@ pub async fn start_lambda(
     network: &str,
     dynamodb_endpoint: &str,
     minio_endpoint: &str,
-    port: u16,
-) -> ContainerAsync<GenericImage> {
+    minio_host_endpoint: &str,
+) -> (ContainerAsync<GenericImage>, String) {
     let base_dir = integration_tests_dir();
     let lambda_source = base_dir.join("lambda-code/test-api.py");
     let bootstrap_source = base_dir.join("lambda-code/bootstrap.py");
@@ -206,28 +216,26 @@ pub async fn start_lambda(
         .with_env_var("DYNAMODB_CHANGE_RECORDS_TABLE_NAME", "change-records")
         .with_env_var("DYNAMODB_CONFIG_TABLE_NAME", "config")
         .with_env_var("MINIO_ENDPOINT", minio_endpoint)
+        .with_env_var("MINIO_HOST_ENDPOINT", minio_host_endpoint)
         .with_env_var("MINIO_ACCESS_KEY", "minio")
         .with_env_var("MINIO_SECRET_KEY", "minio123")
         .with_env_var("MODULE_S3_BUCKET", "modules")
         .with_env_var("POLICY_S3_BUCKET", "policies")
         .with_env_var("CHANGE_RECORD_S3_BUCKET", "change-records")
         .with_env_var("PROVIDERS_S3_BUCKET", "providers")
-        .with_mapped_port(port, container_port.tcp())
         .start()
         .await
         .expect("Failed to start lambda");
     let lambda_host_port = container.get_host_port_ipv4(container_port).await.unwrap();
     let lambda_url = format!("http://127.0.0.1:{}", lambda_host_port);
-    std::env::set_var("LAMBDA_ENDPOINT_URL", &lambda_url);
-    container
+    (container, lambda_url)
 }
 
 pub async fn start_azure_function(
     network: &str,
     cosmos_endpoint: &str,
     azurite_connection_string: &str,
-    port: u16,
-) -> ContainerAsync<GenericImage> {
+) -> (ContainerAsync<GenericImage>, String) {
     let base_dir = integration_tests_dir();
     let container_port = 80;
 
@@ -242,6 +250,7 @@ pub async fn start_azure_function(
         .with_env_var("COSMOS_DB_ENDPOINT", cosmos_endpoint)
         .with_env_var("COSMOS_DB_DATABASE", "iw_database")
         .with_env_var("AZURITE_CONNECTION_STRING", azurite_connection_string)
+        .with_env_var("AZURITE_HOST_ENDPOINT", azurite_host_endpoint())
         .with_env_var("COSMOS_KEY", "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==")
         .with_cmd(vec![
             "/bin/bash",
@@ -251,22 +260,26 @@ pub async fn start_azure_function(
         .with_network(network);
 
     let container = image
-        .with_mapped_port(port, container_port.tcp())
         .start()
         .await
         .expect("Failed to start Azure Functions container");
 
-    container
+    let function_host_port = container.get_host_port_ipv4(container_port).await.unwrap();
+    let function_url = format!("http://127.0.0.1:{}", function_host_port);
+
+    (container, function_url)
 }
 
-pub async fn start_local_dynamodb(network: &str, port: u16) -> (ContainerAsync<DynamoDb>, String) {
+pub async fn start_local_dynamodb(
+    network: &str,
+    container_name: &str,
+) -> (ContainerAsync<DynamoDb>, String) {
     let (image_name, image_tag) = get_image_name(DYNAMODB_IMAGE, "latest");
     let db = DynamoDb::default()
         .with_name(image_name)
         .with_tag(image_tag)
         .with_network(network)
-        .with_container_name("dynamodb")
-        .with_mapped_port(port, 8000.tcp())
+        .with_container_name(container_name)
         .start()
         .await
         .unwrap();
@@ -276,13 +289,10 @@ pub async fn start_local_dynamodb(network: &str, port: u16) -> (ContainerAsync<D
     (db, dynamodb_endpoint)
 }
 
-pub async fn start_local_cosmosdb(network: &str, port: u16) -> ContainerAsync<GenericImage> {
-    // Remove any stale container from a previous run (ignore errors if it doesn't exist)
-    let _ = tokio::process::Command::new("docker")
-        .args(["rm", "-f", "cosmos"])
-        .output()
-        .await;
-
+pub async fn start_local_cosmosdb(
+    network: &str,
+    container_name: &str,
+) -> ContainerAsync<GenericImage> {
     let container_port = 8081;
 
     let (image_name, image_tag) = get_image_name(
@@ -299,8 +309,7 @@ pub async fn start_local_cosmosdb(network: &str, port: u16) -> ContainerAsync<Ge
         .with_network(network);
 
     let container = image
-        .with_container_name("cosmos".to_string())
-        .with_mapped_port(port, container_port.tcp())
+        .with_container_name(container_name.to_string())
         .start()
         .await
         .expect("Failed to start local Cosmos DB Emulator");
@@ -308,15 +317,18 @@ pub async fn start_local_cosmosdb(network: &str, port: u16) -> ContainerAsync<Ge
     container
 }
 
-pub async fn start_local_minio(network: &str, port: u16) -> (ContainerAsync<GenericImage>, String) {
+pub async fn start_local_minio(
+    network: &str,
+    container_name: &str,
+) -> (ContainerAsync<GenericImage>, String) {
     let (image_name, image_tag) = get_image_name(MINIO_IMAGE, "latest");
     let minio = GenericImage::new(&image_name, &image_tag)
+        .with_exposed_port(9000.tcp())
         .with_network(network)
-        .with_container_name("minio")
+        .with_container_name(container_name)
         .with_env_var("MINIO_ACCESS_KEY", "minio")
         .with_env_var("MINIO_SECRET_KEY", "minio123")
         .with_cmd(["server", "/data"])
-        .with_mapped_port(port, 9000.tcp())
         .start()
         .await
         .expect("Failed to start minio");
@@ -329,7 +341,7 @@ pub async fn start_local_minio(network: &str, port: u16) -> (ContainerAsync<Gene
 
 pub async fn start_local_azurite(
     network: &str,
-    host_port: u16,
+    container_name: &str,
 ) -> (ContainerAsync<GenericImage>, String, String) {
     let azurite_blob_port = 10000.tcp();
 
@@ -343,8 +355,7 @@ pub async fn start_local_azurite(
         .with_network(network);
 
     let container = image
-        .with_container_name("azurite".to_string())
-        .with_mapped_port(host_port, azurite_blob_port)
+        .with_container_name(container_name.to_string())
         .start()
         .await
         .expect("Failed to start Azurite container");
@@ -355,12 +366,13 @@ pub async fn start_local_azurite(
         .expect("Failed to get mapped Azurite port");
 
     let azurite_host_endpoint = format!("http://127.0.0.1:{}", actual_mapped_port);
+    env::set_var("AZURITE_HOST_ENDPOINT", &azurite_host_endpoint);
     let azurite_host_connection_string = format!(
         "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint={};",
         azurite_host_endpoint
     );
 
-    let azurite_container_endpoint = "http://azurite:10000";
+    let azurite_container_endpoint = format!("http://{}:10000", container_name);
     let azurite_container_connection_string = format!(
         "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint={}/devstoreaccount1;",
         azurite_container_endpoint
@@ -375,8 +387,7 @@ pub async fn start_local_azurite(
 
 pub async fn bootstrap_tables() {
     let payload = serde_json::json!({ "event": "bootstrap_tables" });
-    let function_endpoint_url = "http://127.0.0.1:8081";
-    GenericCloudHandler::custom(function_endpoint_url)
+    GenericCloudHandler::custom(&bootstrap_function_endpoint())
         .await
         .run_function(&payload)
         .await
@@ -385,8 +396,7 @@ pub async fn bootstrap_tables() {
 
 pub async fn bootstrap_buckets() {
     let payload = serde_json::json!({ "event": "bootstrap_buckets" });
-    let function_endpoint_url = "http://127.0.0.1:8080";
-    GenericCloudHandler::custom(function_endpoint_url)
+    GenericCloudHandler::custom(&api_function_endpoint())
         .await
         .run_function(&payload)
         .await
@@ -398,16 +408,33 @@ pub fn generate_random_network_name() -> String {
     format!("testcontainers-network-{}", random_id)
 }
 
-pub async fn start_local_localstack(
-    network: &str,
-    port: u16,
-) -> (ContainerAsync<LocalStack>, String) {
+pub fn service_container_name(network: &str, service: &str) -> String {
+    format!(
+        "{}-{}",
+        service,
+        network.replace("testcontainers-network-", "")
+    )
+}
+
+pub fn api_function_endpoint() -> String {
+    env::var("LAMBDA_ENDPOINT_URL").unwrap_or_else(|_| "http://127.0.0.1:8080".to_string())
+}
+
+pub fn bootstrap_function_endpoint() -> String {
+    env::var("BOOTSTRAP_LAMBDA_ENDPOINT_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8081".to_string())
+}
+
+pub fn azurite_host_endpoint() -> String {
+    env::var("AZURITE_HOST_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:10000".to_string())
+}
+
+pub async fn start_local_localstack(network: &str) -> (ContainerAsync<LocalStack>, String) {
     let (image_name, image_tag) = get_image_name("localstack/localstack", "3.0");
     let localstack = LocalStack::default()
         .with_name(image_name)
         .with_tag(image_tag)
         .with_network(network)
-        .with_mapped_port(port, 4566.tcp())
         .start()
         .await
         .unwrap();

--- a/integration-tests/src/scaffold.rs
+++ b/integration-tests/src/scaffold.rs
@@ -58,19 +58,21 @@ where
     Fut: Future<Output = ()>,
 {
     let network = generate_random_network_name();
+    let dynamodb_container_name = service_container_name(&network, "dynamodb");
+    let minio_container_name = service_container_name(&network, "minio");
 
     // Start LocalStack for Terraform provider testing (independent of control plane)
-    let (_localstack, localstack_endpoint) = start_local_localstack(&network, 4566).await;
+    let (_localstack, localstack_endpoint) = start_local_localstack(&network).await;
     env::set_var("AWS_ENDPOINT_URL", &localstack_endpoint);
     println!("LocalStack started at: {}", localstack_endpoint);
 
     // Start DynamoDB locally
-    let (_db, dynamodb_endpoint) = start_local_dynamodb(&network, 8000).await;
-    let (_minio, minio_host_endpoint) = start_local_minio(&network, 9000).await;
+    let (_db, dynamodb_endpoint) = start_local_dynamodb(&network, &dynamodb_container_name).await;
+    let (_minio, minio_host_endpoint) = start_local_minio(&network, &minio_container_name).await;
 
     // Container endpoints for services on Docker network (use container names)
-    let minio_container_endpoint = "http://minio:9000";
-    let dynamodb_container_endpoint = "http://dynamodb:8000";
+    let minio_container_endpoint = format!("http://{}:9000", minio_container_name);
+    let dynamodb_container_endpoint = format!("http://{}:8000", dynamodb_container_name);
 
     // Set region for local development (required by direct DB access)
     env::set_var("AWS_REGION", "us-west-2");
@@ -91,20 +93,23 @@ where
         dynamodb_endpoint, dynamodb_container_endpoint
     );
 
-    let _lambda_8081 = start_lambda(
+    let (_lambda_8081, bootstrap_endpoint) = start_lambda(
         &network,
-        dynamodb_container_endpoint,
-        minio_container_endpoint,
-        8081,
+        &dynamodb_container_endpoint,
+        &minio_container_endpoint,
+        &minio_host_endpoint,
     )
     .await;
-    let _lambda_8080 = start_lambda(
+    env::set_var("BOOTSTRAP_LAMBDA_ENDPOINT_URL", &bootstrap_endpoint);
+
+    let (_lambda_8080, api_endpoint) = start_lambda(
         &network,
-        dynamodb_container_endpoint,
-        minio_container_endpoint,
-        8080,
+        &dynamodb_container_endpoint,
+        &minio_container_endpoint,
+        &minio_host_endpoint,
     )
     .await;
+    env::set_var("LAMBDA_ENDPOINT_URL", &api_endpoint);
     tokio::time::sleep(std::time::Duration::from_secs(5)).await; // TODO: Find a better way to wait for the lambda to start
 
     initialize_project_id_and_region().await;
@@ -121,13 +126,15 @@ where
     Fut: Future<Output = ()>,
 {
     let network = generate_random_network_name();
+    let cosmos_container_name = service_container_name(&network, "cosmos");
+    let azurite_container_name = service_container_name(&network, "azurite");
 
-    let _cosmos = start_local_cosmosdb(&network, 8000).await;
+    let _cosmos = start_local_cosmosdb(&network, &cosmos_container_name).await;
     let (_azurite, azurite_host_connection_string, azurite_container_connection_string) =
-        start_local_azurite(&network, 10000).await;
+        start_local_azurite(&network, &azurite_container_name).await;
 
     // Start LocalStack for AWS provider in test modules
-    let (_localstack, localstack_endpoint) = start_local_localstack(&network, 4566).await;
+    let (_localstack, localstack_endpoint) = start_local_localstack(&network).await;
     env::set_var("AWS_ENDPOINT_URL", &localstack_endpoint);
 
     env::set_var(
@@ -137,20 +144,23 @@ where
     env::set_var("ARM_SKIP_PROVIDER_REGISTRATION", "true");
     env::set_var("AZURE_HTTP_USER_AGENT", "azurite-test");
 
-    let _azure_8080: ContainerAsync<GenericImage> = start_azure_function(
+    let cosmos_container_endpoint = format!("http://{}:8081", cosmos_container_name);
+
+    let (_azure_8080, api_endpoint) = start_azure_function(
         &network,
-        "http://cosmos:8081",
+        &cosmos_container_endpoint,
         &azurite_container_connection_string,
-        8080,
     )
     .await;
-    let _azure_8081: ContainerAsync<GenericImage> = start_azure_function(
+    env::set_var("LAMBDA_ENDPOINT_URL", &api_endpoint);
+
+    let (_azure_8081, bootstrap_endpoint) = start_azure_function(
         &network,
-        "http://cosmos:8081",
+        &cosmos_container_endpoint,
         &azurite_container_connection_string,
-        8081,
     )
     .await;
+    env::set_var("BOOTSTRAP_LAMBDA_ENDPOINT_URL", &bootstrap_endpoint);
 
     // Set Azure authentication to use environment variables instead of Azure CLI for Terraform
     env::set_var("ARM_USE_CLI", "false");
@@ -184,8 +194,8 @@ pub async fn start_lambda(
     network: &str,
     dynamodb_endpoint: &str,
     minio_endpoint: &str,
-    port: u16,
-) -> ContainerAsync<GenericImage> {
+    minio_host_endpoint: &str,
+) -> (ContainerAsync<GenericImage>, String) {
     let base_dir = integration_tests_dir();
     let lambda_source = base_dir.join("lambda-code/test-api.py");
     let bootstrap_source = base_dir.join("lambda-code/bootstrap.py");
@@ -208,28 +218,26 @@ pub async fn start_lambda(
         .with_env_var("DYNAMODB_CHANGE_RECORDS_TABLE_NAME", "change-records")
         .with_env_var("DYNAMODB_CONFIG_TABLE_NAME", "config")
         .with_env_var("MINIO_ENDPOINT", minio_endpoint)
+        .with_env_var("MINIO_HOST_ENDPOINT", minio_host_endpoint)
         .with_env_var("MINIO_ACCESS_KEY", "minio")
         .with_env_var("MINIO_SECRET_KEY", "minio123")
         .with_env_var("MODULE_S3_BUCKET", "modules")
         .with_env_var("POLICY_S3_BUCKET", "policies")
         .with_env_var("CHANGE_RECORD_S3_BUCKET", "change-records")
         .with_env_var("PROVIDERS_S3_BUCKET", "providers")
-        .with_mapped_port(port, container_port.tcp())
         .start()
         .await
         .expect("Failed to start lambda");
     let lambda_host_port = container.get_host_port_ipv4(container_port).await.unwrap();
     let lambda_url = format!("http://127.0.0.1:{}", lambda_host_port);
-    std::env::set_var("LAMBDA_ENDPOINT_URL", &lambda_url);
-    container
+    (container, lambda_url)
 }
 
 pub async fn start_azure_function(
     network: &str,
     cosmos_endpoint: &str,
     azurite_connection_string: &str,
-    port: u16,
-) -> ContainerAsync<GenericImage> {
+) -> (ContainerAsync<GenericImage>, String) {
     let base_dir = integration_tests_dir();
     let container_port = 80;
 
@@ -244,6 +252,7 @@ pub async fn start_azure_function(
         .with_env_var("COSMOS_DB_ENDPOINT", cosmos_endpoint)
         .with_env_var("COSMOS_DB_DATABASE", "iw_database")
         .with_env_var("AZURITE_CONNECTION_STRING", azurite_connection_string)
+        .with_env_var("AZURITE_HOST_ENDPOINT", azurite_host_endpoint())
         .with_env_var("COSMOS_KEY", "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==")
         .with_cmd(vec![
             "/bin/bash",
@@ -253,22 +262,26 @@ pub async fn start_azure_function(
         .with_network(network);
 
     let container = image
-        .with_mapped_port(port, container_port.tcp())
         .start()
         .await
         .expect("Failed to start Azure Functions container");
 
-    container
+    let function_host_port = container.get_host_port_ipv4(container_port).await.unwrap();
+    let function_url = format!("http://127.0.0.1:{}", function_host_port);
+
+    (container, function_url)
 }
 
-pub async fn start_local_dynamodb(network: &str, port: u16) -> (ContainerAsync<DynamoDb>, String) {
+pub async fn start_local_dynamodb(
+    network: &str,
+    container_name: &str,
+) -> (ContainerAsync<DynamoDb>, String) {
     let (image_name, image_tag) = get_image_name(DYNAMODB_IMAGE, "latest");
     let db = DynamoDb::default()
         .with_name(image_name)
         .with_tag(image_tag)
         .with_network(network)
-        .with_container_name("dynamodb")
-        .with_mapped_port(port, 8000.tcp())
+        .with_container_name(container_name)
         .start()
         .await
         .unwrap();
@@ -278,13 +291,10 @@ pub async fn start_local_dynamodb(network: &str, port: u16) -> (ContainerAsync<D
     (db, dynamodb_endpoint)
 }
 
-pub async fn start_local_cosmosdb(network: &str, port: u16) -> ContainerAsync<GenericImage> {
-    // Remove any stale container from a previous run (ignore errors if it doesn't exist)
-    let _ = tokio::process::Command::new("docker")
-        .args(["rm", "-f", "cosmos"])
-        .output()
-        .await;
-
+pub async fn start_local_cosmosdb(
+    network: &str,
+    container_name: &str,
+) -> ContainerAsync<GenericImage> {
     let container_port = 8081;
 
     let (image_name, image_tag) = get_image_name(
@@ -301,8 +311,7 @@ pub async fn start_local_cosmosdb(network: &str, port: u16) -> ContainerAsync<Ge
         .with_network(network);
 
     let container = image
-        .with_container_name("cosmos".to_string())
-        .with_mapped_port(port, container_port.tcp())
+        .with_container_name(container_name.to_string())
         .start()
         .await
         .expect("Failed to start local Cosmos DB Emulator");
@@ -310,15 +319,18 @@ pub async fn start_local_cosmosdb(network: &str, port: u16) -> ContainerAsync<Ge
     container
 }
 
-pub async fn start_local_minio(network: &str, port: u16) -> (ContainerAsync<GenericImage>, String) {
+pub async fn start_local_minio(
+    network: &str,
+    container_name: &str,
+) -> (ContainerAsync<GenericImage>, String) {
     let (image_name, image_tag) = get_image_name(MINIO_IMAGE, "latest");
     let minio = GenericImage::new(&image_name, &image_tag)
+        .with_exposed_port(9000.tcp())
         .with_network(network)
-        .with_container_name("minio")
+        .with_container_name(container_name)
         .with_env_var("MINIO_ACCESS_KEY", "minio")
         .with_env_var("MINIO_SECRET_KEY", "minio123")
         .with_cmd(["server", "/data"])
-        .with_mapped_port(port, 9000.tcp())
         .start()
         .await
         .expect("Failed to start minio");
@@ -331,7 +343,7 @@ pub async fn start_local_minio(network: &str, port: u16) -> (ContainerAsync<Gene
 
 pub async fn start_local_azurite(
     network: &str,
-    host_port: u16,
+    container_name: &str,
 ) -> (ContainerAsync<GenericImage>, String, String) {
     let azurite_blob_port = 10000.tcp();
 
@@ -345,8 +357,7 @@ pub async fn start_local_azurite(
         .with_network(network);
 
     let container = image
-        .with_container_name("azurite".to_string())
-        .with_mapped_port(host_port, azurite_blob_port)
+        .with_container_name(container_name.to_string())
         .start()
         .await
         .expect("Failed to start Azurite container");
@@ -357,12 +368,13 @@ pub async fn start_local_azurite(
         .expect("Failed to get mapped Azurite port");
 
     let azurite_host_endpoint = format!("http://127.0.0.1:{}", actual_mapped_port);
+    env::set_var("AZURITE_HOST_ENDPOINT", &azurite_host_endpoint);
     let azurite_host_connection_string = format!(
         "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint={};",
         azurite_host_endpoint
     );
 
-    let azurite_container_endpoint = "http://azurite:10000";
+    let azurite_container_endpoint = format!("http://{}:10000", container_name);
     let azurite_container_connection_string = format!(
         "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint={}/devstoreaccount1;",
         azurite_container_endpoint
@@ -377,8 +389,7 @@ pub async fn start_local_azurite(
 
 pub async fn bootstrap_tables() {
     let payload = serde_json::json!({ "event": "bootstrap_tables" });
-    let function_endpoint_url = "http://127.0.0.1:8081";
-    GenericCloudHandler::custom(function_endpoint_url)
+    GenericCloudHandler::custom(&bootstrap_function_endpoint())
         .await
         .run_function(&payload)
         .await
@@ -387,8 +398,7 @@ pub async fn bootstrap_tables() {
 
 pub async fn bootstrap_buckets() {
     let payload = serde_json::json!({ "event": "bootstrap_buckets" });
-    let function_endpoint_url = "http://127.0.0.1:8080";
-    GenericCloudHandler::custom(function_endpoint_url)
+    GenericCloudHandler::custom(&api_function_endpoint())
         .await
         .run_function(&payload)
         .await
@@ -400,16 +410,33 @@ pub fn generate_random_network_name() -> String {
     format!("testcontainers-network-{}", random_id)
 }
 
-pub async fn start_local_localstack(
-    network: &str,
-    port: u16,
-) -> (ContainerAsync<LocalStack>, String) {
+pub fn service_container_name(network: &str, service: &str) -> String {
+    format!(
+        "{}-{}",
+        service,
+        network.replace("testcontainers-network-", "")
+    )
+}
+
+pub fn api_function_endpoint() -> String {
+    env::var("LAMBDA_ENDPOINT_URL").unwrap_or_else(|_| "http://127.0.0.1:8080".to_string())
+}
+
+pub fn bootstrap_function_endpoint() -> String {
+    env::var("BOOTSTRAP_LAMBDA_ENDPOINT_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8081".to_string())
+}
+
+pub fn azurite_host_endpoint() -> String {
+    env::var("AZURITE_HOST_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:10000".to_string())
+}
+
+pub async fn start_local_localstack(network: &str) -> (ContainerAsync<LocalStack>, String) {
     let (image_name, image_tag) = get_image_name("localstack/localstack", "3.0");
     let localstack = LocalStack::default()
         .with_name(image_name)
         .with_tag(image_tag)
         .with_network(network)
-        .with_mapped_port(port, 4566.tcp())
         .start()
         .await
         .unwrap();

--- a/integration-tests/tests/cli_http.rs
+++ b/integration-tests/tests/cli_http.rs
@@ -9,29 +9,11 @@
 #[allow(deprecated)] // set_var/remove_var: safe here because all writes happen inside OnceCell::get_or_init before any test runs.
 mod cli_http_tests {
     use env_common::interface::initialize_project_id_and_region;
-    use integration_tests::scaffold::ALL_IMAGES;
     use pretty_assertions::assert_eq;
     use tokio::sync::OnceCell;
 
     /// Shared infrastructure + server port, initialized exactly once.
     static SERVER: OnceCell<u16> = OnceCell::const_new();
-
-    /// Remove leftover DynamoDB/MinIO containers from a previous crashed run.
-    fn cleanup_stale_containers() {
-        for image in ALL_IMAGES {
-            let output = std::process::Command::new("docker")
-                .args(["ps", "-q", "--filter", &format!("ancestor={}", image)])
-                .output();
-            if let Ok(out) = output {
-                let ids = String::from_utf8_lossy(&out.stdout);
-                for id in ids.split_whitespace() {
-                    let _ = std::process::Command::new("docker")
-                        .args(["rm", "-f", id])
-                        .output();
-                }
-            }
-        }
-    }
 
     /// Start local infra and HTTP server once; return the port for all tests.
     async fn ensure_server() -> u16 {
@@ -43,9 +25,6 @@ mod cli_http_tests {
                     .expect("integration-tests must be inside workspace");
                 std::env::set_current_dir(workspace_root)
                     .expect("Failed to set CWD to workspace root");
-
-                // Remove any leftover containers from a previous failed run.
-                cleanup_stale_containers();
 
                 // Leak the guard so containers stay alive for the entire test run.
                 let infra = internal_api::local_setup::start_local_infrastructure()

--- a/integration-tests/tests/infra.rs
+++ b/integration-tests/tests/infra.rs
@@ -13,8 +13,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_apply_s3bucket_dev() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -103,8 +103,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_apply_s3bucket_dev_snake_case() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -163,8 +163,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_apply_s3bucket_stable() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -250,8 +250,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_nullable_variable_set_to_null() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -344,8 +344,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_deployment_in_progress_with_job_status_check() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -495,8 +495,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_module_deprecation_existing_deployment_can_modify() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             // Step 1: Publish provider
@@ -653,8 +653,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_module_deprecation_new_deployment_blocked() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             // Step 1: Publish provider

--- a/integration-tests/tests/infra.rs
+++ b/integration-tests/tests/infra.rs
@@ -13,8 +13,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_apply_s3bucket_dev() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -103,8 +103,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_apply_s3bucket_dev_snake_case() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -163,8 +163,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_apply_s3bucket_stable() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -250,8 +250,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_infra_nullable_variable_set_to_null() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -344,8 +344,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_deployment_in_progress_with_job_status_check() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -495,8 +495,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_module_deprecation_existing_deployment_can_modify() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             // Step 1: Publish provider
@@ -655,8 +655,8 @@ mod infra_tests {
     #[tokio::test]
     async fn test_module_deprecation_new_deployment_blocked() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             // Step 1: Publish provider

--- a/integration-tests/tests/module.rs
+++ b/integration-tests/tests/module.rs
@@ -13,8 +13,8 @@ mod module_tests {
     #[tokio::test]
     async fn test_module_publish_s3bucket_invalid_provider() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
             let publish_attempt = env_common::publish_module(
                 &handler,
@@ -40,8 +40,8 @@ mod module_tests {
     #[tokio::test]
     async fn test_module_publish_s3bucket() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -141,8 +141,8 @@ mod module_tests {
     #[tokio::test]
     async fn test_module_publish_s3bucket_defaults() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -209,8 +209,8 @@ mod module_tests {
     #[tokio::test]
     async fn test_module_publish_3_s3bucket_versions() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -278,8 +278,8 @@ mod module_tests {
     #[tokio::test]
     async fn test_module_publish_s3bucket_with_backup() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -24,8 +24,8 @@ mod operator_tests {
     #[tokio::test]
     async fn test_operator() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let home_dir = dirs::home_dir().expect("Failed to get home directory");
             let conf_dir = home_dir.join("k3s_conf_test");
             fs::create_dir_all(&conf_dir).expect("Failed to create config directory");
@@ -145,8 +145,8 @@ spec:
             );
 
             // Set deployment status to successful in database to simulate successful deployment (since start_runner is mocked)
-            let lambda_endpoint_url = "http://127.0.0.1:8081";
-            let handler2 = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::bootstrap_function_endpoint();
+            let handler2 = GenericCloudHandler::custom(&lambda_endpoint_url).await;
 
             let all_deployments = handler2.get_all_deployments(&environment, false).await.unwrap();
             println!("All deployments: {:?}", all_deployments);
@@ -197,8 +197,8 @@ spec:
             use tower::ServiceExt;
 
             // Create a handler for webhook validation
-            let lambda_endpoint_url = "http://127.0.0.1:8081";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::bootstrap_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
 
             let app = create_webhook_router(handler);
 

--- a/integration-tests/tests/provider.rs
+++ b/integration-tests/tests/provider.rs
@@ -12,8 +12,8 @@ mod provider_tests {
     #[tokio::test]
     async fn test_provder_publish_aws_5() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
             env_common::publish_provider(
                 &handler,
@@ -49,8 +49,8 @@ mod provider_tests {
     #[tokio::test]
     async fn test_provder_publish_aws_5_us_east_1() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
             env_common::publish_provider(
                 &handler,

--- a/integration-tests/tests/runner.rs
+++ b/integration-tests/tests/runner.rs
@@ -4,7 +4,10 @@ use utils::test_scaffold;
 #[cfg(test)]
 mod runner_tests {
     use super::*;
-    use env_common::{interface::GenericCloudHandler, logic::run_claim};
+    use env_common::{
+        interface::GenericCloudHandler,
+        logic::{publish_policy, run_claim},
+    };
     use env_defs::ExtraData;
     use env_defs::{CloudProvider, DeploymentStatus};
     use pretty_assertions::assert_eq;
@@ -392,6 +395,164 @@ mod runner_tests {
                     assert!(false, "Stack runner failed: {:?}", e);
                 }
             }
+        })
+        .await;
+    }
+
+    async fn setup_s3bucket_runner_claim(
+        policy_dirs: &[&str],
+    ) -> (GenericCloudHandler, String, String) {
+        let lambda_endpoint_url = "http://127.0.0.1:8080";
+        let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+        let current_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+        env_common::publish_provider(
+            &handler,
+            &current_dir
+                .join("providers/aws-5/")
+                .to_str()
+                .unwrap()
+                .to_string(),
+            Some("0.1.2"),
+        )
+        .await
+        .unwrap();
+
+        env_common::publish_module(
+            &handler,
+            &current_dir
+                .join("modules/s3bucket-dev/")
+                .to_str()
+                .unwrap()
+                .to_string(),
+            &"dev".to_string(),
+            Some("0.1.2-dev+test.10"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        for policy_dir in policy_dirs {
+            publish_policy(
+                &handler,
+                &current_dir.join(policy_dir).to_str().unwrap().to_string(),
+                &"stable".to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let claim_path = current_dir.join("claims/s3bucket-dev-claim.yaml");
+        let claim_yaml_str =
+            std::fs::read_to_string(claim_path).expect("Failed to read claim.yaml");
+        let claims: Vec<serde_yaml::Value> = serde_yaml::Deserializer::from_str(&claim_yaml_str)
+            .map(|doc| serde_yaml::Value::deserialize(doc).unwrap_or("".into()))
+            .collect();
+
+        let environment = "default/playground".to_string();
+        let command = "apply".to_string();
+        let flags = vec![];
+        let (job_id, deployment_id, payload_with_variables) = run_claim(
+            &handler,
+            &claims[0],
+            &environment,
+            &command,
+            flags,
+            ExtraData::None,
+            "",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(job_id, "running-test-job-id");
+
+        let payload = payload_with_variables.payload;
+        let payload_str = serde_json::to_string(&payload).unwrap();
+
+        env::set_var("PAYLOAD", payload_str);
+        env::set_var("TF_BUCKET", "tf-state");
+        env::set_var("REGION", "us-west-2");
+
+        (handler, environment, deployment_id)
+    }
+
+    #[tokio::test]
+    async fn test_runner_passes_when_opa_policy_passes() {
+        test_scaffold(|| async move {
+            let (handler, environment, deployment_id) =
+                setup_s3bucket_runner_claim(&["policies/require-s3-dev-prefix/"]).await;
+
+            let temp_dir = tempfile::Builder::new()
+                .prefix(&format!(
+                    "infraweave-policy-pass-test-{}-",
+                    deployment_id.replace("/", "-")
+                ))
+                .tempdir()
+                .expect("Failed to create temp directory");
+
+            let _guard = RestoreDir::new(temp_dir.path());
+            run_terraform_runner(&handler)
+                .await
+                .expect("Expected runner to succeed when OPA policies pass");
+
+            let deployment = handler
+                .get_deployment(&deployment_id, &environment, false)
+                .await
+                .expect("Failed to get deployment after runner execution")
+                .expect("Deployment not found after runner execution");
+
+            assert_eq!(deployment.status, DeploymentStatus::Successful);
+            assert_eq!(deployment.policy_results.len(), 1);
+
+            let passing_policy_result = deployment
+                .policy_results
+                .iter()
+                .find(|result| result.policy == "requires3devprefix")
+                .expect("Missing passing dev-prefix policy result");
+            assert!(!passing_policy_result.failed);
+            assert_eq!(passing_policy_result.violations, serde_json::json!({}));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_runner_fails_when_opa_policy_fails() {
+        test_scaffold(|| async move {
+            let (handler, environment, deployment_id) =
+                setup_s3bucket_runner_claim(&["policies/block-s3-bucket-name/"]).await;
+
+            let temp_dir = tempfile::Builder::new()
+                .prefix(&format!(
+                    "infraweave-policy-fail-test-{}-",
+                    deployment_id.replace("/", "-")
+                ))
+                .tempdir()
+                .expect("Failed to create temp directory");
+
+            let _guard = RestoreDir::new(temp_dir.path());
+            run_terraform_runner(&handler)
+                .await
+                .expect("Runner should complete after persisting the policy failure");
+
+            let deployment = handler
+                .get_deployment(&deployment_id, &environment, false)
+                .await
+                .expect("Failed to get deployment after runner execution")
+                .expect("Deployment not found after runner execution");
+
+            assert_eq!(deployment.status, DeploymentStatus::FailedPolicy);
+            assert_eq!(deployment.policy_results.len(), 1);
+
+            let failing_policy_result = deployment
+                .policy_results
+                .iter()
+                .find(|result| result.policy == "blocks3bucketname")
+                .expect("Missing failing blocked bucket name policy result");
+            assert!(failing_policy_result.failed);
+            assert_eq!(
+                failing_policy_result.violations["terraform_plan"][0],
+                "S3 bucket name \"dev-my-unique-bucket-name-1234-playground\" is blocked by policy"
+            );
         })
         .await;
     }

--- a/integration-tests/tests/runner.rs
+++ b/integration-tests/tests/runner.rs
@@ -34,8 +34,8 @@ mod runner_tests {
     #[tokio::test]
     async fn test_runner() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
             env_common::publish_provider(
@@ -218,8 +218,8 @@ mod runner_tests {
     #[tokio::test]
     async fn test_runner_stack_with_variables() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
             env_common::publish_provider(
@@ -402,8 +402,8 @@ mod runner_tests {
     async fn setup_s3bucket_runner_claim(
         policy_dirs: &[&str],
     ) -> (GenericCloudHandler, String, String) {
-        let lambda_endpoint_url = "http://127.0.0.1:8080";
-        let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+        let lambda_endpoint_url = utils::api_function_endpoint();
+        let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
         let current_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
         env_common::publish_provider(

--- a/integration-tests/tests/runner_oci.rs
+++ b/integration-tests/tests/runner_oci.rs
@@ -18,8 +18,8 @@ mod runner_tests {
     #[ignore = "OCI signing and attestation is problematic in test"]
     async fn test_runner_oci() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
             env_common::publish_module(
                 &handler,

--- a/integration-tests/tests/stack.rs
+++ b/integration-tests/tests/stack.rs
@@ -14,8 +14,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_bucketcollection() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -145,8 +145,8 @@ mod stack_tests {
     async fn test_stack_publish_bucketcollection_missing_region() {
         // should add variable checks as well
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -210,8 +210,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_bucketcollection_invalid_variables() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -275,8 +275,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_route53records_with_exposed_provider_variables() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -423,8 +423,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_route53records_no_exposed_provider_variables() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -571,8 +571,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_providermix() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -707,8 +707,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_static_website() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -831,8 +831,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_webapp_example() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -1033,8 +1033,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_webapp_example_manual() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(
@@ -1287,8 +1287,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_multiline_policy_with_reference() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             // Publish provider
@@ -1428,8 +1428,8 @@ mod stack_tests {
     #[tokio::test]
     async fn test_stack_publish_with_stack_variables() {
         test_scaffold(|| async move {
-            let lambda_endpoint_url = "http://127.0.0.1:8080";
-            let handler = GenericCloudHandler::custom(lambda_endpoint_url).await;
+            let lambda_endpoint_url = utils::api_function_endpoint();
+            let handler = GenericCloudHandler::custom(&lambda_endpoint_url).await;
             let current_dir = env::current_dir().expect("Failed to get current directory");
 
             env_common::publish_provider(

--- a/terraform_runner/src/opa.rs
+++ b/terraform_runner/src/opa.rs
@@ -42,10 +42,9 @@ pub async fn run_opa_command(
 }
 
 #[tracing::instrument(skip_all, fields(policy = %policy.policy))]
-pub async fn download_policy(policy: &env_defs::PolicyResp) {
+pub async fn download_policy(handler: &GenericCloudHandler, policy: &env_defs::PolicyResp) {
     log::info!("Downloading policy for {}...", policy.policy);
 
-    let handler = GenericCloudHandler::default().await;
     let url = match handler.get_policy_download_url(&policy.s3_key).await {
         Ok(url) => url,
         Err(e) => {
@@ -76,18 +75,27 @@ pub async fn download_policy(policy: &env_defs::PolicyResp) {
 }
 
 pub fn get_all_rego_filenames_in_cwd() -> Vec<String> {
-    let rego_files: Vec<String> = std::fs::read_dir("./")
-        .unwrap()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| {
-            entry
+    fn collect_rego_files(path: &Path, rego_files: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return;
+        };
+
+        for entry in entries.filter_map(|entry| entry.ok()) {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rego_files(&path, rego_files);
+            } else if path
                 .file_name()
-                .to_str()
-                .map(|s| s.ends_with(".rego"))
-                .unwrap_or(false)
-        })
-        .map(|entry| entry.path().to_str().unwrap().to_string())
-        .collect();
+                .and_then(|file_name| file_name.to_str())
+                .is_some_and(|file_name| file_name.ends_with(".rego"))
+            {
+                rego_files.push(path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    let mut rego_files = Vec::new();
+    collect_rego_files(Path::new("./"), &mut rego_files);
     rego_files
 }
 
@@ -115,7 +123,7 @@ pub async fn run_opa_policy_checks(
 
     log::info!("Running OPA policy checks...");
     for policy in policies {
-        download_policy(&policy).await;
+        download_policy(handler, &policy).await;
 
         // Store policy input in a JSON file
         let policy_input_file = "./policy_input.json";
@@ -124,6 +132,12 @@ pub async fn run_opa_policy_checks(
         serde_json::to_writer(policy_input_file, &policy.data).unwrap();
 
         let rego_files: Vec<String> = get_all_rego_filenames_in_cwd();
+        if rego_files.is_empty() {
+            return Err(anyhow::anyhow!(
+                "No .rego files found after downloading policy {}",
+                policy.policy
+            ));
+        }
 
         match run_opa_command(500, &policy.policy, &rego_files).await {
             Ok(command_result) => {

--- a/terraform_runner/src/opa.rs
+++ b/terraform_runner/src/opa.rs
@@ -111,7 +111,7 @@ pub async fn run_opa_policy_checks(
         Err(e) => log::error!("Failed to write file: {}", e),
     }
 
-    let policy_environment = "stable".to_string();
+    let policy_environment = "default".to_string();
     log::info!(
         "Finding all applicable policies for {}...",
         &policy_environment


### PR DESCRIPTION
Add passing and failing OPA policy fixtures for S3 bucket plans, and exercise them through the Terraform runner integration flow.

Reuse the injected cloud handler when downloading policies in the runner and make policy Rego discovery recursive so test-mode policy evaluation matches the local scaffold.