### PR TITLE
feat: scope internal API data access via workload-scoped credentials

### DIFF
--- a/internal-api/src/api_common.rs
+++ b/internal-api/src/api_common.rs
@@ -11,6 +11,17 @@ pub trait DatabaseQuery {
         query: &Value,
         region: Option<&str>,
     ) -> Result<Value>;
+
+    async fn query_workload_account(
+        &self,
+        workload_account: &str,
+        container: &str,
+        query: &Value,
+        region: Option<&str>,
+    ) -> Result<Value> {
+        let _ = workload_account;
+        self.query_table(container, query, region).await
+    }
 }
 
 pub trait JobRunner {
@@ -59,6 +70,38 @@ async fn query_all<Q: DatabaseQuery>(
     db.query_table(container, &query, region).await
 }
 
+async fn query_all_for_workload<Q: DatabaseQuery>(
+    db: &Q,
+    workload_account: &str,
+    container: &str,
+    mut query: Value,
+    payload: Option<&Value>,
+) -> Result<Value> {
+    let mut region = None;
+
+    if let Some(payload) = payload {
+        if let Some(r) = payload.get("region").and_then(|v| v.as_str()) {
+            region = Some(r);
+        }
+
+        if let Some(limit) = payload.get("limit").and_then(|v| v.as_i64()) {
+            query["Limit"] = serde_json::json!(limit);
+        }
+
+        if let Some(next_token) = payload.get("next_token").and_then(|v| v.as_str()) {
+            if let Ok(decoded) = general_purpose::STANDARD.decode(next_token) {
+                if let Ok(json_str) = String::from_utf8(decoded) {
+                    if let Ok(key) = serde_json::from_str::<Value>(&json_str) {
+                        query["ExclusiveStartKey"] = key;
+                    }
+                }
+            }
+        }
+    }
+    db.query_workload_account(workload_account, container, &query, region)
+        .await
+}
+
 // Helper to query and return first item or error if not found
 async fn query_one<Q: DatabaseQuery>(
     db: &Q,
@@ -78,22 +121,46 @@ async fn query_one<Q: DatabaseQuery>(
         .ok_or_else(|| anyhow!("Item not found"))
 }
 
+async fn query_one_for_workload<Q: DatabaseQuery>(
+    db: &Q,
+    workload_account: &str,
+    container: &str,
+    query: Value,
+    region: Option<&str>,
+) -> Result<Value> {
+    let response = db
+        .query_workload_account(workload_account, container, &query, region)
+        .await?;
+    let items = response
+        .get("Items")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("Invalid response from query_table"))?;
+
+    items
+        .first()
+        .map(|v| v.clone())
+        .ok_or_else(|| anyhow!("Item not found"))
+}
+
 pub async fn describe_deployment_impl<Q: DatabaseQuery + JobRunner>(
     db: &Q,
     payload: &Value,
     qb: impl Fn(&str, &str, &str, &str, bool) -> Value,
 ) -> Result<Value> {
-    let record = query_one(
+    let project = get_param!(payload, "project");
+    let region = get_param!(payload, "region");
+    let record = query_one_for_workload(
         db,
+        project,
         "deployments",
         qb(
-            get_param!(payload, "project"),
-            get_param!(payload, "region"),
+            project,
+            region,
             get_param!(payload, "deployment_id"),
             get_param!(payload, "environment"),
             true,
         ),
-        payload.get("region").and_then(|v| v.as_str()),
+        Some(region),
     )
     .await
     .map_err(|_| anyhow!("Deployment not found"))?;
@@ -105,17 +172,20 @@ pub async fn get_plan_deployment_impl<Q: DatabaseQuery + JobRunner>(
     payload: &Value,
     qb: impl Fn(&str, &str, &str, &str, &str) -> Value,
 ) -> Result<Value> {
-    let record = query_one(
+    let project = get_param!(payload, "project");
+    let region = get_param!(payload, "region");
+    let record = query_one_for_workload(
         db,
+        project,
         "deployments",
         qb(
-            get_param!(payload, "project"),
-            get_param!(payload, "region"),
+            project,
+            region,
             get_param!(payload, "deployment_id"),
             get_param!(payload, "environment"),
             get_param!(payload, "job_id"),
         ),
-        payload.get("region").and_then(|v| v.as_str()),
+        Some(region),
     )
     .await
     .map_err(|_| anyhow!("Plan deployment not found"))?;
@@ -136,7 +206,7 @@ pub async fn get_deployments_impl<Q: DatabaseQuery>(
     if let Some(projects) = payload.get("projects").and_then(|v| v.as_array()) {
         let futures = projects.iter().filter_map(|p| p.as_str()).map(|project| {
             let query = qb(project, region, "", include_deleted);
-            query_all(db, "deployments", query, Some(payload))
+            query_all_for_workload(db, project, "deployments", query, Some(payload))
         });
 
         let results = join_all(futures).await;
@@ -154,8 +224,9 @@ pub async fn get_deployments_impl<Q: DatabaseQuery>(
             "Count": all_items.len()
         }))
     } else {
-        query_all(
+        query_all_for_workload(
             db,
+            get_param!(payload, "project"),
             "deployments",
             qb(get_param!(payload, "project"), region, "", include_deleted),
             Some(payload),
@@ -386,7 +457,7 @@ pub async fn get_deployments_for_module_impl<Q: DatabaseQuery>(
             .filter_map(|p| p.as_str())
             .map(|project| {
                 let query_val = qb(project, region, module, "", include_deleted);
-                query_all(db, "deployments", query_val, Some(payload))
+                query_all_for_workload(db, project, "deployments", query_val, Some(payload))
             })
             .collect();
 
@@ -406,8 +477,9 @@ pub async fn get_deployments_for_module_impl<Q: DatabaseQuery>(
             "Count": all_items.len()
         }))
     } else {
-        query_all(
+        query_all_for_workload(
             db,
+            get_param!(payload, "project"),
             "deployments",
             qb(
                 get_param!(payload, "project"),
@@ -427,8 +499,9 @@ pub async fn get_events_impl<Q: DatabaseQuery>(
     payload: &Value,
     qb: impl Fn(&str, &str, &str, &str, Option<&str>) -> Value,
 ) -> Result<Value> {
-    query_all(
+    query_all_for_workload(
         db,
+        get_param!(payload, "project"),
         "events",
         qb(
             get_param!(payload, "project"),
@@ -449,8 +522,9 @@ pub async fn get_change_records_impl<Q: DatabaseQuery>(
 ) -> Result<Value> {
     let change_type = normalize_change_type(get_param!(payload, "change_type"));
 
-    query_all(
+    query_all_for_workload(
         db,
+        get_param!(payload, "project"),
         "change_records",
         qb(
             get_param!(payload, "project"),
@@ -496,7 +570,7 @@ pub async fn get_change_record_impl<Q: DatabaseQuery>(
             "Querying with MUTATE, query: {}",
             serde_json::to_string_pretty(&query).unwrap_or_default()
         );
-        query_one(db, "change_records", query, Some(region)).await
+        query_one_for_workload(db, project, "change_records", query, Some(region)).await
     } else {
         Err(anyhow!("Skipping MUTATE for PLAN"))
     };
@@ -515,7 +589,7 @@ pub async fn get_change_record_impl<Q: DatabaseQuery>(
             pk_prefix,
             serde_json::to_string_pretty(&query).unwrap_or_default()
         );
-        result = query_one(db, "change_records", query, Some(region)).await;
+        result = query_one_for_workload(db, project, "change_records", query, Some(region)).await;
     }
 
     result.map_err(|e| {
@@ -566,7 +640,8 @@ pub async fn get_deployment_history_impl<Q: DatabaseQuery>(
         serde_json::to_string_pretty(&query).unwrap_or_default()
     );
 
-    let mut result = query_all(db, "deployments", query, Some(payload)).await?;
+    let mut result =
+        query_all_for_workload(db, project, "deployments", query, Some(payload)).await?;
 
     // Sort results by epoch in descending order
     if let Some(items) = result.get_mut("Items").and_then(|v| v.as_array_mut()) {
@@ -578,4 +653,195 @@ pub async fn get_deployment_history_impl<Q: DatabaseQuery>(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingDb {
+        calls: Mutex<Vec<Option<String>>>,
+    }
+
+    impl RecordingDb {
+        fn calls(&self) -> Vec<Option<String>> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl DatabaseQuery for RecordingDb {
+        async fn query_table(
+            &self,
+            _container: &str,
+            _query: &Value,
+            _region: Option<&str>,
+        ) -> Result<Value> {
+            self.calls.lock().unwrap().push(None);
+            Ok(serde_json::json!({
+                "Items": [],
+                "Count": 0
+            }))
+        }
+
+        async fn query_workload_account(
+            &self,
+            workload_account: &str,
+            _container: &str,
+            _query: &Value,
+            _region: Option<&str>,
+        ) -> Result<Value> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(Some(workload_account.to_string()));
+            Ok(serde_json::json!({
+                "Items": [],
+                "Count": 0
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn deployment_list_scopes_single_project_query() {
+        let db = RecordingDb::default();
+        let payload = serde_json::json!({
+            "project": "111111111111",
+            "region": "us-west-2"
+        });
+
+        get_deployments_impl(&db, &payload, |project, region, _, _| {
+            serde_json::json!({
+                "project": project,
+                "region": region
+            })
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(db.calls(), vec![Some("111111111111".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn deployment_list_scopes_each_project_query() {
+        let db = RecordingDb::default();
+        let payload = serde_json::json!({
+            "projects": ["111111111111", "222222222222"],
+            "region": "us-west-2"
+        });
+
+        get_deployments_impl(&db, &payload, |project, region, _, _| {
+            serde_json::json!({
+                "project": project,
+                "region": region
+            })
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            db.calls(),
+            vec![
+                Some("111111111111".to_string()),
+                Some("222222222222".to_string())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn events_query_scopes_project_query() {
+        let db = RecordingDb::default();
+        let payload = serde_json::json!({
+            "project": "111111111111",
+            "region": "us-west-2",
+            "deployment_id": "module/name",
+            "environment": "dev"
+        });
+
+        get_events_impl(
+            &db,
+            &payload,
+            |project, region, deployment_id, environment, _| {
+                serde_json::json!({
+                    "project": project,
+                    "region": region,
+                    "deployment_id": deployment_id,
+                    "environment": environment
+                })
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(db.calls(), vec![Some("111111111111".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn change_records_query_scopes_project_query() {
+        let db = RecordingDb::default();
+        let payload = serde_json::json!({
+            "project": "111111111111",
+            "region": "us-west-2",
+            "deployment_id": "module/name",
+            "environment": "dev",
+            "change_type": "mutate"
+        });
+
+        get_change_records_impl(
+            &db,
+            &payload,
+            |project, region, environment, deployment_id, change_type| {
+                serde_json::json!({
+                    "project": project,
+                    "region": region,
+                    "environment": environment,
+                    "deployment_id": deployment_id,
+                    "change_type": change_type
+                })
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(db.calls(), vec![Some("111111111111".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn modules_query_does_not_use_workload_scope() {
+        let db = RecordingDb::default();
+        let payload = serde_json::json!({});
+
+        get_modules_impl(&db, &payload, |_, _, _| {
+            serde_json::json!({
+                "KeyConditionExpression": "PK = :pk",
+                "ExpressionAttributeValues": {
+                    ":pk": "MODULES"
+                }
+            })
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(db.calls(), vec![None]);
+    }
+
+    #[tokio::test]
+    async fn projects_query_does_not_use_workload_scope() {
+        let db = RecordingDb::default();
+        let payload = serde_json::json!({});
+
+        get_projects_impl(&db, &payload, || {
+            serde_json::json!({
+                "KeyConditionExpression": "PK = :pk",
+                "ExpressionAttributeValues": {
+                    ":pk": "PROJECTS"
+                }
+            })
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(db.calls(), vec![None]);
+    }
 }

--- a/internal-api/src/aws_handlers.rs
+++ b/internal-api/src/aws_handlers.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "aws")]
 use anyhow::{anyhow, Result};
 use axum::{body::Body, http::header, response::Response};
+use env_defs::CloudProvider;
 use serde_json::{json, Value};
 use tracing::{error, info, instrument, warn};
 
@@ -11,6 +12,38 @@ use crate::get_param;
 pub use env_aws_direct::utils::{
     get_bucket_name, get_bucket_name_for_region, get_table_name_for_region,
 };
+
+pub fn ensure_workload_access_configured() -> Result<()> {
+    env_aws_direct::ensure_workload_access_role_configured()
+}
+
+pub fn ensure_access_roles_configured() -> Result<()> {
+    env_aws_direct::ensure_workload_access_role_configured()?;
+    env_aws_direct::ensure_publish_access_role_configured()
+}
+
+pub fn ensure_publish_access_configured() -> Result<()> {
+    env_aws_direct::ensure_publish_access_role_configured()
+}
+
+pub async fn with_workload_account<F, T>(workload_account: String, future: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    env_aws_direct::with_workload_account(workload_account, future).await
+}
+
+pub async fn with_publish_scope<F, T>(
+    resource_type: String,
+    resource_name: String,
+    track: Option<String>,
+    future: F,
+) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    env_aws_direct::with_publish_scope(resource_type, resource_name, track, future).await
+}
 
 // Backend implementation for AWS (DynamoDB + ECS)
 pub struct AwsBackend;
@@ -36,6 +69,20 @@ impl DatabaseQuery for AwsBackend {
         }
 
         read_db(&payload).await
+    }
+
+    async fn query_workload_account(
+        &self,
+        workload_account: &str,
+        container: &str,
+        query: &Value,
+        region: Option<&str>,
+    ) -> Result<Value> {
+        env_aws_direct::with_workload_account(
+            workload_account.to_string(),
+            self.query_table(container, query, region),
+        )
+        .await
     }
 }
 
@@ -520,8 +567,7 @@ pub async fn download_provider(payload: &Value) -> Result<Value> {
 }
 
 pub async fn publish_provider(payload: &Value) -> Result<Value> {
-    use env_common::logic::upload_provider;
-    use env_defs::{CloudProvider, ProviderResp};
+    use env_defs::ProviderResp;
 
     let zip_base64 = payload
         .get("zip_base64")
@@ -543,18 +589,16 @@ pub async fn publish_provider(payload: &Value) -> Result<Value> {
     let handler = env_common::interface::GenericCloudHandler::default().await;
     let all_regions = handler.get_all_regions().await?;
 
-    for region in all_regions.iter() {
-        let region_handler = handler.copy_with_region(region).await;
-        upload_provider(&region_handler, &provider, &zip_base64.to_string())
-            .await
-            .map_err(|e| anyhow!("Failed to upload provider to region {}: {}", region, e))?;
-        info!("Provider uploaded to region {}", region);
-    }
+    with_publish_scope("provider".to_string(), provider.name.clone(), None, async {
+        env_common::logic::server_publish_provider(&handler, &provider, zip_base64, &all_regions)
+            .await?;
 
-    info!("Provider uploaded successfully to all regions");
+        info!("Provider uploaded successfully to all regions");
 
-    Ok(json!({
-        "status": "success",
-        "message": format!("Provider {} version {} uploaded", provider.name, provider.version)
-    }))
+        Ok(json!({
+            "status": "success",
+            "message": format!("Provider {} version {} uploaded", provider.name, provider.version)
+        }))
+    })
+    .await
 }

--- a/internal-api/src/azure_handlers.rs
+++ b/internal-api/src/azure_handlers.rs
@@ -58,6 +58,25 @@ fn get_id(item: &Value) -> Result<String> {
 // DatabaseQuery implementation for Azure (Cosmos DB)
 pub struct AzureBackend;
 
+pub async fn with_workload_account<F, T>(_workload_account: String, future: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    future.await
+}
+
+pub async fn with_publish_scope<F, T>(
+    _resource_type: String,
+    _resource_name: String,
+    _track: Option<String>,
+    future: F,
+) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    future.await
+}
+
 impl DatabaseQuery for AzureBackend {
     async fn query_table(
         &self,
@@ -588,6 +607,14 @@ pub async fn download_file_as_string(container_name: &str, blob_name: &str) -> R
     }
 
     Ok(String::from_utf8(data)?)
+}
+
+pub async fn download_file_as_string_from_region(
+    container_name: &str,
+    blob_name: &str,
+    _region: Option<&str>,
+) -> Result<String> {
+    download_file_as_string(container_name, blob_name).await
 }
 
 pub async fn download_file(container_name: &str, blob_name: &str) -> Result<Response> {

--- a/internal-api/src/handlers.rs
+++ b/internal-api/src/handlers.rs
@@ -6,17 +6,42 @@ use axum::response::{IntoResponse, Response};
 use env_defs::CloudProvider;
 use log::info;
 use serde_json::{json, Value};
+use std::future::Future;
 
 #[cfg(feature = "aws")]
 use crate::aws_handlers::{
-    download_file, download_file_as_string, download_file_as_string_from_region, get_bucket_name,
-    get_bucket_name_for_region, AwsBackend as Backend,
+    download_file, download_file_as_string_from_region, get_bucket_name,
+    get_bucket_name_for_region, with_publish_scope as provider_with_publish_scope,
+    with_workload_account as provider_with_workload_account, AwsBackend as Backend,
 };
 
 #[cfg(feature = "azure")]
-use crate::azure_handlers::{download_file, download_file_as_string, AzureBackend as Backend};
+use crate::azure_handlers::{
+    download_file, download_file_as_string_from_region,
+    with_publish_scope as provider_with_publish_scope,
+    with_workload_account as provider_with_workload_account, AzureBackend as Backend,
+};
 #[cfg(feature = "azure")]
 use crate::common::get_env_var;
+
+pub async fn with_workload_account<F, T>(workload_account: String, future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    provider_with_workload_account(workload_account, future).await
+}
+
+pub async fn with_publish_scope<F, T>(
+    resource_type: String,
+    resource_name: String,
+    track: Option<String>,
+    future: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    provider_with_publish_scope(resource_type, resource_name, track, future).await
+}
 
 pub async fn describe_deployment(payload: &Value) -> Result<Value> {
     api_common::describe_deployment_impl(&Backend, payload, get_deployment_and_dependents_query)
@@ -215,144 +240,155 @@ pub async fn get_deployment_history(payload: &Value) -> Result<Value> {
 }
 
 pub async fn get_change_record_graph(payload: &Value) -> Result<Response> {
-    info!("get_change_record_graph payload: {:?}", payload);
-    let change_record =
-        match api_common::get_change_record_impl(&Backend, payload, get_change_records_query).await
-        {
-            Ok(cr) => cr,
-            Err(e) => {
-                log::error!("Failed to fetch change record: {:?}", e);
-                return Err(e);
-            }
+    let project = get_param!(payload, "project").to_string();
+
+    with_workload_account(project, async {
+        info!("get_change_record_graph payload: {:?}", payload);
+        let change_record =
+            match api_common::get_change_record_impl(&Backend, payload, get_change_records_query)
+                .await
+            {
+                Ok(cr) => cr,
+                Err(e) => {
+                    log::error!("Failed to fetch change record: {:?}", e);
+                    return Err(e);
+                }
+            };
+
+        let plan_key = change_record
+            .get("plan_raw_json_key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Change record has no plan_raw_json_key"))?;
+
+        // Generate graph key based on the plan key format
+        // For MUTATE: xxx_mutate_output.json -> xxx_graph.dot
+        // For PLAN: xxx_plan_output.json -> xxx_graph.dot
+        let graph_key = if plan_key.contains("_mutate_output.json") {
+            plan_key.replace("_mutate_output.json", "_graph.dot")
+        } else if plan_key.contains("_plan_output.json") {
+            plan_key.replace("_plan_output.json", "_graph.dot")
+        } else {
+            return Err(anyhow!("Unknown plan key format: {}", plan_key));
         };
 
-    let plan_key = change_record
-        .get("plan_raw_json_key")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!("Change record has no plan_raw_json_key"))?;
+        // Get region from payload to use correct S3 bucket
+        let region = payload
+            .get("region")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing region in payload"))?;
 
-    // Generate graph key based on the plan key format
-    // For MUTATE: xxx_mutate_output.json -> xxx_graph.dot
-    // For PLAN: xxx_plan_output.json -> xxx_graph.dot
-    let graph_key = if plan_key.contains("_mutate_output.json") {
-        plan_key.replace("_mutate_output.json", "_graph.dot")
-    } else if plan_key.contains("_plan_output.json") {
-        plan_key.replace("_plan_output.json", "_graph.dot")
-    } else {
-        return Err(anyhow!("Unknown plan key format: {}", plan_key));
-    };
+        #[cfg(feature = "aws")]
+        let container_name = get_bucket_name_for_region("change_records", region)?;
+        #[cfg(feature = "azure")]
+        let container_name = get_env_var("CHANGE_RECORD_S3_BUCKET")?;
 
-    // Get region from payload to use correct S3 bucket
-    let region = payload
-        .get("region")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!("Missing region in payload"))?;
+        info!(
+            "Fetching plan from container: {}, key: {}",
+            container_name, plan_key
+        );
+        let plan_content =
+            download_file_as_string_from_region(&container_name, plan_key, Some(region)).await?;
+        info!("Plan content length: {}", plan_content.len());
 
-    #[cfg(feature = "aws")]
-    let container_name = get_bucket_name_for_region("change_records", region)?;
-    #[cfg(feature = "azure")]
-    let container_name = get_env_var("CHANGE_RECORD_S3_BUCKET")?;
+        info!(
+            "Fetching graph from container: {}, key: {}",
+            container_name, graph_key
+        );
+        let graph_content =
+            download_file_as_string_from_region(&container_name, &graph_key, Some(region)).await?;
+        info!("Graph content length: {}", graph_content.len());
+        info!("Graph content preview: {:.500}", graph_content);
 
-    info!(
-        "Fetching plan from container: {}, key: {}",
-        container_name, plan_key
-    );
-    let plan_content =
-        download_file_as_string_from_region(&container_name, plan_key, Some(region)).await?;
-    info!("Plan content length: {}", plan_content.len());
+        // let graph = json!({}); // Placeholder until tofu is imported
+        let graph = graph::process_graph(&plan_content, &graph_content, true, None)
+            .map_err(|e| anyhow!("Failed to process graph: {}", e))?;
 
-    info!(
-        "Fetching graph from container: {}, key: {}",
-        container_name, graph_key
-    );
-    let graph_content =
-        download_file_as_string_from_region(&container_name, &graph_key, Some(region)).await?;
-    info!("Graph content length: {}", graph_content.len());
-    info!("Graph content preview: {:.500}", graph_content);
+        info!(
+            "Processed graph nodes: {}, edges: {}",
+            graph.nodes.len(),
+            graph.edges.len()
+        );
 
-    // let graph = json!({}); // Placeholder until tofu is imported
-    let graph = graph::process_graph(&plan_content, &graph_content, true, None)
-        .map_err(|e| anyhow!("Failed to process graph: {}", e))?;
-
-    info!(
-        "Processed graph nodes: {}, edges: {}",
-        graph.nodes.len(),
-        graph.edges.len()
-    );
-
-    Ok((axum::http::StatusCode::OK, axum::Json(graph)).into_response())
+        Ok((axum::http::StatusCode::OK, axum::Json(graph)).into_response())
+    })
+    .await
 }
 
 pub async fn get_deployment_graph(payload: &Value) -> Result<Response> {
-    info!("get_deployment_graph payload: {:?}", payload);
     let project = get_param!(payload, "project");
-    let region = get_param!(payload, "region");
-    let deployment_id = get_param!(payload, "deployment_id");
-    let environment = get_param!(payload, "environment");
+    with_workload_account(project.to_string(), async {
+        info!("get_deployment_graph payload: {:?}", payload);
+        let region = get_param!(payload, "region");
+        let deployment_id = get_param!(payload, "deployment_id");
+        let environment = get_param!(payload, "environment");
 
-    // Get job_id and command from query params (merged into payload)
-    let job_id = get_param!(payload, "job_id");
+        // Get job_id and command from query params (merged into payload)
+        let job_id = get_param!(payload, "job_id");
 
-    info!(
-        "Using job_id: {} and change_type: {} provided in request",
-        job_id, "MUTATE"
-    );
+        info!(
+            "Using job_id: {} and change_type: {} provided in request",
+            job_id, "MUTATE"
+        );
 
-    // 2. Fetch the specific change record
-    let cr_query = get_change_records_query(
-        project,
-        region,
-        environment,
-        deployment_id,
-        job_id,
-        "MUTATE",
-    );
+        // 2. Fetch the specific change record
+        let cr_query = get_change_records_query(
+            project,
+            region,
+            environment,
+            deployment_id,
+            job_id,
+            "MUTATE",
+        );
 
-    let cr_resp = Backend
-        .query_table("change_records", &cr_query, None)
-        .await?;
-    let change_record = cr_resp
-        .get("Items")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| arr.first())
-        .ok_or_else(|| anyhow!("Change record not found for job_id: {}", job_id))?;
+        let cr_resp = Backend
+            .query_workload_account(project, "change_records", &cr_query, Some(region))
+            .await?;
+        let change_record = cr_resp
+            .get("Items")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .ok_or_else(|| anyhow!("Change record not found for job_id: {}", job_id))?;
 
-    let plan_key = change_record
-        .get("plan_raw_json_key")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!("Change record has no plan_raw_json_key"))?;
+        let plan_key = change_record
+            .get("plan_raw_json_key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Change record has no plan_raw_json_key"))?;
 
-    let state_key = plan_key.replace("_mutate_output.json", "_state_output.json");
-    let graph_key = plan_key.replace("_mutate_output.json", "_graph.dot");
+        let state_key = plan_key.replace("_mutate_output.json", "_state_output.json");
+        let graph_key = plan_key.replace("_mutate_output.json", "_graph.dot");
 
-    #[cfg(feature = "aws")]
-    let container_name = get_bucket_name("change_records")?;
-    #[cfg(feature = "azure")]
-    let container_name = get_env_var("CHANGE_RECORD_S3_BUCKET")?;
+        #[cfg(feature = "aws")]
+        let container_name = get_bucket_name_for_region("change_records", region)?;
+        #[cfg(feature = "azure")]
+        let container_name = get_env_var("CHANGE_RECORD_S3_BUCKET")?;
 
-    info!(
-        "Fetching state from container: {}, key: {}",
-        container_name, state_key
-    );
-    let state_content = download_file_as_string(&container_name, &state_key).await?;
+        info!(
+            "Fetching state from container: {}, key: {}",
+            container_name, state_key
+        );
+        let state_content =
+            download_file_as_string_from_region(&container_name, &state_key, Some(region)).await?;
 
-    info!(
-        "Fetching graph from container: {}, key: {}",
-        container_name, graph_key
-    );
-    let graph_content = download_file_as_string(&container_name, &graph_key).await?;
+        info!(
+            "Fetching graph from container: {}, key: {}",
+            container_name, graph_key
+        );
+        let graph_content =
+            download_file_as_string_from_region(&container_name, &graph_key, Some(region)).await?;
 
-    // let graph = json!({}); // Placeholder until tofu is imported
-    let graph = graph::process_graph(&state_content, &graph_content, true, None)
-        .map_err(|e| anyhow!("Failed to process graph: {}", e))?;
+        // let graph = json!({}); // Placeholder until tofu is imported
+        let graph = graph::process_graph(&state_content, &graph_content, true, None)
+            .map_err(|e| anyhow!("Failed to process graph: {}", e))?;
 
-    info!(
-        "Processed graph nodes: {}, edges: {}",
-        graph.nodes.len(),
-        graph.edges.len()
-    );
+        info!(
+            "Processed graph nodes: {}, edges: {}",
+            graph.nodes.len(),
+            graph.edges.len()
+        );
 
-    Ok((axum::http::StatusCode::OK, axum::Json(graph)).into_response())
+        Ok((axum::http::StatusCode::OK, axum::Json(graph)).into_response())
+    })
+    .await
 }
 
 pub async fn deprecate_module(payload: &Value) -> Result<Value> {
@@ -364,17 +400,25 @@ pub async fn deprecate_module(payload: &Value) -> Result<Value> {
     let version = get_param!(payload, "version");
     let message = payload.get("message").and_then(|v| v.as_str());
 
-    // Create a GenericCloudHandler for AWS
     let handler = GenericCloudHandler::default().await;
     let all_regions = handler.get_all_regions().await?;
 
-    deprecate_module_impl(&handler, module, track, version, message, &all_regions).await?;
-    info!("Module deprecated successfully in all regions");
+    with_publish_scope(
+        "module".to_string(),
+        module.to_string(),
+        Some(track.to_string()),
+        async {
+            deprecate_module_impl(&handler, module, track, version, message, &all_regions).await?;
 
-    Ok(json!({
-        "success": true,
-        "message": format!("Module {} version {} in track {} has been deprecated in all regions", module, version, track)
-    }))
+            info!("Module deprecated successfully in all regions");
+
+            Ok(json!({
+                "success": true,
+                "message": format!("Module {} version {} in track {} has been deprecated in all regions", module, version, track)
+            }))
+        },
+    )
+    .await
 }
 
 pub async fn deprecate_stack(payload: &Value) -> Result<Value> {
@@ -389,15 +433,26 @@ pub async fn deprecate_stack(payload: &Value) -> Result<Value> {
     let handler = GenericCloudHandler::default().await;
     let all_regions = handler.get_all_regions().await?;
 
-    deprecate_stack_impl(&handler, stack, track, version, message, &all_regions).await?;
+    with_publish_scope(
+        "stack".to_string(),
+        stack.to_string(),
+        Some(track.to_string()),
+        async {
+            deprecate_stack_impl(&handler, stack, track, version, message, &all_regions).await?;
 
-    Ok(json!({
-        "success": true,
-        "message": format!("Stack {} version {} in track {} has been deprecated in all regions", stack, version, track)
-    }))
+            info!("Stack deprecated successfully in all regions");
+
+            Ok(json!({
+                "success": true,
+                "message": format!("Stack {} version {} in track {} has been deprecated in all regions", stack, version, track)
+            }))
+        },
+    )
+    .await
 }
 
 pub async fn publish_module(payload: &Value) -> Result<Value> {
+    use env_common::interface::GenericCloudHandler;
     use env_defs::ModuleResp;
 
     let zip_base64 = payload
@@ -412,18 +467,28 @@ pub async fn publish_module(payload: &Value) -> Result<Value> {
     let module: ModuleResp = serde_json::from_value(module_json.clone())
         .map_err(|e| anyhow!("Failed to deserialize module: {}", e))?;
 
-    let handler = env_common::interface::GenericCloudHandler::default().await;
-
+    let handler = GenericCloudHandler::default().await;
     let all_regions = handler.get_all_regions().await?;
-    env_common::logic::server_publish_module(&handler, &module, zip_base64, &all_regions).await?;
 
-    Ok(json!({
-        "status": "success",
-        "message": format!("Module {} version {} uploaded", module.module, module.version)
-    }))
+    with_publish_scope(
+        "module".to_string(),
+        module.module.clone(),
+        Some(module.track.clone()),
+        async {
+            env_common::logic::server_publish_module(&handler, &module, zip_base64, &all_regions)
+                .await?;
+
+            Ok(json!({
+                "status": "success",
+                "message": format!("Module {} version {} uploaded", module.module, module.version)
+            }))
+        },
+    )
+    .await
 }
 
 pub async fn publish_stack(payload: &Value) -> Result<Value> {
+    use env_common::interface::GenericCloudHandler;
     use env_defs::ModuleResp;
 
     let zip_base64 = payload
@@ -438,15 +503,55 @@ pub async fn publish_stack(payload: &Value) -> Result<Value> {
     let module: ModuleResp = serde_json::from_value(module_json.clone())
         .map_err(|e| anyhow!("Failed to deserialize stack: {}", e))?;
 
-    let handler = env_common::interface::GenericCloudHandler::default().await;
-
+    let handler = GenericCloudHandler::default().await;
     let all_regions = handler.get_all_regions().await?;
-    env_common::logic::server_publish_stack(&handler, &module, zip_base64, &all_regions).await?;
 
-    Ok(json!({
-        "status": "success",
-        "message": format!("Stack {} version {} uploaded", module.module, module.version)
-    }))
+    with_publish_scope(
+        "stack".to_string(),
+        module.module.clone(),
+        Some(module.track.clone()),
+        async {
+            env_common::logic::server_publish_stack(&handler, &module, zip_base64, &all_regions)
+                .await?;
+
+            Ok(json!({
+                "status": "success",
+                "message": format!("Stack {} version {} uploaded", module.module, module.version)
+            }))
+        },
+    )
+    .await
+}
+
+pub async fn publish_policy(payload: &Value) -> Result<Value> {
+    use env_common::interface::GenericCloudHandler;
+    use env_defs::PolicyResp;
+
+    let zip_base64 = payload
+        .get("zip_base64")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("Missing 'zip_base64' parameter"))?;
+
+    let policy_json = payload
+        .get("policy")
+        .ok_or_else(|| anyhow!("Missing 'policy' parameter"))?;
+
+    let policy: PolicyResp = serde_json::from_value(policy_json.clone())
+        .map_err(|e| anyhow!("Failed to deserialize policy: {}", e))?;
+
+    let handler = GenericCloudHandler::default().await;
+    let all_regions = handler.get_all_regions().await?;
+
+    with_publish_scope("policy".to_string(), policy.policy.clone(), None, async {
+        env_common::logic::server_publish_policy(&handler, &policy, zip_base64, &all_regions)
+            .await?;
+
+        Ok(json!({
+            "status": "success",
+            "message": format!("Policy {} version {} uploaded", policy.policy, policy.version)
+        }))
+    })
+    .await
 }
 
 // Re-export or delegate remaining handlers if needed, assuming they are imported from handlers module

--- a/internal-api/src/http_router.rs
+++ b/internal-api/src/http_router.rs
@@ -120,6 +120,10 @@ async fn auth_middleware(
     request: Request,
     next: Next,
 ) -> Response {
+    if let Err(e) = ensure_authenticated_user(&headers) {
+        return e.into_response();
+    }
+
     if let Some(project_param) = params.get("project") {
         for project in project_param.split(',') {
             let p = project.trim();
@@ -217,6 +221,14 @@ async fn publish_auth_middleware(headers: HeaderMap, request: Request, next: Nex
                     .unwrap_or("unknown")
                     .to_string();
                 ("provider".to_string(), name)
+            } else if path.contains("/policy/publish") {
+                let name = body_json
+                    .get("policy")
+                    .and_then(|p| p.get("policy"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                ("policy".to_string(), name)
             } else {
                 return (
                     StatusCode::BAD_REQUEST,
@@ -407,6 +419,8 @@ pub fn create_router() -> Router {
         .route("/api/v1/stack/publish", post(publish_stack))
         // Provider publish route - accepts pre-built providers
         .route("/api/v1/provider/publish", post(publish_provider))
+        // Policy publish route - accepts pre-built policies
+        .route("/api/v1/policy/publish", post(publish_policy))
         .layer(middleware::from_fn(publish_auth_middleware));
 
     open_routes
@@ -549,6 +563,35 @@ async fn ensure_access(
                 })),
             ))
         }
+    }
+}
+
+fn ensure_authenticated_user(
+    headers: &HeaderMap,
+) -> Result<(), (StatusCode, axum::response::Json<serde_json::Value>)> {
+    if headers
+        .get("x-auth-user")
+        .and_then(|v| v.to_str().ok())
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    #[cfg(feature = "local")]
+    {
+        log::warn!(
+            "Missing x-auth-user header, allowing authenticated-only route (LOCAL MODE ONLY)"
+        );
+        Ok(())
+    }
+    #[cfg(not(feature = "local"))]
+    {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({
+                "error": "Missing authentication user context"
+            })),
+        ))
     }
 }
 
@@ -1424,6 +1467,7 @@ async fn download_provider(Json(body): Json<Value>) -> impl IntoResponse {
         .await,
     )
     .await
+    .into_response()
 }
 
 async fn publish_module(Json(body): Json<PublishModuleBody>) -> impl IntoResponse {
@@ -1462,6 +1506,12 @@ struct PublishProviderBody {
     provider: Value,
 }
 
+#[derive(Deserialize)]
+struct PublishPolicyBody {
+    zip_base64: String,
+    policy: Value,
+}
+
 async fn publish_provider(Json(body): Json<PublishProviderBody>) -> impl IntoResponse {
     handle_result(
         handlers::publish_provider(&json!({
@@ -1473,25 +1523,64 @@ async fn publish_provider(Json(body): Json<PublishProviderBody>) -> impl IntoRes
     .await
 }
 
-async fn run_claim(Json(body): Json<Value>) -> impl IntoResponse {
+async fn publish_policy(Json(body): Json<PublishPolicyBody>) -> impl IntoResponse {
+    handle_result(
+        handlers::publish_policy(&json!({
+            "zip_base64": body.zip_base64,
+            "policy": body.policy
+        }))
+        .await,
+    )
+    .await
+}
+
+async fn run_claim(headers: HeaderMap, Json(body): Json<Value>) -> Response {
     log::info!("Received run_claim request");
     // Body is ApiInfraPayloadWithVariables
     // Manually extract payload and variables from the JSON value
     let payload_value = match body.get("payload") {
         Some(p) => p.clone(),
-        None => return handle_result(Err(anyhow::anyhow!("Missing 'payload' field"))).await,
+        None => {
+            return handle_result(Err(anyhow::anyhow!("Missing 'payload' field")))
+                .await
+                .into_response()
+        }
     };
 
     let variables = match body.get("variables") {
         Some(v) => v.clone(),
-        None => return handle_result(Err(anyhow::anyhow!("Missing 'variables' field"))).await,
+        None => {
+            return handle_result(Err(anyhow::anyhow!("Missing 'variables' field")))
+                .await
+                .into_response()
+        }
     };
 
     let payload: env_defs::ApiInfraPayload = match serde_json::from_value(payload_value.clone()) {
         Ok(p) => p,
-        Err(e) => return handle_result(Err(anyhow::anyhow!("Invalid payload: {}", e))).await,
+        Err(e) => {
+            return handle_result(Err(anyhow::anyhow!("Invalid payload: {}", e)))
+                .await
+                .into_response()
+        }
     };
 
+    if let Err(e) = ensure_access(&headers, &payload.project_id).await {
+        return e.into_response();
+    }
+
+    handlers::with_workload_account(
+        payload.project_id.clone(),
+        run_claim_authorized(payload_value, variables, payload),
+    )
+    .await
+}
+
+async fn run_claim_authorized(
+    payload_value: Value,
+    variables: Value,
+    payload: env_defs::ApiInfraPayload,
+) -> Response {
     // Launch runner with ApiInfraPayload only (no variables to avoid size limits)
     let result = handlers::start_runner(&json!({
         "data": payload_value
@@ -1500,7 +1589,7 @@ async fn run_claim(Json(body): Json<Value>) -> impl IntoResponse {
 
     let task_arn = match result {
         Ok(resp) => resp["task_arn"].as_str().unwrap_or("").to_string(),
-        Err(e) => return handle_result(Err(e)).await,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
     };
 
     // Extract task ID from ARN: arn:aws:ecs:region:account:task/cluster/TASK_ID
@@ -1512,7 +1601,7 @@ async fn run_claim(Json(body): Json<Value>) -> impl IntoResponse {
     // This allows the runner to query the deployment and get variables
     if let Err(e) = insert_deployment_record(&payload, &variables, &task_id).await {
         log::error!("Failed to insert deployment record: {}", e);
-        return handle_result(Err(e)).await;
+        return handle_result(Err(e)).await.into_response();
     }
 
     handle_result(Ok(json!({
@@ -1520,6 +1609,7 @@ async fn run_claim(Json(body): Json<Value>) -> impl IntoResponse {
         "job_id": task_id
     })))
     .await
+    .into_response()
 }
 
 async fn insert_deployment_record(
@@ -1690,5 +1780,62 @@ mod tests {
             .unwrap();
 
         assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    // The `local` feature compiles in an auth bypass (missing x-auth-user is
+    // allowed), so these auth-requirement assertions only hold with it off.
+    #[cfg(not(feature = "local"))]
+    #[tokio::test]
+    async fn provider_download_requires_auth_context() {
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/provider/download")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"s3_key":"aws/aws-1.0.0.zip"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[cfg(not(feature = "local"))]
+    #[tokio::test]
+    async fn project_routes_require_auth_context_before_project_check() {
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/v1/deployments/135808927253/us-west-2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[cfg(not(feature = "local"))]
+    #[tokio::test]
+    async fn policy_publish_route_requires_publish_auth_context() {
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/policy/publish")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"zip_base64":"AA==","policy":{"policy":"guardrail","environment":"default"}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/internal-api/src/main_aws_unified.rs
+++ b/internal-api/src/main_aws_unified.rs
@@ -81,6 +81,7 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
         .or_else(|| payload.get("rawPath"))
         .and_then(|v| v.as_str())
         .unwrap_or("/");
+    let is_token_route = path == "/api/v1/auth/token";
 
     // Build full URI with query string parameters
     let uri = if let Some(query_params) = payload
@@ -184,16 +185,14 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
             }
 
             if let Some(claims) = maybe_claims {
-                use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-
                 let claims_json = serde_json::to_vec(&claims)
                     .map_err(|e| Error::from(format!("Failed to serialize JWT claims: {}", e)))?;
                 request_builder = request_builder.header(
                     "x-infraweave-verified-claims",
-                    URL_SAFE_NO_PAD.encode(claims_json),
+                    general_purpose::URL_SAFE_NO_PAD.encode(claims_json),
                 );
             }
-        } else {
+        } else if is_token_route {
             // Try IAM authentication (for IAM-signed requests to token bridge)
             // IAM auth info is in requestContext.authorizer.iam
             if let Some(authorizer) = request_context.get("authorizer") {
@@ -211,6 +210,7 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
                     if let Some(user) = iam_user {
                         info!("Authenticated user (IAM): {}", user);
                         request_builder = request_builder.header("x-auth-user", user);
+                        span.record("user_id", &user);
                     } else {
                         warn!("No user identity found in IAM authorizer");
                         warn!(
@@ -224,6 +224,11 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
             } else {
                 warn!("No authorizer found in request context");
             }
+        } else {
+            debug!(
+                "Skipping IAM auth fallback for non-token route {}; IAM auth is only accepted for /api/v1/auth/token",
+                path
+            );
         }
     }
 
@@ -352,6 +357,7 @@ async fn main() -> Result<(), Error> {
     }
 
     initialize_project_id_and_region().await;
+    handlers::ensure_access_roles_configured().map_err(|e| Error::from(e.to_string()))?;
 
     info!(
         "Starting unified internal-api Lambda handler (supports both direct invocation and HTTP)"

--- a/internal-api/src/publish_auth/README.md
+++ b/internal-api/src/publish_auth/README.md
@@ -51,8 +51,8 @@ The Rego policy then:
    `identity.workflow_name`, or `identity.environment`.
 3. Looks up the actor prefix for the requested resource type and strips it
    from the actor. The remainder must equal the requested resource name.
-4. If the resource type is in `track_exempt_types` (default: `provider`),
-   allow.
+4. If the resource type is in `track_exempt_types` (default: `provider` and
+   `policy`), allow.
 5. Otherwise, allow iff `request.track` is in the trusted or untrusted set,
    selected by `identity.ref == trusted_context`.
 

--- a/internal-api/src/publish_auth/github_oidc.rego
+++ b/internal-api/src/publish_auth/github_oidc.rego
@@ -12,7 +12,7 @@ import rego.v1
 #
 # Publishes from the trusted ref (refs/heads/main) may target trusted tracks
 # (stable/rc/beta/alpha). Publishes from any other ref may target only `dev`.
-# `provider` is exempt from track gating.
+# `provider` and `policy` are exempt from track gating.
 #
 # Defense in depth: pair this with an IAM trust policy that only lets the
 # expected GitHub repos assume the publish role. For monorepos or extra
@@ -59,7 +59,7 @@ trusted_tracks := {"stable", "rc", "beta", "alpha"}
 
 untrusted_tracks := {"dev"}
 
-track_exempt_types := {"provider"}
+track_exempt_types := {"provider", "policy"}
 
 allow if {
 	input.identity.provider == "github_oidc"

--- a/internal-api/src/publish_auth/tests.rs
+++ b/internal-api/src/publish_auth/tests.rs
@@ -184,6 +184,22 @@ fn rego_policy_allows_dev_publish_from_non_main_ref() {
 }
 
 #[test]
+fn rego_policy_allows_matching_policy_publish_without_track() {
+    let _guard = test_setup();
+    use_github_oidc_policy();
+
+    let claims = json!({
+        "iss": GITHUB_OIDC_ISS,
+        "repository": "infraweave-io/tf-policy-guardrail",
+        "repository_owner": "infraweave-io",
+        "ref": "refs/heads/feature"
+    });
+
+    assert!(publish_allowed(&claims, "policy", "guardrail", None));
+    assert!(!publish_allowed(&claims, "policy", "baseline", None));
+}
+
+#[test]
 fn rego_policy_denies_cross_module_publish() {
     let _guard = test_setup();
     use_github_oidc_policy();


### PR DESCRIPTION
- Add with_workload_account / with_publish_scope wrappers backed by task-locals; get_aws_config resolves the matching assume-role creds, so DynamoDB queries and S3 reads/writes are scoped automatically.
- Read handlers (deployments, events, change records, graphs) now query within the caller's workload account via query_workload_account.
- Publish/deprecate handlers (module, stack, policy, provider) run inside a publish scope tagged with resource type/name/track.
- Add the /policy/publish route, body parsing, and publish auth; exempt policy from track gating in the GitHub OIDC rego (alongside provider).
- Require an authenticated user context on protected routes and restrict the IAM auth fallback to /api/v1/auth/token.
- Add unit tests for workload scoping and policy publish authorization.