### PR TITLE
feat: authorize publishes with rego policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3937,6 +3937,7 @@ dependencies = [
  "integration-tests",
  "lambda_runtime",
  "log",
+ "regorus",
  "reqwest",
  "serde",
  "serde_json",

--- a/internal-api/Cargo.toml
+++ b/internal-api/Cargo.toml
@@ -31,6 +31,7 @@ futures = { workspace = true }
 base64 = { workspace = true }
 uuid = { workspace = true }
 axum = { workspace = true }
+regorus = "0.4.0"
 tower = "0.4"
 tower-http = { workspace = true, features = ["trace", "cors", "compression-gzip"] }
 urlencoding = { workspace = true }

--- a/internal-api/README.md
+++ b/internal-api/README.md
@@ -135,7 +135,9 @@ All routes return JSON. See [API_EXAMPLES.md](./API_EXAMPLES.md).
 
 Routes under `/api/v1/deployment*`, `/api/v1/deployments*`, `/api/v1/plan*`, `/api/v1/logs*`, `/api/v1/events*`, `/api/v1/change_record*`, `/api/v1/change_record_graph*`, `/api/v1/deployment_graph*`, `/api/v1/job_status*`, `/api/v1/provider/download`, and `/api/v1/claim/run` require project-level JWT authorization.
 
-Publish and deprecate routes (`/api/v1/module/publish`, `/api/v1/stack/publish`, `/api/v1/provider/publish`, and `*/deprecate`) require publish-level JWT authorization via the `custom:publish_permissions` claim.
+Publish and deprecate routes (`/api/v1/module/publish`, `/api/v1/stack/publish`, `/api/v1/provider/publish`, and `*/deprecate`) require publish-level JWT authorization. Publish rights are derived from CI/CD identity-provider claims (GitHub Actions OIDC today) and evaluated by the Rego publish policy.
+
+The full design, configuration reference, and GitHub OIDC examples for single-repo and monorepo layouts live in [src/publish_auth/README.md](src/publish_auth/README.md).
 
 **Deployments:**
 - `GET /api/v1/deployment/{project}/{region}/*rest`

--- a/internal-api/src/auth_handler.rs
+++ b/internal-api/src/auth_handler.rs
@@ -462,15 +462,6 @@ pub fn allowed_projects_claim_key() -> String {
         .unwrap_or_else(|_| "custom:allowed_projects".to_string())
 }
 
-/// Return the JWT claim key used for publish permissions.
-///
-/// Configurable via `AUTH_PUBLISH_PERMISSIONS_CLAIM` env var.
-/// Defaults to `custom:publish_permissions` for backward compatibility with Cognito.
-pub fn publish_permissions_claim_key() -> String {
-    std::env::var("AUTH_PUBLISH_PERMISSIONS_CLAIM")
-        .unwrap_or_else(|_| "custom:publish_permissions".to_string())
-}
-
 /// Return the ordered list of JWT claim keys to try when resolving user identity.
 ///
 /// Configurable via `AUTH_USERNAME_CLAIMS` env var (comma-separated).
@@ -533,16 +524,6 @@ mod tests {
         std::env::set_var("AUTH_ALLOWED_PROJECTS_CLAIM", "projects");
         assert_eq!(allowed_projects_claim_key(), "projects");
         std::env::remove_var("AUTH_ALLOWED_PROJECTS_CLAIM");
-    }
-
-    #[test]
-    fn test_publish_permissions_claim_key_default() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        std::env::remove_var("AUTH_PUBLISH_PERMISSIONS_CLAIM");
-        assert_eq!(
-            publish_permissions_claim_key(),
-            "custom:publish_permissions"
-        );
     }
 
     #[test]

--- a/internal-api/src/auth_handler_tests.rs
+++ b/internal-api/src/auth_handler_tests.rs
@@ -19,22 +19,6 @@ mod auth_handler_tests {
     }
 
     #[test]
-    fn test_publish_permissions_claim_key_default() {
-        std::env::remove_var("AUTH_PUBLISH_PERMISSIONS_CLAIM");
-        assert_eq!(
-            auth_handler::publish_permissions_claim_key(),
-            "custom:publish_permissions"
-        );
-    }
-
-    #[test]
-    fn test_publish_permissions_claim_key_custom() {
-        std::env::set_var("AUTH_PUBLISH_PERMISSIONS_CLAIM", "roles");
-        assert_eq!(auth_handler::publish_permissions_claim_key(), "roles");
-        std::env::remove_var("AUTH_PUBLISH_PERMISSIONS_CLAIM");
-    }
-
-    #[test]
     fn test_username_claim_keys_default() {
         std::env::remove_var("AUTH_USERNAME_CLAIMS");
         let keys = auth_handler::username_claim_keys();

--- a/internal-api/src/http_router.rs
+++ b/internal-api/src/http_router.rs
@@ -130,113 +130,138 @@ async fn auth_middleware(
             }
         }
     }
+
     next.run(request).await
 }
 
-/// Middleware that enforces publish permissions based on JWT claims.
+/// Middleware that enforces publish permissions with the Rego publish policy.
 ///
 /// Extracts the resource type from the URL path and the resource name from
 /// either path parameters (for deprecate) or the request body (for publish).
-/// Checks the `custom:publish_permissions` JWT claim for a matching pattern.
 async fn publish_auth_middleware(headers: HeaderMap, request: Request, next: Next) -> Response {
     let path = request.uri().path().to_string();
     let method = request.method().clone();
 
     // Determine resource type and name from the request
-    let (resource_type, resource_name) = if method == Method::PUT && path.contains("/deprecate") {
-        // Deprecate routes:
-        //   /api/v1/module/:track/:module/:version/deprecate
-        //   /api/v1/stack/:track/:stack/:version/deprecate
-        let segments: Vec<&str> = path.split('/').collect();
-        // segments: ["", "api", "v1", "module"|"stack", track, name, version, "deprecate"]
-        if segments.len() >= 6 {
-            let res_type = if segments[3] == "stack" {
-                "stack"
+    let (resource_type, resource_name, resource_track) =
+        if method == Method::PUT && path.contains("/deprecate") {
+            // Deprecate routes:
+            //   /api/v1/module/:track/:module/:version/deprecate
+            //   /api/v1/stack/:track/:stack/:version/deprecate
+            let segments: Vec<&str> = path.split('/').collect();
+            // segments: ["", "api", "v1", "module"|"stack", track, name, version, "deprecate"]
+            if segments.len() >= 6 {
+                let res_type = if segments[3] == "stack" {
+                    "stack"
+                } else {
+                    "module"
+                };
+                (
+                    res_type.to_string(),
+                    segments[5].to_string(),
+                    Some(segments[4].to_string()),
+                )
             } else {
-                "module"
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "error": "Invalid deprecate path" })),
+                )
+                    .into_response();
+            }
+        } else if method == Method::POST {
+            // Publish routes: read body to extract resource name
+            let (parts, body) = request.into_parts();
+            let bytes = match axum::body::to_bytes(body, 512 * 1024 * 1024).await {
+                Ok(b) => b,
+                Err(e) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": format!("Failed to read request body: {}", e) })),
+                    )
+                        .into_response();
+                }
             };
-            (res_type.to_string(), segments[5].to_string())
-        } else {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "error": "Invalid deprecate path" })),
-            )
-                .into_response();
-        }
-    } else if method == Method::POST {
-        // Publish routes: read body to extract resource name
-        let (parts, body) = request.into_parts();
-        let bytes = match axum::body::to_bytes(body, 512 * 1024 * 1024).await {
-            Ok(b) => b,
-            Err(e) => {
+
+            let body_json: Value = match serde_json::from_slice(&bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": format!("Invalid JSON body: {}", e) })),
+                    )
+                        .into_response();
+                }
+            };
+
+            let (res_type, res_name) = if path.contains("/module/publish") {
+                let name = body_json
+                    .get("module")
+                    .and_then(|m| m.get("module").or_else(|| m.get("module_name")))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                ("module".to_string(), name)
+            } else if path.contains("/stack/publish") {
+                let name = body_json
+                    .get("module")
+                    .and_then(|m| m.get("module").or_else(|| m.get("module_name")))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                ("stack".to_string(), name)
+            } else if path.contains("/provider/publish") {
+                let name = body_json
+                    .get("provider")
+                    .and_then(|p| p.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                ("provider".to_string(), name)
+            } else {
                 return (
                     StatusCode::BAD_REQUEST,
-                    Json(json!({ "error": format!("Failed to read request body: {}", e) })),
+                    Json(json!({ "error": "Unknown publish endpoint" })),
                 )
                     .into_response();
-            }
-        };
+            };
+            let track = body_json
+                .get("track")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .or_else(|| {
+                    body_json
+                        .get("module")
+                        .and_then(|m| m.get("track"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                });
 
-        let body_json: Value = match serde_json::from_slice(&bytes) {
-            Ok(v) => v,
-            Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({ "error": format!("Invalid JSON body: {}", e) })),
-                )
-                    .into_response();
+            // Reconstruct the request with the buffered body
+            let request = Request::from_parts(parts, axum::body::Body::from(bytes));
+            // Check permissions before continuing
+            if let Err(e) =
+                ensure_publish_access(&headers, &res_type, &res_name, track.as_deref()).await
+            {
+                return e.into_response();
             }
-        };
-
-        let (res_type, res_name) = if path.contains("/module/publish") {
-            let name = body_json
-                .get("module")
-                .and_then(|m| m.get("module").or_else(|| m.get("module_name")))
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            ("module".to_string(), name)
-        } else if path.contains("/stack/publish") {
-            let name = body_json
-                .get("module")
-                .and_then(|m| m.get("module").or_else(|| m.get("module_name")))
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            ("stack".to_string(), name)
-        } else if path.contains("/provider/publish") {
-            let name = body_json
-                .get("provider")
-                .and_then(|p| p.get("name"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
-                .to_string();
-            ("provider".to_string(), name)
+            return next.run(request).await;
         } else {
             return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "error": "Unknown publish endpoint" })),
