### PR TITLE
fix: fetch latest provider version for http mode

### DIFF
--- a/env_common/src/interface/no_cloud_provider.rs
+++ b/env_common/src/interface/no_cloud_provider.rs
@@ -155,9 +155,9 @@ impl CloudProvider for NoCloudProvider {
 
     async fn get_latest_provider_version(
         &self,
-        _provider: &str,
+        provider: &str,
     ) -> Result<Option<ProviderResp>, anyhow::Error> {
-        Ok(None)
+        http_client::http_get_latest_provider_version(provider).await
     }
 
     async fn generate_presigned_url(


### PR DESCRIPTION
Call existing `http_client::http_get_latest_provider_version` with the provider name, enabling actual retrieval of the latest provider version in http mode