### PR TITLE
feat: add change_records list endpoint

### DIFF
--- a/env_aws_direct/src/api.rs
+++ b/env_aws_direct/src/api.rs
@@ -1066,6 +1066,22 @@ pub fn get_all_events_between_query(region: &str, start_epoch: u128, end_epoch: 
 
 // Change record
 
+pub fn get_change_records_for_deployment_query(
+    project_id: &str,
+    region: &str,
+    environment: &str,
+    deployment_id: &str,
+    change_type: &str,
+) -> Value {
+    json!({
+        "KeyConditionExpression": "PK = :pk",
+        "ExpressionAttributeValues": {
+            ":pk": format!("{}#{}", change_type, get_change_record_identifier(project_id, region, deployment_id, environment)),
+        },
+        "ScanIndexForward": false,
+    })
+}
+
 pub fn get_change_records_query(
     project_id: &str,
     region: &str,

--- a/env_aws_direct/src/lib.rs
+++ b/env_aws_direct/src/lib.rs
@@ -23,6 +23,7 @@ pub use api::{
     get_all_projects_query,
     get_all_regions_query,
     get_all_stack_versions_query,
+    get_change_records_for_deployment_query,
     get_change_records_query,
     get_current_project_query,
     get_dependents_query,

--- a/env_azure/src/api.rs
+++ b/env_azure/src/api.rs
@@ -674,6 +674,24 @@ pub fn get_all_events_between_query(region: &str, start_epoch: u128, end_epoch: 
 
 // Change record
 
+pub fn get_change_records_for_deployment_query(
+    project_id: &str,
+    region: &str,
+    environment: &str,
+    deployment_id: &str,
+    change_type: &str,
+) -> Value {
+    json!({
+        "query": "SELECT * FROM c WHERE c.PK = @pk ORDER BY c.SK DESC",
+        "parameters": [
+            {
+                "name": "@pk",
+                "value": format!("{}#{}", change_type, get_change_record_identifier(project_id, region, deployment_id, environment))
+            }
+        ]
+    })
+}
+
 pub fn get_change_records_query(
     project_id: &str,
     region: &str,

--- a/env_azure/src/lib.rs
+++ b/env_azure/src/lib.rs
@@ -19,6 +19,7 @@ pub use api::{
     get_all_projects_query,
     get_all_regions_query,
     get_all_stack_versions_query,
+    get_change_records_for_deployment_query,
     get_change_records_query,
     get_current_project_query,
     get_dependents_query,

--- a/env_azure_direct/src/api.rs
+++ b/env_azure_direct/src/api.rs
@@ -674,6 +674,24 @@ pub fn get_all_events_between_query(region: &str, start_epoch: u128, end_epoch: 
 
 // Change record
 
+pub fn get_change_records_for_deployment_query(
+    project_id: &str,
+    region: &str,
+    environment: &str,
+    deployment_id: &str,
+    change_type: &str,
+) -> Value {
+    json!({
+        "query": "SELECT * FROM c WHERE c.PK = @pk ORDER BY c.SK DESC",
+        "parameters": [
+            {
+                "name": "@pk",
+                "value": format!("{}#{}", change_type, get_change_record_identifier(project_id, region, deployment_id, environment))
+            }
+        ]
+    })
+}
+
 pub fn get_change_records_query(
     project_id: &str,
     region: &str,

--- a/env_azure_direct/src/lib.rs
+++ b/env_azure_direct/src/lib.rs
@@ -19,6 +19,7 @@ pub use api::{
     get_all_projects_query,
     get_all_regions_query,
     get_all_stack_versions_query,
+    get_change_records_for_deployment_query,
     get_change_records_query,
     get_current_project_query,
     get_dependents_query,

--- a/internal-api/src/api_common.rs
+++ b/internal-api/src/api_common.rs
@@ -442,6 +442,28 @@ pub async fn get_events_impl<Q: DatabaseQuery>(
     .await
 }
 
+pub async fn get_change_records_impl<Q: DatabaseQuery>(
+    db: &Q,
+    payload: &Value,
+    qb: impl Fn(&str, &str, &str, &str, &str) -> Value,
+) -> Result<Value> {
+    let change_type = normalize_change_type(get_param!(payload, "change_type"));
+
+    query_all(
+        db,
+        "change_records",
+        qb(
+            get_param!(payload, "project"),
+            get_param!(payload, "region"),
+            get_param!(payload, "environment"),
+            get_param!(payload, "deployment_id"),
+            change_type,
+        ),
+        Some(payload),
+    )
+    .await
+}
+
 pub async fn get_change_record_impl<Q: DatabaseQuery>(
     db: &Q,
     payload: &Value,
@@ -456,11 +478,7 @@ pub async fn get_change_record_impl<Q: DatabaseQuery>(
 
     // Normalize change_type to PK prefix (same logic as insertion)
     // This handles both lowercase ("plan") and uppercase ("PLAN") inputs
-    let pk_prefix = match change_type.to_lowercase().as_str() {
-        "apply" | "destroy" | "mutate" => "MUTATE",
-        "plan" => "PLAN",
-        _ => change_type, // fallback to original if unknown
-    };
+    let pk_prefix = normalize_change_type(change_type);
 
     log::info!("get_change_record_impl: project={}, region={}, env={}, dep_id={}, job_id={}, change_type={} -> pk_prefix={}", 
         project, region, environment, deployment_id, job_id, change_type, pk_prefix);
@@ -505,6 +523,15 @@ pub async fn get_change_record_impl<Q: DatabaseQuery>(
         anyhow!("Change record not found")
     })
 }
+
+fn normalize_change_type(change_type: &str) -> &str {
+    match change_type.to_lowercase().as_str() {
+        "apply" | "destroy" | "mutate" => "MUTATE",
+        "plan" => "PLAN",
+        _ => change_type,
+    }
+}
+
 pub async fn get_deployment_history_impl<Q: DatabaseQuery>(
     db: &Q,
     payload: &Value,

--- a/internal-api/src/handlers.rs
+++ b/internal-api/src/handlers.rs
@@ -195,6 +195,11 @@ pub async fn get_events(payload: &Value) -> Result<Value> {
     api_common::get_events_impl(&Backend, payload, get_events_query).await
 }
 
+pub async fn get_change_records(payload: &Value) -> Result<Value> {
+    api_common::get_change_records_impl(&Backend, payload, get_change_records_for_deployment_query)
+        .await
+}
+
 pub async fn get_change_record(payload: &Value) -> Result<Value> {
     api_common::get_change_record_impl(&Backend, payload, get_change_records_query).await
 }

--- a/internal-api/src/http_router.rs
+++ b/internal-api/src/http_router.rs
@@ -308,6 +308,10 @@ pub fn create_router() -> Router {
         .route("/api/v1/logs/{project}/{region}/{job_id}", get(read_logs))
         .route("/api/v1/events/{project}/{region}/{*rest}", get(get_events))
         .route(
+            "/api/v1/change_records/{project}/{region}/{*rest}",
+            get(get_change_records),
+        )
+        .route(
             "/api/v1/change_record/{project}/{region}/{*rest}",
             get(get_change_record),
         )
@@ -818,6 +822,13 @@ struct EventPaginationQuery {
     event_type: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct ChangeRecordPaginationQuery {
+    limit: Option<i64>,
+    next_token: Option<String>,
+    change_type: String,
+}
+
 async fn read_logs(
     Path((project, region, job_id)): Path<(String, String, String)>,
     Query(query): Query<PaginationQuery>,
@@ -897,6 +908,46 @@ async fn get_events(
     }
 
     handle_result(handlers::get_events(&payload).await)
+        .await
+        .into_response()
+}
+
+async fn get_change_records(
+    Path((project, region, rest)): Path<(String, String, String)>,
+    Query(query): Query<ChangeRecordPaginationQuery>,
+) -> impl IntoResponse {
+    // Expected format: environment1/environment2/deployment1/deployment2
+    let parts: Vec<&str> = rest.split('/').collect();
+
+    if parts.len() != 4 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!("Invalid path format. Expected exactly 4 segments (env1/env2/dep1/dep2), got {}", parts.len())
+            })),
+        )
+            .into_response();
+    }
+
+    let environment = format!("{}/{}", parts[0], parts[1]);
+    let deployment_id = format!("{}/{}", parts[2], parts[3]);
+
+    let mut payload = json!({
+        "project": project,
+        "region": region,
+        "environment": environment,
+        "deployment_id": deployment_id,
+        "change_type": query.change_type
+    });
+
+    if let Some(limit) = query.limit {
+        payload["limit"] = json!(limit);
+    }
+    if let Some(next_token) = query.next_token {
+        payload["next_token"] = json!(next_token);
+    }
+
+    handle_result(handlers::get_change_records(&payload).await)
         .await
         .into_response()
 }
@@ -1617,4 +1668,27 @@ async fn get_meta_info() -> impl IntoResponse {
         "service": "infraweave-internal-api",
         "version": env!("CARGO_PKG_VERSION")
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn change_records_route_is_not_handled_as_publish_endpoint() {
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/v1/change_records/135808927253/us-west-2/cli%2Fdefault/s3bucket%2Fmy-s3bucket2?limit=5&change_type=mutate")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
 }

--- a/internal-api/src/queries.rs
+++ b/internal-api/src/queries.rs
@@ -2,20 +2,22 @@
 pub use env_aws_direct::{
     get_all_deployments_query, get_all_latest_modules_query, get_all_latest_providers_query,
     get_all_latest_stacks_query, get_all_module_versions_query, get_all_policies_query,
-    get_all_projects_query, get_all_stack_versions_query, get_change_records_query,
-    get_deployment_and_dependents_query, get_deployment_history_deleted_query,
-    get_deployment_history_plans_query, get_deployments_using_module_query, get_events_query,
-    get_module_version_query, get_plan_deployment_query, get_policy_query,
-    get_provider_version_query, get_stack_version_query,
+    get_all_projects_query, get_all_stack_versions_query, get_change_records_for_deployment_query,
+    get_change_records_query, get_deployment_and_dependents_query,
+    get_deployment_history_deleted_query, get_deployment_history_plans_query,
+    get_deployments_using_module_query, get_events_query, get_module_version_query,
+    get_plan_deployment_query, get_policy_query, get_provider_version_query,
+    get_stack_version_query,
 };
 
 #[cfg(feature = "azure")]
 pub use env_azure_direct::{
     get_all_deployments_query, get_all_latest_modules_query, get_all_latest_providers_query,
     get_all_latest_stacks_query, get_all_module_versions_query, get_all_policies_query,
-    get_all_projects_query, get_all_stack_versions_query, get_change_records_query,
-    get_deployment_and_dependents_query, get_deployment_history_deleted_query,
-    get_deployment_history_plans_query, get_deployments_using_module_query, get_events_query,
-    get_module_version_query, get_plan_deployment_query, get_policy_query,
-    get_provider_version_query, get_stack_version_query,
+    get_all_projects_query, get_all_stack_versions_query, get_change_records_for_deployment_query,
+    get_change_records_query, get_deployment_and_dependents_query,
+    get_deployment_history_deleted_query, get_deployment_history_plans_query,
+    get_deployments_using_module_query, get_events_query, get_module_version_query,
+    get_plan_deployment_query, get_policy_query, get_provider_version_query,
+    get_stack_version_query,
 };


### PR DESCRIPTION
Adds GET /api/v1/change_records/{project}/{region}/{env}/{deployment_id} returning paginated change records filtered by change_type. 

Also extracts normalize_change_type into a helper shared with get_change_record_impl.