+                StatusCode::METHOD_NOT_ALLOWED,
+                Json(json!({ "error": "Unsupported method for publish endpoint" })),
             )
                 .into_response();
         };
-
-        // Reconstruct the request with the buffered body
-        let request = Request::from_parts(parts, axum::body::Body::from(bytes));
-        // Check permissions before continuing
-        if let Err(e) = ensure_publish_access(&headers, &res_type, &res_name).await {
-            return e.into_response();
-        }
-        return next.run(request).await;
-    } else {
-        return (
-            StatusCode::METHOD_NOT_ALLOWED,
-            Json(json!({ "error": "Unsupported method for publish endpoint" })),
-        )
-            .into_response();
-    };
 
     // Check permissions (for non-POST paths like deprecate)
-    if let Err(e) = ensure_publish_access(&headers, &resource_type, &resource_name).await {
+    if let Err(e) = ensure_publish_access(
+        &headers,
+        &resource_type,
+        &resource_name,
+        resource_track.as_deref(),
+    )
+    .await
+    {
         return e.into_response();
     }
     next.run(request).await
@@ -360,7 +385,7 @@ pub fn create_router() -> Router {
             get(get_policy_version),
         );
 
-    // Routes that require publish permission (JWT custom:publish_permissions claim)
+    // Routes that require publish permission.
     let publish_protected_routes = Router::new()
         // Module deprecation route
         .route(
@@ -395,6 +420,10 @@ pub fn create_router() -> Router {
 /// upstream by the platform (API Gateway on AWS, or Azure App Service EasyAuth on Azure)
 /// before the request ever reaches this service.
 fn extract_jwt_claims(headers: &HeaderMap) -> Option<Value> {
+    if let Some(claims) = extract_verified_claims(headers) {
+        return Some(claims);
+    }
+
     let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok())?;
 
     // Remove "Bearer " prefix
@@ -423,6 +452,36 @@ fn extract_jwt_claims(headers: &HeaderMap) -> Option<Value> {
         Ok(claims) => Some(claims),
         Err(e) => {
             log::error!("Failed to parse JWT claims as JSON: {}", e);
+            None
+        }
+    }
+}
+
+fn extract_verified_claims(headers: &HeaderMap) -> Option<Value> {
+    let claims_header = headers
+        .get("x-infraweave-verified-claims")
+        .and_then(|v| v.to_str().ok())?;
+
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+    let payload_bytes = match URL_SAFE_NO_PAD.decode(claims_header) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            log::warn!(
+                "Failed to decode x-infraweave-verified-claims header: {}",
+                e
+            );
+            return None;
+        }
+    };
+
+    match serde_json::from_slice(&payload_bytes) {
+        Ok(claims) => Some(claims),
+        Err(e) => {
+            log::error!(
+                "Failed to parse x-infraweave-verified-claims as JSON: {}",
+                e
+            );
             None
         }
     }
@@ -489,118 +548,38 @@ async fn ensure_access(
     }
 }
 
-/// Check if any of the user's publish permission patterns authorize the given resource.
-///
-/// Patterns are comma-separated in the JWT publish permissions claim
-/// (configurable via `AUTH_PUBLISH_PERMISSIONS_CLAIM`, default: `custom:publish_permissions`).
-///
-/// Format: `{type}/{name_pattern}`
-///   - `*` alone grants access to publish anything
-///   - `module/{name}` grants access to publish a specific module (any track)
-///   - `module/eksaddon-*` grants access to publish any module starting with `eksaddon-`
-///   - `provider/{name}` grants access to publish a specific provider
-///   - `provider/*` grants access to publish any provider
-///
-/// Examples of publish permissions claim values:
-///   `module/s3bucket`                   → can only publish the s3bucket module
-///   `module/s3bucket,module/eksaddon-*` → can publish s3bucket and any eksaddon-* module
-///   `module/*,provider/*`               → can publish any module and any provider
-///   `*`                                 → can publish anything
-fn matches_publish_permission(
-    permissions: &[String],
-    resource_type: &str,
-    resource_name: &str,
-) -> bool {
-    for pattern in permissions {
-        let pattern = pattern.trim();
-
-        // Global wildcard
-        if pattern == "*" {
-            return true;
-        }
-
-        let parts: Vec<&str> = pattern.splitn(2, '/').collect();
-        if parts.len() != 2 {
-            continue;
-        }
-
-        let (pattern_type, pattern_name) = (parts[0], parts[1]);
-
-        // Type must match
-        if pattern_type != resource_type {
-            continue;
-        }
-
-        // Check name match with glob support
-        if pattern_name == "*" {
-            return true;
-        } else if pattern_name.ends_with('*') {
-            // Prefix glob: "eksaddon-*" matches "eksaddon-vpc", "eksaddon-iam", etc.
-            let prefix = &pattern_name[..pattern_name.len() - 1];
-            if resource_name.starts_with(prefix) {
-                return true;
-            }
-        } else if pattern_name == resource_name {
-            // Exact match
-            return true;
-        }
-    }
-    false
-}
-
 /// Ensure the authenticated user has permission to publish a specific resource.
 ///
-/// Authorization is based solely on the JWT publish permissions claim
-/// (a comma-separated list of patterns). If the claim is absent, access is denied.
-/// The claim key is configurable via `AUTH_PUBLISH_PERMISSIONS_CLAIM` env var
-/// (default: `custom:publish_permissions`).
+/// Authorization is handled by the configured identity-provider extractor and
+/// Rego publish policy (see [`crate::publish_auth`]).
 ///
 /// For CI/CD pipelines: configure the pipeline's identity in your identity provider
