### PR TITLE
feat: add provider-agnostic config parameter reads

### DIFF
--- a/env_aws_direct/src/direct_impl.rs
+++ b/env_aws_direct/src/direct_impl.rs
@@ -796,6 +796,35 @@ pub async fn download_file_as_bytes_direct(
     Ok((bytes.to_vec(), content_length, content_type))
 }
 
+// ============= Configuration parameters =============
+
+/// Read a value from AWS SSM Parameter Store using the ambient AWS config
+/// (central credentials or the default AWS provider chain, with no workload
+/// account assume-role). Used by env_common to expose a provider-agnostic
+/// config-parameter reader to callers like internal-api.
+pub async fn read_config_parameter(name: &str) -> Result<String> {
+    let config = get_aws_config(None).await;
+    let client = aws_sdk_ssm::Client::new(&config);
+    read_ssm_parameter(&client, name).await
+}
+
+async fn read_ssm_parameter(client: &aws_sdk_ssm::Client, name: &str) -> Result<String> {
+    let response = client
+        .get_parameter()
+        .name(name)
+        .with_decryption(true)
+        .send()
+        .await
+        .map_err(|e| anyhow!("failed to read SSM parameter '{}': {}", name, e))?;
+
+    response
+        .parameter()
+        .and_then(|p| p.value())
+        .map(str::to_string)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("SSM parameter '{}' is missing or empty", name))
+}
+
 // ============= Cross-account operations =============
 
 pub(crate) async fn get_aws_config(region: Option<&str>) -> aws_config::SdkConfig {
@@ -913,57 +942,20 @@ pub async fn start_runner_cross_account(data: &Value) -> Result<Value> {
         region, environment
     );
 
-    let cluster = ssm_client
-        .get_parameter()
-        .name(&cluster_param)
-        .send()
+    let cluster = read_ssm_parameter(&ssm_client, &cluster_param)
         .await
-        .map_err(|e| {
-            anyhow!(
-                "Failed to get cluster name from SSM parameter {}: {:?}",
-                cluster_param,
-                e
-            )
-        })?
-        .parameter()
-        .and_then(|p| p.value())
-        .ok_or_else(|| anyhow!("No cluster name value in SSM parameter"))?
-        .to_string();
+        .map_err(|e| anyhow!("Failed to get cluster name: {}", e))?;
 
-    let subnets: Vec<String> = ssm_client
-        .get_parameter()
-        .name(&subnets_param)
-        .send()
+    let subnets: Vec<String> = read_ssm_parameter(&ssm_client, &subnets_param)
         .await
-        .map_err(|e| {
-            anyhow!(
-                "Failed to get subnets from SSM parameter {}: {:?}",
-                subnets_param,
-                e
-            )
-        })?
-        .parameter()
-        .and_then(|p| p.value())
-        .ok_or_else(|| anyhow!("No subnets value in SSM parameter"))?
+        .map_err(|e| anyhow!("Failed to get subnets: {}", e))?
         .split(',')
         .map(|s| s.trim().to_string())
         .collect();
 
-    let security_groups: Vec<String> = ssm_client
-        .get_parameter()
-        .name(&sg_param)
-        .send()
+    let security_groups: Vec<String> = read_ssm_parameter(&ssm_client, &sg_param)
         .await
-        .map_err(|e| {
-            anyhow!(
-                "Failed to get security groups from SSM parameter {}: {}",
-                sg_param,
-                e
-            )
-        })?
-        .parameter()
-        .and_then(|p| p.value())
-        .ok_or_else(|| anyhow!("No security groups value in SSM parameter"))?
+        .map_err(|e| anyhow!("Failed to get security groups: {}", e))?
         .split(',')
         .map(|s| s.trim().to_string())
         .collect();
@@ -1079,22 +1071,7 @@ pub async fn get_job_status_cross_account(
         region, environment
     );
 
-    let cluster = ssm_client
-        .get_parameter()
-        .name(&cluster_param_name)
-        .send()
-        .await
-        .map_err(|e| {
-            anyhow!(
-                "Failed to get SSM parameter {}: {:?}",
-                cluster_param_name,
-                e
-            )
-        })?
-        .parameter()
-        .and_then(|p| p.value())
-        .ok_or_else(|| anyhow!("SSM parameter {} has no value", cluster_param_name))?
-        .to_string();
+    let cluster = read_ssm_parameter(&ssm_client, &cluster_param_name).await?;
 
     let ecs_client = aws_sdk_ecs::Client::new(&assumed_config);
 

--- a/env_aws_direct/src/lib.rs
+++ b/env_aws_direct/src/lib.rs
@@ -65,7 +65,7 @@ pub use utils::{
 pub use direct_impl::{
     download_file_as_bytes_direct, download_file_as_string_direct, generate_presigned_url_direct,
     get_environment_variables_direct, get_job_status_cross_account, insert_db_direct,
-    publish_notification_direct, read_db_direct, read_logs_cross_account,
+    publish_notification_direct, read_config_parameter, read_db_direct, read_logs_cross_account,
     start_runner_cross_account, transact_write_direct, upload_file_base64_direct,
     upload_file_url_direct,
 };

--- a/env_azure_direct/src/lib.rs
+++ b/env_azure_direct/src/lib.rs
@@ -49,3 +49,13 @@ pub use http_auth::{call_authenticated_http, call_authenticated_http_with_creden
 pub use job_id::get_current_job_id;
 pub use provider::AzureCloudProvider;
 pub use utils::get_region;
+
+/// Provider-agnostic config-parameter reader counterpart to
+/// `env_aws_direct::read_config_parameter`. Wire this up to App Configuration
+/// or Key Vault when an Azure publish-auth path is needed; until then it
+/// fails closed so callers see a clear, actionable error.
+pub async fn read_config_parameter(_name: &str) -> Result<String, anyhow::Error> {
+    Err(anyhow::anyhow!(
+        "read_config_parameter is not implemented for the Azure backend"
+    ))
+}

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -613,6 +613,20 @@ pub fn get_region_env_var() -> &'static str {
     }
 }
 
+/// Provider-agnostic read of a configuration parameter (AWS SSM Parameter
+/// Store, Azure App Configuration / Key Vault, ...). Callers above the cloud
+/// boundary should use this instead of reaching into a specific SDK.
+pub async fn read_config_parameter(name: &str) -> Result<String, anyhow::Error> {
+    match provider_name().as_str() {
+        "aws" => env_aws_direct::read_config_parameter(name).await,
+        "azure" => env_azure_direct::read_config_parameter(name).await,
+        other => Err(anyhow::anyhow!(
+            "read_config_parameter is not supported for provider '{}'",
+            other
+        )),
+    }
+}
+
 fn provider_name() -> String {
     std::env::var("CLOUD_PROVIDER")
         .or_else(|_| std::env::var("PROVIDER"))

--- a/env_common/src/interface/mod.rs
+++ b/env_common/src/interface/mod.rs
@@ -5,7 +5,8 @@ mod mock_cloud_provider;
 mod no_cloud_provider;
 
 pub use cloud_handlers::{
-    get_region_env_var, initialize_project_id_and_region, GenericCloudHandler,
+    get_region_env_var, initialize_project_id_and_region, read_config_parameter,
+    GenericCloudHandler,
 };
 pub use deployment_status_handler::DeploymentStatusHandler;
 


### PR DESCRIPTION
Introduces a provider-agnostic interface for reading configuration parameters from cloud providers, enabling callers to fetch parameters without coupling to a specific cloud SDK. 

* Exposed `read_config_parameter` in the public API of `env_common::interface::mod.rs` for use by other crates.

AWS backend implementation:

* Implemented `read_config_parameter` in `env_aws_direct::direct_impl.rs` to fetch parameters from AWS SSM Parameter Store using the ambient AWS config, including error handling for missing or empty parameters.
* Exposed the new AWS implementation in the public API of `env_aws_direct::lib.rs`.

Azure backend placeholder:

* Added a stub implementation of `read_config_parameter` in `env_azure_direct::lib.rs` that returns a clear error message indicating the function is not yet implemented for Azure.