-/// with the appropriate publish permissions attribute,
-/// e.g. `module/s3bucket` to restrict that pipeline to only publishing the s3bucket module.
+/// so the Rego policy can derive the publish principal from trusted claims.
 async fn ensure_publish_access(
     headers: &HeaderMap,
     resource_type: &str,
     resource_name: &str,
+    track: Option<&str>,
 ) -> Result<(), (StatusCode, axum::response::Json<serde_json::Value>)> {
-    let resource_desc = format!("{}/{}", resource_type, resource_name);
+    let resource_desc = match track {
+        Some(track) => format!("{}/{}/{}", resource_type, resource_name, track),
+        None => format!("{}/{}", resource_type, resource_name),
+    };
 
-    if let Some(_user_id) = headers.get("x-auth-user").and_then(|v| v.to_str().ok()) {
-        // Check JWT claims for publish permissions (configurable via AUTH_PUBLISH_PERMISSIONS_CLAIM)
-        if let Some(claims) = extract_jwt_claims(headers) {
-            let claim_key = crate::auth_handler::publish_permissions_claim_key();
-            if let Some(perms_str) = claims.get(&claim_key).and_then(|v| v.as_str()) {
-                let permissions: Vec<String> = perms_str
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect();
-
-                if matches_publish_permission(&permissions, resource_type, resource_name) {
-                    log::info!("User authorized to publish {} via JWT claim", resource_desc);
-                    return Ok(());
-                } else {
-                    log::warn!("User denied publish access to {}", resource_desc,);
-                    return Err((
-                        StatusCode::FORBIDDEN,
-                        Json(json!({
-                            "error": format!(
-                                "You do not have permission to publish {}. Your publish_permissions ({}) do not match this resource. Contact your administrator to update your permissions.",
-                                resource_desc,
-                                perms_str
-                            )
-                        })),
-                    ));
-                }
-            }
+    if let Some(claims) = extract_verified_claims(headers) {
+        if crate::publish_auth::check_publish(&claims, resource_type, resource_name, track).await {
+            log::info!(
+                "User authorized to publish {} via Rego policy",
+                resource_desc
+            );
+            return Ok(());
         }
 
-        // No publish_permissions claim found at all → deny
-        log::warn!("User has no publish_permissions claim in JWT");
+        log::warn!("User has no matching publish grant for {}", resource_desc);
         Err((
             StatusCode::FORBIDDEN,
             Json(json!({
-                "error": "You do not have permission to publish. No publish_permissions claim found. Contact your administrator to configure publish access."
+                "error": format!("You do not have permission to publish {}. Configure AUTH_PUBLISH_REGO_POLICY_PARAMETER with the Rego publish policy.", resource_desc)
             })),
         ))
     } else {

--- a/internal-api/src/lib.rs
+++ b/internal-api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod handlers;
 pub mod http_router;
 #[cfg(feature = "local")]
 pub mod local_setup;
+mod publish_auth;
 mod queries;
 
 pub use common::CloudRuntime;

--- a/internal-api/src/main_aws_unified.rs
+++ b/internal-api/src/main_aws_unified.rs
@@ -113,8 +113,10 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
     // Add headers if present
     if let Some(headers) = payload.get("headers").and_then(|h| h.as_object()) {
         for (key, value) in headers {
-            // SECURITY: Do not allow client to inject the auth user header
-            if key.eq_ignore_ascii_case("x-auth-user") {
+            // SECURITY: Do not allow client to inject internal auth headers.
+            if key.eq_ignore_ascii_case("x-auth-user")
+                || key.eq_ignore_ascii_case("x-infraweave-verified-claims")
+            {
                 continue;
             }
             if let Some(val_str) = value.as_str() {
@@ -132,7 +134,7 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
         );
 
         // First try JWT claims (for IdP-authenticated requests)
-        let (maybe_user, maybe_allowed_projects) = request_context
+        let (maybe_user, maybe_allowed_projects, maybe_claims) = request_context
             .get("authorizer")
             .map(|auth| {
                 // Handle both direct claims and nested jwt.claims
@@ -161,9 +163,9 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
                     c.get(&claim_key).and_then(|v| v.as_str())
                 });
 
-                (user, allowed_projects)
+                (user, allowed_projects, claims.cloned())
             })
-            .unwrap_or((None, None));
+            .unwrap_or((None, None, None));
 
         if let Some(user) = maybe_user {
             info!("Authenticated user (JWT): {}", user);
@@ -179,6 +181,17 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
                     allowed_projects
                 );
                 request_builder = request_builder.header("x-allowed-projects", allowed_projects);
+            }
+
+            if let Some(claims) = maybe_claims {
+                use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+                let claims_json = serde_json::to_vec(&claims)
+                    .map_err(|e| Error::from(format!("Failed to serialize JWT claims: {}", e)))?;
+                request_builder = request_builder.header(
+                    "x-infraweave-verified-claims",
+                    URL_SAFE_NO_PAD.encode(claims_json),
+                );
             }
         } else {
             // Try IAM authentication (for IAM-signed requests to token bridge)

--- a/internal-api/src/main_azure_unified.rs
+++ b/internal-api/src/main_azure_unified.rs
@@ -13,8 +13,9 @@ use axum::response::Response;
 async fn normalize_azure_headers(mut req: Request, next: Next) -> Response {
     let headers = req.headers_mut();
 
-    // 1. SECURITY: Remove any client-supplied 'x-auth-user' to prevent spoofing
+    // 1. SECURITY: Remove any client-supplied internal auth headers to prevent spoofing.
     headers.remove("x-auth-user");
+    headers.remove("x-infraweave-verified-claims");
 
     // 2. Extract Azure App Service Authentication Header
     // 'X-MS-CLIENT-PRINCIPAL-NAME' typically contains the user's email/login

--- a/internal-api/src/publish_auth/README.md
+++ b/internal-api/src/publish_auth/README.md
@@ -1,0 +1,257 @@
+# Publish authorization
+
+Provider-agnostic publish authorization that extracts trusted identity facts
+from JWT claims and asks a Rego policy whether the caller may publish a
+specific resource (`module`, `stack`, `provider`, `policy`) to a specific
+track (`stable`, `rc`, `beta`, `alpha`, `dev`).
+
+It is the only publish authorization path in
+[`http_router::ensure_publish_access`](../http_router.rs). If the policy
+parameter is unset, identity extraction fails, or the Rego policy denies the
+request, publishes are denied.
+
+## Model
+
+The provider is auto-detected from the JWT `iss` claim, which is verified
+upstream during JWT validation. GitHub Actions tokens
+(`iss == https://token.actions.githubusercontent.com`) route to the
+first-class `github_oidc` extractor; every other issuer falls through to the
+generic `raw` extractor, where the raw verified claims are exposed for Rego
+to interpret. AWS IAM identities are also passed through `raw` facts. Rust
+does not choose the authorizing actor; the Rego policy chooses which fact is
+authoritative.
+
+For GitHub Actions OIDC, the single provider is `github_oidc`. It exposes
+facts that work for both one-repo-per-resource layouts and monorepos:
+
+| Field | Meaning | GitHub OIDC mapping |
+|---|---|---|
+| `repository` | full repository | `owner/name` |
+| `repository_name` | repository without owner | e.g. `tf-module-s3bucket` |
+| `repository_owner` | organizational boundary | e.g. `infraweave-io` |
+| `ref` | qualifier that gates which tracks may be published | `ref` or `:ref:` segment of `sub` |
+| `workflow_ref` | workflow reference, when present | `job_workflow_ref` |
+| `workflow_name` | workflow filename stem, when present | e.g. `publish-module-s3bucket` |
+| `environment` | GitHub Environment, when present | e.g. `publish-module-s3bucket` |
+
+For other OIDC providers and non-OIDC identities, use `raw`:
+
+| Field | Meaning | Mapping |
+|---|---|---|
+| `claims` | raw trusted facts object | raw JWT claims, AWS IAM facts, etc. |
+| `issuer` | issuer alias | `iss` |
+| `subject` | subject alias | `sub` |
+| `audience` | audience alias | `aud` |
+
+The Rego policy then:
+
+1. Pins the tenant via `identity.repository_owner == tenant` so a token from
+   another org with a matching repo name cannot publish here.
+2. Chooses an actor, e.g. `identity.repository_name`,
+   `identity.workflow_name`, or `identity.environment`.
+3. Looks up the actor prefix for the requested resource type and strips it
+   from the actor. The remainder must equal the requested resource name.
+4. If the resource type is in `track_exempt_types` (default: `provider`),
+   allow.
+5. Otherwise, allow iff `request.track` is in the trusted or untrusted set,
+   selected by `identity.ref == trusted_context`.
+
+Source: [`mod.rs`](mod.rs).
+
+## Configuration
+
+Enable by pointing at the cloud parameter that holds the Rego policy. Without
+this the rule is off and all publishes are denied. The provider is detected
+automatically from the JWT `iss` claim - no provider env var.
+
+| Variable | Description | Default |
+|---|---|---|
+| `AUTH_PUBLISH_REGO_POLICY_PARAMETER` | Cloud parameter name containing the raw Rego policy source (AWS SSM Parameter Store, Azure App Configuration, ...) | *(disabled when unset)* |
+| `AUTH_PUBLISH_REGO_POLICY_CACHE_TTL_SECONDS` | Warm-process policy cache TTL | `300` |
+
+The actual read is delegated to `env_common::interface::read_config_parameter`,
+which dispatches to the active cloud backend - internal-api itself has no
+cloud SDK dependency.
+
+All authorization policy choices live in Rego. Do not configure tenant,
+actor prefixes, track sets, track exemptions, repository pins, or monorepo
+mode through env vars; update the hosted Rego policy instead so there is a
+single source of truth. If the policy is not already cached and the parameter
+cannot be read, publishes fail closed.
+
+The API passes Rego an input with two top-level fields:
+
+```json
+{
+  "identity": {
+    "provider": "github_oidc",
+    "repository": "infraweave-io/modules",
+    "repository_name": "modules",
+    "repository_owner": "infraweave-io",
+    "ref": "refs/heads/main",
+    "workflow_ref": "infraweave-io/modules/.github/workflows/publish-module-s3bucket.yml@refs/heads/main",
+    "workflow_name": "publish-module-s3bucket",
+    "environment": "publish-module-s3bucket"
+  },
+  "request": {
+    "action": "publish",
+    "resource_type": "module",
+    "resource_name": "s3bucket",
+    "track": "stable"
+  }
+}
+```
+
+Default policies should use only `identity` and `request`.
+
+## Policy Examples
+
+The API does not install a bundled default publish policy. It reads the active
+policy from `AUTH_PUBLISH_REGO_POLICY_PARAMETER`; without that setting,
+publishes are denied.
+
+A common GitHub OIDC policy is intentionally small and covers one convention:
+one repo per publishable resource.
+
+| Resource type | Repository prefix |
+|---|---|
+| `module` | `tf-module-` |
+| `stack` | `tf-stack-` |
+| `provider` | `tf-provider-` |
+| `policy` | `tf-policy-` |
+
+Provider-specific examples live as separate policy files so each one mirrors
+a single raw policy you could store in SSM. They are bundled into the Rust
+test suite via `include_str!`, so renaming an identity fact in Rust without
+updating the example will fail `cargo test`.
+
+Example alternatives:
+
+| Policy | Use case |
+|---|---|
+| [`github_oidc.rego`](github_oidc.rego) | GitHub Actions OIDC through `github_oidc` |
+| [`aws_iam_raw.rego`](aws_iam_raw.rego) | AWS IAM through `raw` |
+| [`jwt_user_raw.rego`](jwt_user_raw.rego) | Human/admin JWT users through `raw` |
+
+## Defense In Depth
+
+This rule is the application-layer check. Sitting in front of it should be
+an AWS IAM trust policy on the publish-caller role that only lets the right
+GitHub workflows assume the role in the first place. IAM grants access to
+call the API; this rule decides what the call may do.
+
+For one-repo-per-resource layouts, an IAM trust policy can allow
+`repo:infraweave-io/tf-*:*`, and Rego maps `identity.repository_name` to the
+resource.
+
+For monorepos, an IAM trust policy should pin the repo, for example
+`repo:infraweave-io/modules:*`. Then Rego should also pin
+`identity.repository == "infraweave-io/modules"` and use a GitHub-set scoping
+fact such as `workflow_name` or `environment`.
+
+## Provider: `github_oidc`
+
+Source: [`github_oidc.rs`](github_oidc.rs).
+
+Maps GitHub Actions OIDC claims onto identity facts:
+
+- `repository`
+- `repository_name`
+- `repository_owner`
+- `ref`
+- `workflow_ref`
+- `workflow_name`
+- `environment`
+
+### One Repo Per Resource
+
+Setup:
+
+```bash
+AUTH_PUBLISH_REGO_POLICY_PARAMETER=/infraweave/prod/publish-auth-rego
+```
+
+The default Rego policy uses `identity.repository_name` as the actor. A repo
+named `infraweave-io/tf-module-s3bucket` can publish `module/s3bucket`; it
+cannot publish `module/eks` or `stack/webapp`. A trusted ref
+(`refs/heads/main` by default) can publish release tracks, while other refs
+can publish only `dev`.
+
+The example pins the GitHub organization with a top-level
+`tenant := "infraweave-io"` constant. Replace it with your own organization
+before deploying.
+
+### Monorepo
+
+Same configuration - the provider is still auto-detected as `github_oidc`:
+
+```bash
+AUTH_PUBLISH_REGO_POLICY_PARAMETER=/infraweave/prod/publish-auth-rego
+```
+
+In Rego, use `identity.workflow_name` or `identity.environment` as the actor.
+For example, a workflow file named `publish-module-s3bucket.yml` can map to
+`module/s3bucket` by stripping the `publish-module-` prefix. Pair workflow
+scoping with `CODEOWNERS` on `.github/workflows/`; pair environment scoping
+with GitHub Environment required reviewers and branch restrictions.
+
+Always pin the expected monorepo in Rego:
+
+```rego
+input.identity.repository == "infraweave-io/modules"
+```
+
+## Provider: `raw`
+
+Use `raw` when the caller comes from AWS IAM, a human/admin JWT issuer, or
+anything else that is not worth hard-coding in Rust.
+
+Setup:
+
+```bash
+AUTH_PUBLISH_REGO_POLICY_PARAMETER=/infraweave/prod/publish-auth-rego
+```
+
+The provider is auto-detected as `raw` whenever the JWT `iss` claim is
+anything other than the GitHub Actions issuer. AWS IAM publish checks also
+use `raw`.
+
+The input shape is still `identity` and `request`, but provider-specific
+claims stay under `identity.claims`:
+
+```json
+{
+  "identity": {
+    "provider": "raw",
+    "issuer": "https://issuer.example.com",
+    "subject": "user-123",
+    "claims": {
+      "email": "alice@example.com"
+    }
+  },
+  "request": {
+    "action": "publish",
+    "resource_type": "module",
+    "resource_name": "s3bucket",
+    "track": "stable"
+  }
+}
+```
+
+The Rego policy should pin the issuer and interpret whatever claims that
+issuer guarantees.
+
+For AWS IAM, a full example lives in [`aws_iam_raw.rego`](aws_iam_raw.rego).
+It shows how to match either an STS assumed-role ARN normalized to an IAM
+role ARN, or the role-id prefix from API Gateway's IAM `userId`.
+
+For human/admin JWT users, [`jwt_user_raw.rego`](jwt_user_raw.rego) shows an
+email allow-list based on `identity.email`, with `identity.subject` available
+as a fallback when an issuer does not provide stable email claims.
+
+## Adding Another Provider
+
+Start with `raw` for non-GitHub identities. Add a first-class provider
+module only when repeated policies would benefit from stable aliases or
+careful parsing in Rust. The Rego input shape stays the same; add any
+provider-specific facts and rules to the Rego policy.

--- a/internal-api/src/publish_auth/aws_iam_raw.rego
+++ b/internal-api/src/publish_auth/aws_iam_raw.rego
@@ -1,0 +1,50 @@
+package infraweave.publish
+
+import rego.v1
+
+default allow := false
+
+# Expected input shape:
+#
+# {
+#   "identity": {
+#     "provider": "raw",
+#     "claims": {
+#       "aws_iam_arn": "arn:aws:sts::123456789012:assumed-role/AdminRole/alice@example.com",
+#       "aws_iam_user_id": "AROAEXAMPLE123456:alice@example.com"
+#     }
+#   },
+#   "request": {
+#     "action": "publish",
+#     "resource_type": "module",
+#     "resource_name": "s3bucket",
+#     "track": "stable"
+#   }
+# }
+
+admin_aws_role_arns := set()
+
+admin_aws_role_ids := set()
+
+allow if {
+	input.identity.provider == "raw"
+	admin_aws_role_arns[aws_assumed_role_arn]
+}
+
+allow if {
+	input.identity.provider == "raw"
+	admin_aws_role_ids[aws_assumed_role_id]
+}
+
+aws_assumed_role_arn := sprintf("arn:aws:iam::%s:role/%s", [account_id, role_name]) if {
+	arn := input.identity.claims.aws_iam_arn
+	parts := split(arn, ":")
+	parts[2] == "sts"
+	account_id := parts[4]
+	resource := parts[5]
+	resource_parts := split(resource, "/")
+	resource_parts[0] == "assumed-role"
+	role_name := resource_parts[1]
+}
+
+aws_assumed_role_id := split(input.identity.claims.aws_iam_user_id, ":")[0]

--- a/internal-api/src/publish_auth/github_oidc.rego
+++ b/internal-api/src/publish_auth/github_oidc.rego
@@ -1,0 +1,103 @@
+package infraweave.publish
+
+import rego.v1
+
+# GitHub Actions OIDC — one repo per publishable resource.
+#
+# Convention:
+#   tf-module-<name>   -> module/<name>
+#   tf-stack-<name>    -> stack/<name>
+#   tf-provider-<name> -> provider/<name>
+#   tf-policy-<name>   -> policy/<name>
+#
+# Publishes from the trusted ref (refs/heads/main) may target trusted tracks
+# (stable/rc/beta/alpha). Publishes from any other ref may target only `dev`.
+# `provider` is exempt from track gating.
+#
+# Defense in depth: pair this with an IAM trust policy that only lets the
+# expected GitHub repos assume the publish role. For monorepos or extra
+# hardening (pinning `workflow_ref`, `workflow_name`, or `environment`), see
+# the README in this directory.
+#
+# Expected input shape:
+#
+# {
+#   "identity": {
+#     "provider": "github_oidc",
+#     "repository": "infraweave-io/tf-module-s3bucket",
+#     "repository_name": "tf-module-s3bucket",
+#     "repository_owner": "infraweave-io",
+#     "ref": "refs/heads/main",
+#     "workflow_ref": "infraweave-io/tf-module-s3bucket/.github/workflows/publish.yml@refs/heads/main",
+#     "workflow_name": "publish",
+#     "environment": "publish"
+#   },
+#   "request": {
+#     "action": "publish",
+#     "resource_type": "module",
+#     "resource_name": "s3bucket",
+#     "track": "stable"
+#   }
+# }
+
+default allow := false
+
+# Replace with your GitHub organization. Pinning the tenant prevents a token
+# from another org with a matching repo name from publishing here.
+tenant := "infraweave-io"
+
+actor_prefixes := {
+	"module": "tf-module-",
+	"stack": "tf-stack-",
+	"provider": "tf-provider-",
+	"policy": "tf-policy-",
+}
+
+trusted_context := "refs/heads/main"
+
+trusted_tracks := {"stable", "rc", "beta", "alpha"}
+
+untrusted_tracks := {"dev"}
+
+track_exempt_types := {"provider"}
+
+allow if {
+	input.identity.provider == "github_oidc"
+	tenant_matches
+	actor_matches_resource
+	track_allowed
+}
+
+tenant_matches if {
+	input.identity.repository_owner == tenant
+}
+
+# The "actor" is the identity fact that maps to a publishable resource. Here
+# the actor is the repository name; swap for `workflow_name` or `environment`
+# in a monorepo. See the README.
+actor_matches_resource if {
+	actor := input.identity.repository_name
+	prefix := actor_prefixes[input.request.resource_type]
+	startswith(actor, prefix)
+	resource_name := substring(actor, count(prefix), -1)
+	resource_name != ""
+	resource_name == input.request.resource_name
+}
+
+track_allowed if {
+	track_exempt_types[input.request.resource_type]
+}
+
+track_allowed if {
+	track := object.get(input.request, "track", "")
+	track != ""
+	allowed_tracks[track]
+}
+
+allowed_tracks := trusted_tracks if {
+	object.get(input.identity, "ref", "") == trusted_context
+}
+
+allowed_tracks := untrusted_tracks if {
+	object.get(input.identity, "ref", "") != trusted_context
+}

--- a/internal-api/src/publish_auth/github_oidc.rs
+++ b/internal-api/src/publish_auth/github_oidc.rs
@@ -1,0 +1,173 @@
+//! GitHub Actions OIDC extractor.
+//!
+//! Maps GitHub OIDC claims onto trusted identity facts:
+//! - `repository`
+//! - `repository_name` (repository without owner)
+//! - `repository_owner` (fallback: owner from `repository`)
+//! - `ref` (or `:ref:` segment of `sub`)
+//! - `workflow_ref` / `workflow_name` when `job_workflow_ref` is present
+//! - `environment` when present
+
+use serde_json::Value;
+
+use super::PublishIdentity;
+
+pub(super) fn extract(claims: &Value) -> Option<PublishIdentity> {
+    let repository = claims.get("repository").and_then(|v| v.as_str())?;
+    let (owner, name) = repository.split_once('/')?;
+    if name.is_empty() {
+        return None;
+    }
+
+    let context = claims
+        .get("ref")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            claims
+                .get("sub")
+                .and_then(|v| v.as_str())
+                .and_then(|sub| sub.split_once(":ref:").map(|(_, r)| r.to_string()))
+        });
+
+    let tenant = claims
+        .get("repository_owner")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| owner.to_string());
+
+    let mut facts = serde_json::Map::new();
+    copy_claim(claims, &mut facts, "iss", "issuer");
+    facts.insert(
+        "repository".to_string(),
+        Value::String(repository.to_string()),
+    );
+    facts.insert(
+        "repository_name".to_string(),
+        Value::String(name.to_string()),
+    );
+    facts.insert("repository_owner".to_string(), Value::String(tenant));
+    if let Some(context) = context {
+        facts.insert("ref".to_string(), Value::String(context));
+    }
+    if let Some(workflow_name) = workflow_name_from_claims(claims) {
+        facts.insert("workflow_name".to_string(), Value::String(workflow_name));
+    }
+    copy_claim(claims, &mut facts, "job_workflow_ref", "workflow_ref");
+    copy_claim(claims, &mut facts, "environment", "environment");
+
+    Some(PublishIdentity { facts })
+}
+
+/// `job_workflow_ref` looks like
+/// `org/repo/.github/workflows/publish-s3bucket.yml@refs/heads/main`.
+/// We expose the filename stem as `workflow_name`.
+fn workflow_name_from_claims(claims: &Value) -> Option<String> {
+    let raw = claims.get("job_workflow_ref").and_then(|v| v.as_str())?;
+    let path = raw.split('@').next()?;
+    let file = path.rsplit('/').next()?;
+    let stem = file
+        .strip_suffix(".yml")
+        .or_else(|| file.strip_suffix(".yaml"))
+        .unwrap_or(file);
+    if stem.is_empty() {
+        None
+    } else {
+        Some(stem.to_string())
+    }
+}
+
+fn copy_claim(
+    claims: &Value,
+    target: &mut serde_json::Map<String, Value>,
+    claim_key: &str,
+    target_key: &str,
+) {
+    if let Some(value) = claims.get(claim_key) {
+        target.insert(target_key.to_string(), value.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::IdentityProvider;
+    use serde_json::json;
+    use serde_json::Value;
+
+    #[test]
+    fn maps_repo_to_identity_facts() {
+        let claims = json!({
+            "repository": "infraweave-io/tf-module-s3bucket",
+            "ref": "refs/heads/main",
+            "repository_owner": "infraweave-io"
+        });
+        let id = IdentityProvider::GitHubOidc.extract(&claims).unwrap();
+        assert_eq!(
+            id.facts.get("repository_name").and_then(Value::as_str),
+            Some("tf-module-s3bucket")
+        );
+        assert_eq!(
+            id.facts.get("ref").and_then(Value::as_str),
+            Some("refs/heads/main")
+        );
+        assert_eq!(
+            id.facts.get("repository_owner").and_then(Value::as_str),
+            Some("infraweave-io")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_sub_for_ref() {
+        let claims = json!({
+            "repository": "infraweave-io/tf-module-s3bucket",
+            "sub": "repo:infraweave-io/tf-module-s3bucket:ref:refs/heads/feature"
+        });
+        let id = IdentityProvider::GitHubOidc.extract(&claims).unwrap();
+        assert_eq!(
+            id.facts.get("ref").and_then(Value::as_str),
+            Some("refs/heads/feature")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_owner_from_repository_when_owner_claim_missing() {
+        let claims = json!({
+            "repository": "infraweave-io/tf-module-s3bucket",
+            "ref": "refs/heads/main"
+        });
+        let id = IdentityProvider::GitHubOidc.extract(&claims).unwrap();
+        assert_eq!(
+            id.facts.get("repository_owner").and_then(Value::as_str),
+            Some("infraweave-io")
+        );
+    }
+
+    #[test]
+    fn rejects_repository_without_slash() {
+        let claims = json!({ "repository": "no-slash", "ref": "refs/heads/main" });
+        assert!(IdentityProvider::GitHubOidc.extract(&claims).is_none());
+    }
+
+    #[test]
+    fn exposes_workflow_and_environment_facts_when_present() {
+        let claims = json!({
+            "repository": "infraweave-io/modules",
+            "ref": "refs/heads/main",
+            "job_workflow_ref": "infraweave-io/modules/.github/workflows/publish-module-s3bucket.yaml@refs/heads/main",
+            "environment": "publish-module-s3bucket"
+        });
+        let id = IdentityProvider::GitHubOidc.extract(&claims).unwrap();
+        assert_eq!(
+            id.facts.get("workflow_name").and_then(Value::as_str),
+            Some("publish-module-s3bucket")
+        );
+        assert_eq!(
+            id.facts.get("workflow_ref").and_then(Value::as_str),
+            Some("infraweave-io/modules/.github/workflows/publish-module-s3bucket.yaml@refs/heads/main")
+        );
+        assert_eq!(
+            id.facts.get("environment").and_then(Value::as_str),
+            Some("publish-module-s3bucket")
+        );
+    }
+}

--- a/internal-api/src/publish_auth/jwt_user_raw.rego
+++ b/internal-api/src/publish_auth/jwt_user_raw.rego
@@ -1,0 +1,66 @@
+package infraweave.publish
+
+import rego.v1
+
+default allow := false
+
+# Expected input shape:
+#
+# {
+#   "identity": {
+#     "provider": "raw",
+#     "issuer": "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_example",
+#     "email": "alice@example.com",
+#     "subject": "00000000-0000-0000-0000-000000000000",
+#     "claims": {
+#       "sub": "00000000-0000-0000-0000-000000000000",
+#       "email": "alice@example.com",
+#       "identities": [
+#         {
+#           "providerName": "IdentityCenter",
+#           "userId": "alice@example.com"
+#         }
+#       ],
+#       "custom:allowed_projects": "123456789012"
+#     }
+#   },
+#   "request": {
+#     "action": "publish",
+#     "resource_type": "module",
+#     "resource_name": "s3bucket",
+#     "track": "stable"
+#   }
+# }
+
+admin_jwt_emails := set()
+
+admin_jwt_usernames := set()
+
+admin_jwt_subjects := set()
+
+allow if {
+	input.identity.provider == "raw"
+	admin_jwt_emails[lower(input.identity.email)]
+}
+
+allow if {
+	input.identity.provider == "raw"
+	admin_jwt_emails[lower(input.identity.claims.email)]
+}
+
+allow if {
+	input.identity.provider == "raw"
+	admin_jwt_usernames[input.identity.claims["cognito:username"]]
+}
+
+allow if {
+	input.identity.provider == "raw"
+	identity := input.identity.claims.identities[_]
+	identity.providerName == "IdentityCenter"
+	admin_jwt_emails[lower(identity.userId)]
+}
+
+allow if {
+	input.identity.provider == "raw"
+	admin_jwt_subjects[input.identity.subject]
+}

--- a/internal-api/src/publish_auth/mod.rs
+++ b/internal-api/src/publish_auth/mod.rs
@@ -1,0 +1,335 @@
+//! Provider-agnostic publish authorization.
+//!
+//! The model has two pieces, deliberately decoupled from any specific
+//! identity provider (GitHub, GitLab, ...):
+//!
+//! 1. [`PublishIdentity`] - trusted identity facts extracted from JWT claims.
+//! 2. [`IdentityProvider`] - knows how to fill a [`PublishIdentity`] from a
+//!    provider's claim shape. First-class providers live in their own
+//!    submodules (e.g. [`github_oidc`]); everything else falls back to [`raw`].
+//! 3. Rego policy - receives `identity` and `request` input and returns the
+//!    publish allow/deny decision.
+//!
+//! The active provider is auto-detected from the JWT `iss` claim. The rule is
+//! enabled by setting `AUTH_PUBLISH_REGO_POLICY_PARAMETER` to the cloud
+//! parameter name (AWS SSM Parameter Store, Azure App Configuration, ...)
+//! holding the Rego policy; without it, publishes are denied. The actual read
+//! is delegated to `env_common::interface::read_config_parameter` so that
+//! internal-api stays provider-agnostic.
+
+mod github_oidc;
+mod raw;
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex, OnceLock},
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishIdentity {
+    pub facts: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityProvider {
+    /// GitHub Actions OIDC. Exposes trusted GitHub facts; Rego decides which
+    /// fact is authoritative for the requested publish operation.
+    GitHubOidc,
+    /// Generic raw fallback. Exposes trusted facts to Rego without
+    /// provider-specific parsing.
+    Raw,
+}
+
+/// Issuer URL for GitHub Actions OIDC tokens. The `iss` claim is verified
+/// upstream during JWT validation, so it is safe to use for provider routing.
+const GITHUB_ACTIONS_ISSUER: &str = "https://token.actions.githubusercontent.com";
+
+impl IdentityProvider {
+    /// Pick a provider from the JWT `iss` claim. GitHub Actions tokens route to
+    /// the first-class extractor; everything else falls through to the raw
+    /// extractor, where the Rego policy is expected to pin the relevant facts.
+    pub fn detect(claims: &Value) -> Self {
+        let issuer = claims.get("iss").and_then(|v| v.as_str()).unwrap_or("");
+        if issuer == GITHUB_ACTIONS_ISSUER {
+            Self::GitHubOidc
+        } else {
+            Self::Raw
+        }
+    }
+
+    pub fn extract(&self, claims: &Value) -> Option<PublishIdentity> {
+        match self {
+            Self::GitHubOidc => github_oidc::extract(claims),
+            Self::Raw => raw::extract(claims),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::GitHubOidc => "github_oidc",
+            Self::Raw => "raw",
+        }
+    }
+}
+
+/// Top-level entry: auto-detect the provider from claims, then evaluate the
+/// Rego policy. Returns `false` if the policy SSM parameter is unset, claims
+/// don't yield an identity, or policy evaluation fails.
+pub async fn check_publish(
+    claims: &Value,
+    resource_type: &str,
+    resource_name: &str,
+    track: Option<&str>,
+) -> bool {
+    if std::env::var("AUTH_PUBLISH_REGO_POLICY_PARAMETER").is_err() {
+        return false;
+    }
+    let provider = IdentityProvider::detect(claims);
+    let Some(identity) = provider.extract(claims) else {
+        log::warn!(
+            "Publish auth denied: provider={} did not yield an identity",
+            provider.as_str()
+        );
+        return false;
+    };
+
+    match check_publish_with_rego(&provider, &identity, resource_type, resource_name, track).await {
+        Ok(allowed) => {
+            if !allowed {
+                log_publish_denial(&provider, &identity, resource_type, resource_name, track);
+            }
+            allowed
+        }
+        Err(e) => {
+            log::warn!("Failed to evaluate publish Rego policy: {}", e);
+            false
+        }
+    }
+}
+
+fn log_publish_denial(
+    provider: &IdentityProvider,
+    identity: &PublishIdentity,
+    resource_type: &str,
+    resource_name: &str,
+    track: Option<&str>,
+) {
+    let email = identity.facts.get("email").and_then(Value::as_str);
+    let claims_email = identity
+        .facts
+        .get("claims")
+        .and_then(|claims| claims.get("email"))
+        .and_then(Value::as_str);
+    let identity_center_user_id = identity
+        .facts
+        .get("claims")
+        .and_then(|claims| claims.get("identities"))
+        .and_then(Value::as_array)
+        .and_then(|identities| {
+            identities.iter().find_map(|identity| {
+                let provider_name = identity.get("providerName").and_then(Value::as_str)?;
+                if provider_name == "IdentityCenter" {
+                    identity.get("userId").and_then(Value::as_str)
+                } else {
+                    None
+                }
+            })
+        });
+    let subject_present = identity.facts.get("subject").is_some();
+    let parameter_name =
+        std::env::var("AUTH_PUBLISH_REGO_POLICY_PARAMETER").unwrap_or_else(|_| "<unset>".into());
+
+    log::warn!(
+        "Publish auth denied by Rego: provider={}, resource={}/{}/{}, email_present={}, claims_email_present={}, identity_center_user_id_present={}, subject_present={}, policy_parameter={}",
+        provider.as_str(),
+        resource_type,
+        resource_name,
+        track.unwrap_or("-"),
+        email.is_some(),
+        claims_email.is_some(),
+        identity_center_user_id.is_some(),
+        subject_present,
+        parameter_name
+    );
+}
+
+async fn check_publish_with_rego(
+    provider: &IdentityProvider,
+    identity: &PublishIdentity,
+    resource_type: &str,
+    resource_name: &str,
+    track: Option<&str>,
+) -> Result<bool> {
+    let mut engine = regorus::Engine::new();
+    engine.add_policy(
+        "publish_auth.rego".to_string(),
+        publish_rego_policy().await?,
+    )?;
+    engine.set_input(json_to_rego_value(&publish_rego_input(
+        provider,
+        identity,
+        resource_type,
+        resource_name,
+        track,
+    ))?);
+
+    let result = engine.eval_query("data.infraweave.publish.allow".to_string(), false)?;
+    let Some(result) = result.result.first() else {
+        return Ok(false);
+    };
+    let Some(expression) = result.expressions.first() else {
+        return Ok(false);
+    };
+
+    match &expression.value {
+        regorus::Value::Bool(allowed) => Ok(*allowed),
+        other => Err(anyhow!(
+            "publish policy returned non-boolean allow value: {:?}",
+            other
+        )),
+    }
+}
+
+#[derive(Clone)]
+struct CachedPolicy {
+    parameter_name: String,
+    policy: String,
+    expires_at: Instant,
+}
+
+static POLICY_CACHE: OnceLock<Mutex<Option<CachedPolicy>>> = OnceLock::new();
+
+async fn publish_rego_policy() -> Result<String> {
+    let parameter_name = std::env::var("AUTH_PUBLISH_REGO_POLICY_PARAMETER")
+        .map_err(|_| anyhow!("AUTH_PUBLISH_REGO_POLICY_PARAMETER must be set"))?;
+
+    if let Some(policy) = cached_policy(&parameter_name)? {
+        return Ok(policy);
+    }
+
+    let policy = env_common::interface::read_config_parameter(&parameter_name)
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "failed to read publish Rego policy parameter '{}': {}",
+                parameter_name,
+                e
+            )
+        })?;
+    if policy.trim().is_empty() {
+        return Err(anyhow!(
+            "publish Rego policy parameter '{}' is empty",
+            parameter_name
+        ));
+    }
+    cache_policy(parameter_name, policy.clone())?;
+    Ok(policy)
+}
+
+fn policy_cache() -> &'static Mutex<Option<CachedPolicy>> {
+    POLICY_CACHE.get_or_init(|| Mutex::new(None))
+}
+
+fn cached_policy(parameter_name: &str) -> Result<Option<String>> {
+    let cache = policy_cache()
+        .lock()
+        .map_err(|_| anyhow!("publish policy cache mutex poisoned"))?;
+
+    let Some(cached) = cache.as_ref() else {
+        return Ok(None);
+    };
+
+    if cached.parameter_name == parameter_name && cached.expires_at > Instant::now() {
+        return Ok(Some(cached.policy.clone()));
+    }
+
+    Ok(None)
+}
+
+fn cache_policy(parameter_name: String, policy: String) -> Result<()> {
+    let mut cache = policy_cache()
+        .lock()
+        .map_err(|_| anyhow!("publish policy cache mutex poisoned"))?;
+    *cache = Some(CachedPolicy {
+        parameter_name,
+        policy,
+        expires_at: Instant::now() + policy_cache_ttl(),
+    });
+    Ok(())
+}
+
+fn policy_cache_ttl() -> Duration {
+    let seconds = std::env::var("AUTH_PUBLISH_REGO_POLICY_CACHE_TTL_SECONDS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(300);
+    Duration::from_secs(seconds)
+}
+
+fn publish_rego_input(
+    provider: &IdentityProvider,
+    identity: &PublishIdentity,
+    resource_type: &str,
+    resource_name: &str,
+    track: Option<&str>,
+) -> Value {
+    let mut identity_facts = serde_json::Map::new();
+    identity_facts.insert("provider".to_string(), serde_json::json!(provider.as_str()));
+    identity_facts.extend(identity.facts.clone());
+
+    let mut request = serde_json::Map::new();
+    request.insert("action".to_string(), serde_json::json!("publish"));
+    request.insert(
+        "resource_type".to_string(),
+        serde_json::json!(resource_type),
+    );
+    request.insert(
+        "resource_name".to_string(),
+        serde_json::json!(resource_name),
+    );
+    if let Some(track) = track {
+        request.insert("track".to_string(), serde_json::json!(track));
+    }
+
+    serde_json::json!({
+        "identity": identity_facts,
+        "request": request,
+    })
+}
+
+fn json_to_rego_value(json: &Value) -> Result<regorus::Value> {
+    match json {
+        Value::Null => Ok(regorus::Value::Null),
+        Value::Bool(b) => Ok(regorus::Value::Bool(*b)),
+        Value::Number(n) => {
+            let Some(f) = n.as_f64() else {
+                return Err(anyhow!("invalid JSON number for Rego input"));
+            };
+            Ok(regorus::Value::Number(f.into()))
+        }
+        Value::String(s) => Ok(regorus::Value::String(Arc::from(s.as_str()))),
+        Value::Array(arr) => {
+            let mut values = Vec::with_capacity(arr.len());
+            for value in arr {
+                values.push(json_to_rego_value(value)?);
+            }
+            Ok(regorus::Value::Array(Arc::new(values)))
+        }
+        Value::Object(obj) => {
+            let mut values = BTreeMap::new();
+            for (key, value) in obj {
+                values.insert(
+                    regorus::Value::String(Arc::from(key.as_str())),
+                    json_to_rego_value(value)?,
+                );
+            }
+            Ok(regorus::Value::Object(Arc::new(values)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/internal-api/src/publish_auth/raw.rs
+++ b/internal-api/src/publish_auth/raw.rs
@@ -1,0 +1,72 @@
+//! Raw identity extractor.
+//!
+//! This is the fallback for identities without a first-class extractor. It
+//! exposes trusted raw facts to Rego and does not try to infer provider
+//! semantics such as repository, project, workflow, actor names, or AWS roles.
+
+use serde_json::Value;
+
+use super::PublishIdentity;
+
+pub(super) fn extract(claims: &Value) -> Option<PublishIdentity> {
+    let claims_object = claims.as_object()?;
+
+    let mut facts = serde_json::Map::new();
+    facts.insert("claims".to_string(), Value::Object(claims_object.clone()));
+    copy_claim(claims, &mut facts, "iss", "issuer");
+    copy_claim(claims, &mut facts, "sub", "subject");
+    copy_claim(claims, &mut facts, "aud", "audience");
+    copy_claim(claims, &mut facts, "email", "email");
+
+    Some(PublishIdentity { facts })
+}
+
+fn copy_claim(
+    claims: &Value,
+    target: &mut serde_json::Map<String, Value>,
+    claim_key: &str,
+    target_key: &str,
+) {
+    if let Some(value) = claims.get(claim_key) {
+        target.insert(target_key.to_string(), value.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::IdentityProvider;
+    use serde_json::json;
+    use serde_json::Value;
+
+    #[test]
+    fn exposes_raw_claims_and_generic_aliases() {
+        let claims = json!({
+            "iss": "https://gitlab.com",
+            "sub": "project_path:infraweave/modules:ref_type:branch:ref:main",
+            "aud": "infraweave",
+            "project_path": "infraweave/modules"
+        });
+        let id = IdentityProvider::Raw.extract(&claims).unwrap();
+
+        assert_eq!(
+            id.facts.get("issuer").and_then(Value::as_str),
+            Some("https://gitlab.com")
+        );
+        assert_eq!(
+            id.facts.get("subject").and_then(Value::as_str),
+            Some("project_path:infraweave/modules:ref_type:branch:ref:main")
+        );
+        assert_eq!(
+            id.facts
+                .get("claims")
+                .and_then(|claims| claims.pointer("/project_path"))
+                .and_then(Value::as_str),
+            Some("infraweave/modules")
+        );
+    }
+
+    #[test]
+    fn rejects_non_object_claims() {
+        assert!(IdentityProvider::Raw.extract(&json!("nope")).is_none());
+    }
+}

--- a/internal-api/src/publish_auth/tests.rs
+++ b/internal-api/src/publish_auth/tests.rs
@@ -1,0 +1,483 @@
+use super::*;
+use serde_json::json;
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const GITHUB_OIDC_REGO: &str = include_str!("github_oidc.rego");
+const JWT_USER_RAW_REGO: &str = include_str!("jwt_user_raw.rego");
+const AWS_IAM_RAW_REGO: &str = include_str!("aws_iam_raw.rego");
+
+const GITHUB_OIDC_ISS: &str = "https://token.actions.githubusercontent.com";
+const COGNITO_ISS: &str = "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_example";
+const GITLAB_ISS: &str = "https://gitlab.com";
+const OTHER_ISS: &str = "https://example.com";
+
+/// Serialize tests on the shared env + policy cache and start each from a
+/// clean slate. Hold the returned guard for the lifetime of the test.
+fn test_setup() -> MutexGuard<'static, ()> {
+    let guard = ENV_LOCK.lock().unwrap();
+    reset_env();
+    guard
+}
+
+fn reset_env() {
+    for var in [
+        "AUTH_PUBLISH_REGO_POLICY_PARAMETER",
+        "AUTH_PUBLISH_REGO_POLICY_CACHE_TTL_SECONDS",
+    ] {
+        std::env::remove_var(var);
+    }
+    *policy_cache().lock().unwrap() = None;
+}
+
+fn publish_allowed(
+    claims: &Value,
+    resource_type: &str,
+    resource_name: &str,
+    track: Option<&str>,
+) -> bool {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(check_publish(claims, resource_type, resource_name, track))
+}
+
+fn install_policy(policy: String) {
+    std::env::set_var(
+        "AUTH_PUBLISH_REGO_POLICY_PARAMETER",
+        "/infraweave/test/publish-auth-rego",
+    );
+    cache_policy("/infraweave/test/publish-auth-rego".to_string(), policy).unwrap();
+}
+
+fn replace_set(policy: &str, name: &str, values: &[&str]) -> String {
+    let set = format!(
+        "{{{}}}",
+        values
+            .iter()
+            .map(|v| format!("\"{}\"", v))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    policy.replace(
+        &format!("{} := set()", name),
+        &format!("{} := {}", name, set),
+    )
+}
+
+fn use_github_oidc_policy() {
+    install_policy(GITHUB_OIDC_REGO.to_string());
+}
+
+fn use_aws_iam_raw_policy_with_admin_arns(arns: &[&str]) {
+    install_policy(replace_set(AWS_IAM_RAW_REGO, "admin_aws_role_arns", arns));
+}
+
+fn use_aws_iam_raw_policy_with_admin_ids(ids: &[&str]) {
+    install_policy(replace_set(AWS_IAM_RAW_REGO, "admin_aws_role_ids", ids));
+}
+
+fn use_jwt_user_raw_policy_with(name: &str, values: &[&str]) {
+    install_policy(replace_set(JWT_USER_RAW_REGO, name, values));
+}
+
+#[test]
+fn check_publish_requires_policy_parameter_env_var() {
+    let _guard = test_setup();
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "infraweave-io/tf-module-s3bucket",
+        "repository_owner": "infraweave-io",
+        "ref": "refs/heads/main"
+    });
+
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+
+    use_github_oidc_policy();
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn detect_routes_github_issuer_to_github_oidc() {
+    let claims = json!({ "iss": GITHUB_OIDC_ISS });
+    assert_eq!(
+        IdentityProvider::detect(&claims),
+        IdentityProvider::GitHubOidc
+    );
+}
+
+#[test]
+fn detect_falls_back_to_raw_for_other_issuers() {
+    let claims = json!({ "iss": GITLAB_ISS });
+    assert_eq!(IdentityProvider::detect(&claims), IdentityProvider::Raw);
+
+    let claims = json!({});
+    assert_eq!(IdentityProvider::detect(&claims), IdentityProvider::Raw);
+}
+
+#[test]
+fn rego_policy_allows_matching_publish() {
+    let _guard = test_setup();
+    use_github_oidc_policy();
+
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "infraweave-io/tf-module-s3bucket",
+        "repository_owner": "infraweave-io",
+        "ref": "refs/heads/main"
+    });
+
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+    assert!(!publish_allowed(&claims, "module", "eks", Some("stable")));
+}
+
+#[test]
+fn rego_policy_denies_stable_publish_from_non_main_ref() {
+    let _guard = test_setup();
+    use_github_oidc_policy();
+
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "infraweave-io/tf-module-s3bucket",
+        "repository_owner": "infraweave-io",
+        "ref": "refs/heads/feature"
+    });
+
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn rego_policy_allows_dev_publish_from_non_main_ref() {
+    let _guard = test_setup();
+    use_github_oidc_policy();
+
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "infraweave-io/tf-module-s3bucket",
+        "repository_owner": "infraweave-io",
+        "ref": "refs/heads/feature"
+    });
+
+    assert!(publish_allowed(&claims, "module", "s3bucket", Some("dev")));
+}
+
+#[test]
+fn rego_policy_denies_cross_module_publish() {
+    let _guard = test_setup();
+    use_github_oidc_policy();
+
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "infraweave-io/tf-module-other",
+        "repository_owner": "infraweave-io",
+        "ref": "refs/heads/main"
+    });
+
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn rego_policy_denies_publish_from_foreign_tenant() {
+    let _guard = test_setup();
+    use_github_oidc_policy();
+
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "attacker-org/tf-module-s3bucket",
+        "repository_owner": "attacker-org",
+        "ref": "refs/heads/main"
+    });
+
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn rego_input_contains_identity_and_request() {
+    let _guard = test_setup();
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "infraweave-io/modules",
+        "repository_owner": "infraweave-io",
+        "ref": "refs/heads/main",
+        "job_workflow_ref": "infraweave-io/modules/.github/workflows/publish-module-s3bucket.yml@refs/heads/main",
+        "environment": "publish-module-s3bucket"
+    });
+    let identity = IdentityProvider::GitHubOidc.extract(&claims).unwrap();
+
+    let input = publish_rego_input(
+        &IdentityProvider::GitHubOidc,
+        &identity,
+        "module",
+        "s3bucket",
+        Some("stable"),
+    );
+
+    assert_eq!(
+        input.pointer("/identity/provider").and_then(Value::as_str),
+        Some("github_oidc")
+    );
+    assert_eq!(
+        input
+            .pointer("/identity/workflow_ref")
+            .and_then(Value::as_str),
+        claims.get("job_workflow_ref").and_then(Value::as_str)
+    );
+    assert_eq!(
+        input
+            .pointer("/identity/workflow_name")
+            .and_then(Value::as_str),
+        Some("publish-module-s3bucket")
+    );
+    assert_eq!(
+        input
+            .pointer("/identity/environment")
+            .and_then(Value::as_str),
+        Some("publish-module-s3bucket")
+    );
+    assert_eq!(
+        input
+            .pointer("/identity/repository")
+            .and_then(Value::as_str),
+        Some("infraweave-io/modules")
+    );
+    assert_eq!(
+        input
+            .pointer("/request/resource_name")
+            .and_then(Value::as_str),
+        Some("s3bucket")
+    );
+}
+
+#[test]
+fn rego_input_supports_raw_claims() {
+    let _guard = test_setup();
+    let claims = json!({
+        "iss": GITLAB_ISS,
+        "sub": "project_path:infraweave/tf-module-s3bucket:ref_type:branch:ref:main",
+        "project_path": "infraweave/tf-module-s3bucket"
+    });
+    let identity = IdentityProvider::Raw.extract(&claims).unwrap();
+
+    let input = publish_rego_input(
+        &IdentityProvider::Raw,
+        &identity,
+        "module",
+        "s3bucket",
+        Some("stable"),
+    );
+
+    assert_eq!(
+        input.pointer("/identity/provider").and_then(Value::as_str),
+        Some("raw")
+    );
+    assert_eq!(
+        input.pointer("/identity/issuer").and_then(Value::as_str),
+        Some(GITLAB_ISS)
+    );
+    assert_eq!(
+        input
+            .pointer("/identity/claims/project_path")
+            .and_then(Value::as_str),
+        Some("infraweave/tf-module-s3bucket")
+    );
+}
+
+#[test]
+fn aws_iam_raw_configured_role_arn_can_publish() {
+    let _guard = test_setup();
+    use_aws_iam_raw_policy_with_admin_arns(&["arn:aws:iam::123456789012:role/AdminRole"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "aws_iam_arn": "arn:aws:sts::123456789012:assumed-role/AdminRole/alice@example.com",
+    });
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn aws_iam_raw_other_role_arn_cannot_publish() {
+    let _guard = test_setup();
+    use_aws_iam_raw_policy_with_admin_arns(&["arn:aws:iam::123456789012:role/AdminRole"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "aws_iam_arn": "arn:aws:sts::123456789012:assumed-role/OtherRole/alice@example.com",
+    });
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn aws_iam_raw_configured_role_id_can_publish() {
+    let _guard = test_setup();
+    use_aws_iam_raw_policy_with_admin_ids(&["AROAEXAMPLE123456"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "aws_iam_user_id": "AROAEXAMPLE123456:alice@example.com",
+    });
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn aws_iam_raw_other_role_id_cannot_publish() {
+    let _guard = test_setup();
+    use_aws_iam_raw_policy_with_admin_ids(&["AROAEXAMPLE123456"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "aws_iam_user_id": "AROADIFFERENT123:alice@example.com",
+    });
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn jwt_user_raw_configured_email_can_publish() {
+    let _guard = test_setup();
+    use_jwt_user_raw_policy_with("admin_jwt_emails", &["alice@example.com"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "sub": "user-123",
+        "email": "Alice@Example.com",
+    });
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn jwt_user_raw_other_email_cannot_publish() {
+    let _guard = test_setup();
+    use_jwt_user_raw_policy_with("admin_jwt_emails", &["alice@example.com"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "sub": "user-456",
+        "email": "bob@example.com",
+    });
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn jwt_user_raw_identity_center_user_id_can_publish() {
+    let _guard = test_setup();
+    use_jwt_user_raw_policy_with("admin_jwt_emails", &["alice@example.com"]);
+    let claims = json!({
+        "iss": COGNITO_ISS,
+        "sub": "user-123",
+        "cognito:username": "IdentityCenter_alice@example.com",
+        "identities": [{
+            "providerName": "IdentityCenter",
+            "userId": "Alice@Example.com",
+        }],
+    });
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn jwt_user_raw_cognito_username_can_publish() {
+    let _guard = test_setup();
+    use_jwt_user_raw_policy_with("admin_jwt_usernames", &["IdentityCenter_alice@example.com"]);
+    let claims = json!({
+        "iss": COGNITO_ISS,
+        "sub": "user-123",
+        "cognito:username": "IdentityCenter_alice@example.com",
+    });
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn jwt_user_raw_subject_fallback_can_publish() {
+    let _guard = test_setup();
+    use_jwt_user_raw_policy_with("admin_jwt_subjects", &["user-123"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "sub": "user-123",
+    });
+    assert!(publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}
+
+#[test]
+fn jwt_user_raw_other_subject_fallback_cannot_publish() {
+    let _guard = test_setup();
+    use_jwt_user_raw_policy_with("admin_jwt_subjects", &["user-123"]);
+    let claims = json!({
+        "iss": OTHER_ISS,
+        "sub": "user-456",
+    });
+    assert!(!publish_allowed(
+        &claims,
+        "module",
+        "s3bucket",
+        Some("stable")
+    ));
+}


### PR DESCRIPTION
Provider-agnostic publish authorization. A JWT-aware identity extractor (`github_oidc` and `raw`) builds a trusted input structure; a Rego policy loaded from the cloud parameter store (AWS SSM, Azure App Configuration, ...) decides allow/deny. 

Without any policy configured, publishes fail closed.
