### PR TITLE
feat: refactor local development configuration and remove TEST_MODE references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,6 @@ Thank you for your interest in contributing to Infraweave! We value your contrib
               "AWS_ACCESS_KEY_ID": "dummy",
               "AWS_SECRET_ACCESS_KEY": "dummy",
               "AWS_REGION": "us-east-1",
-              "TEST_MODE": "true",
               "CONCURRENCY_LIMIT": "1"
           },
           "rust-analyzer.runnables.extraTestBinaryArgs": [

--- a/env_aws_direct/README.md
+++ b/env_aws_direct/README.md
@@ -88,11 +88,15 @@ Functions that build DynamoDB query payloads for use with `read_db_direct`:
 - `CENTRAL_ACCOUNT_ID` - Central AWS account ID
 - `NOTIFICATION_TOPIC_ARN` - SNS topic ARN for notifications
 
-### Local Development (`TEST_MODE`)
+### Local Development
 
-When `TEST_MODE` is set, the crate uses local endpoints instead of real AWS services:
+When local endpoints are configured, the crate uses them instead of real AWS services:
 
 - `DYNAMODB_ENDPOINT` or `AWS_ENDPOINT_URL_DYNAMODB` - Local DynamoDB endpoint
 - `AWS_ENDPOINT_URL_S3` or `MINIO_ENDPOINT` - Local S3/MinIO endpoint
 - `AWS_S3_FORCE_PATH_STYLE` - Force path-style S3 URLs (for MinIO)
 - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` - Credentials for local services
+
+When local endpoints are configured, stored login tokens are ignored for HTTP
+mode detection. Set `INFRAWEAVE_API_ENDPOINT` explicitly to use the HTTP API
+transport against a local server.

--- a/env_aws_direct/src/api.rs
+++ b/env_aws_direct/src/api.rs
@@ -52,12 +52,7 @@ fn get_s3_client(config: &aws_config::SdkConfig) -> aws_sdk_s3::Client {
 async fn get_s3_client_direct(region: &str) -> aws_sdk_s3::Client {
     use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
 
-    // Check for MinIO/custom S3 endpoint (local development)
-    let endpoint_opt = std::env::var("AWS_ENDPOINT_URL_S3")
-        .or_else(|_| std::env::var("MINIO_ENDPOINT"))
-        .ok();
-
-    if let Some(endpoint) = endpoint_opt {
+    if let Some(endpoint) = env_utils::runtime_env::s3_endpoint() {
         // Local development mode - use MinIO/custom endpoint
         eprintln!("Local mode: Using S3 endpoint {}", endpoint);
 

--- a/env_aws_direct/src/backend.rs
+++ b/env_aws_direct/src/backend.rs
@@ -15,33 +15,6 @@ pub async fn set_backend(
     exec.arg(format!("-backend-config=bucket={}", tf_bucket));
     exec.arg(format!("-backend-config=key={}", key));
     exec.arg(format!("-backend-config=region={}", region));
-
-    // // In test mode, use MinIO for state storage instead of real S3
-    // #[cfg(feature = "test-mode")]
-    // {
-    //     let minio_endpoint =
-    //         env::var("MINIO_ENDPOINT").expect("MINIO_ENDPOINT must be set in test-mode");
-    //     let minio_access_key =
-    //         env::var("MINIO_ACCESS_KEY").expect("MINIO_ACCESS_KEY must be set in test-mode");
-    //     let minio_secret_key =
-    //         env::var("MINIO_SECRET_KEY").expect("MINIO_SECRET_KEY must be set in test-mode");
-
-    //     exec.arg(format!("-backend-config=endpoint={}", minio_endpoint));
-    //     exec.arg(format!("-backend-config=access_key={}", minio_access_key));
-    //     exec.arg(format!("-backend-config=secret_key={}", minio_secret_key));
-    //     exec.arg("-backend-config=skip_credentials_validation=true");
-    //     exec.arg("-backend-config=skip_metadata_api_check=true");
-    //     exec.arg("-backend-config=skip_requesting_account_id=true");
-    //     exec.arg("-backend-config=use_path_style=true");
-    //     // Skip DynamoDB locking in test mode - tests run sequentially so no conflicts
-    // }
-
-    // // Use DynamoDB locking only in production (not in test mode)
-    // #[cfg(not(feature = "test-mode"))]
-    // {
-    //     let dynamodb_table = get_env_var("TF_DYNAMODB_TABLE");
-    //     exec.arg(format!("-backend-config=dynamodb_table={}", dynamodb_table));
-    // }
 }
 
 fn get_env_var(key: &str) -> String {

--- a/env_aws_direct/src/direct_impl.rs
+++ b/env_aws_direct/src/direct_impl.rs
@@ -10,11 +10,8 @@ use crate::utils::get_table_name;
 async fn get_dynamodb_client(region_opt: Option<&str>) -> aws_sdk_dynamodb::Client {
     use aws_sdk_dynamodb::config::{BehaviorVersion, Credentials, Region};
 
-    if std::env::var("TEST_MODE").is_ok() {
+    if let Some(endpoint) = env_utils::runtime_env::dynamodb_endpoint() {
         // Local development mode - use local DynamoDB
-        let endpoint = std::env::var("DYNAMODB_ENDPOINT")
-            .or_else(|_| std::env::var("AWS_ENDPOINT_URL_DYNAMODB"))
-            .expect("DYNAMODB_ENDPOINT or AWS_ENDPOINT_URL_DYNAMODB must be set in TEST_MODE");
         eprintln!("Local mode: Using DynamoDB endpoint: {}", endpoint);
 
         // Use same credentials as internal-api-local for local DynamoDB
@@ -321,6 +318,22 @@ async fn get_cloudwatch_logs_client(region_opt: Option<&str>) -> aws_sdk_cloudwa
 }
 
 pub async fn get_job_status_direct(job_id: &str, region_opt: Option<&str>) -> Result<Value> {
+    if env_utils::runtime_env::has_local_provider_endpoints() {
+        return Ok(json!({
+            "is_running": job_id.starts_with("running-"),
+            "status": if job_id.starts_with("running-") {
+                "RUNNING"
+            } else {
+                "STOPPED"
+            },
+            "stopped_reason": if job_id.starts_with("running-") {
+                ""
+            } else {
+                "local test job is not running"
+            }
+        }));
+    }
+
     let cluster = get_env_var("ECS_CLUSTER")?;
     let client = get_ecs_client(region_opt).await;
 
@@ -626,11 +639,7 @@ fn json_to_dynamodb_item_helper(json: &Value) -> Result<HashMap<String, Attribut
 // ============= S3 Operations =============
 
 async fn get_s3_client(region_opt: Option<&str>) -> aws_sdk_s3::Client {
-    let endpoint_opt = std::env::var("AWS_ENDPOINT_URL_S3")
-        .or_else(|_| std::env::var("MINIO_ENDPOINT"))
-        .ok();
-
-    if let Some(endpoint) = endpoint_opt {
+    if let Some(endpoint) = env_utils::runtime_env::s3_endpoint() {
         use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
 
         let credentials = Credentials::new(

--- a/env_aws_direct/src/job_id.rs
+++ b/env_aws_direct/src/job_id.rs
@@ -10,7 +10,8 @@ use reqwest::Client;
 use std::env;
 
 pub async fn get_current_job_id() -> Result<String, anyhow::Error> {
-    if std::env::var("TEST_MODE").is_ok() {
+    if !env_utils::runtime_env::is_running_in_ecs() && env_utils::runtime_env::has_local_dynamodb()
+    {
         return Ok("running-test-job-id".to_string());
     };
 

--- a/env_common/src/interface/cloud_handlers.rs
+++ b/env_common/src/interface/cloud_handlers.rs
@@ -552,23 +552,21 @@ impl GenericCloudHandler {
 pub async fn initialize_project_id_and_region() -> String {
     // Check if HTTP mode is enabled - if so, skip AWS SDK calls and output
     let is_http_mode = http_client::is_http_mode_enabled();
+    let has_local_provider_endpoints = env_utils::runtime_env::has_local_provider_endpoints();
 
     if crate::logic::PROJECT_ID.get().is_none() {
-        let project_id = match std::env::var("TEST_MODE") {
-            Ok(_) => "test-mode".to_string(),
-            Err(_) => {
-                if is_http_mode {
-                    // In HTTP mode, project_id should come from --project flag.
-                    // If not set yet, use a placeholder; the actual project arrives per-request.
-                    "http-mode-no-project".to_string()
-                } else {
-                    GenericCloudHandler::default()
-                        .await
-                        .provider
-                        .get_project_id()
-                        .to_string()
-                }
-            }
+        let project_id = if is_http_mode {
+            // In HTTP mode, project_id should come from --project flag.
+            // If not set yet, use a placeholder; the actual project arrives per-request.
+            "http-mode-no-project".to_string()
+        } else if has_local_provider_endpoints {
+            std::env::var("ACCOUNT_ID").unwrap_or_else(|_| "000000000000".to_string())
+        } else {
+            GenericCloudHandler::default()
+                .await
+                .provider
+                .get_project_id()
+                .to_string()
         };
         if !is_http_mode {
             eprintln!("Project ID: {}", &project_id);
@@ -578,22 +576,23 @@ pub async fn initialize_project_id_and_region() -> String {
             .expect("Failed to set PROJECT_ID");
     }
     if crate::logic::REGION.get().is_none() {
-        let region = match std::env::var("TEST_MODE") {
-            Ok(_) => std::env::var("AWS_REGION").unwrap_or_else(|_| "us-west-2".to_string()),
-            Err(_) => {
+        let region = if is_http_mode || has_local_provider_endpoints {
+            // In HTTP mode, region is resolved per-request from the claim
+            // file (spec.region) or --region flag.  At init time we just
+            // need a default so the global REGION OnceLock is populated.
+            std::env::var("AWS_REGION").unwrap_or_else(|_| {
                 if is_http_mode {
-                    // In HTTP mode, region is resolved per-request from the claim
-                    // file (spec.region) or --region flag.  At init time we just
-                    // need a default so the global REGION OnceLock is populated.
-                    std::env::var("AWS_REGION").unwrap_or_else(|_| "unknown".to_string())
+                    "unknown".to_string()
                 } else {
-                    GenericCloudHandler::default()
-                        .await
-                        .provider
-                        .get_region()
-                        .to_string()
+                    "us-west-2".to_string()
                 }
-            }
+            })
+        } else {
+            GenericCloudHandler::default()
+                .await
+                .provider
+                .get_region()
+                .to_string()
         };
         if !is_http_mode {
             eprintln!("Region initialized");

--- a/env_common/src/logic/api_module.rs
+++ b/env_common/src/logic/api_module.rs
@@ -484,22 +484,18 @@ pub async fn publish_module_from_zip(
             info!("Successfully completed OCI module publishing");
         }
         None => {
-            // Check if TEST_MODE is enabled to determine concurrency limit
-            let is_test_mode = std::env::var("TEST_MODE")
-                .map(|val| val.to_lowercase() == "true" || val == "1")
-                .unwrap_or(false);
-
             let concurrency_limit_env = std::env::var("CONCURRENCY_LIMIT")
                 .unwrap_or_else(|_| "".to_string())
                 .parse::<usize>()
                 .unwrap_or(10);
 
-            let effective_concurrency_limit = if is_test_mode {
-                debug!("TEST_MODE enabled, limiting all upload operations to concurrency of 1");
-                1
-            } else {
-                concurrency_limit_env
-            };
+            let effective_concurrency_limit =
+                if env_utils::runtime_env::has_local_provider_endpoints() {
+                    debug!("Local endpoints configured, limiting all upload operations to concurrency of 1");
+                    1
+                } else {
+                    concurrency_limit_env
+                };
 
             println!("Publishing module and ensuring providers in all regions with concurrency limit: {}", effective_concurrency_limit);
 

--- a/env_common/src/logic/api_provider.rs
+++ b/env_common/src/logic/api_provider.rs
@@ -132,18 +132,13 @@ pub async fn publish_provider_from_zip(
 
     let all_regions = handler.get_all_regions().await?;
 
-    // Check if TEST_MODE is enabled to determine concurrency limit
-    let is_test_mode = std::env::var("TEST_MODE")
-        .map(|val| val.to_lowercase() == "true" || val == "1")
-        .unwrap_or(false);
-
     let concurrency_limit_env = std::env::var("CONCURRENCY_LIMIT")
         .unwrap_or_else(|_| "".to_string())
         .parse::<usize>()
         .unwrap_or(10);
 
-    let effective_concurrency_limit = if is_test_mode {
-        debug!("TEST_MODE enabled, limiting all upload operations to concurrency of 1");
+    let effective_concurrency_limit = if env_utils::runtime_env::has_local_provider_endpoints() {
+        debug!("Local endpoints configured, limiting all upload operations to concurrency of 1");
         1
     } else {
         concurrency_limit_env

--- a/env_common/src/logic/api_stack.rs
+++ b/env_common/src/logic/api_stack.rs
@@ -589,18 +589,13 @@ pub async fn publish_stack(
 
     let all_regions = handler.get_all_regions().await?;
 
-    // Check if TEST_MODE is enabled to determine concurrency limit
-    let is_test_mode = std::env::var("TEST_MODE")
-        .map(|val| val.to_lowercase() == "true" || val == "1")
-        .unwrap_or(false);
-
     let concurrency_limit_env = std::env::var("CONCURRENCY_LIMIT")
         .unwrap_or_else(|_| "".to_string())
         .parse::<usize>()
         .unwrap_or(10);
 
-    let effective_concurrency_limit = if is_test_mode {
-        debug!("TEST_MODE enabled, limiting all upload operations to concurrency of 1");
+    let effective_concurrency_limit = if env_utils::runtime_env::has_local_provider_endpoints() {
+        debug!("Local endpoints configured, limiting all upload operations to concurrency of 1");
         1
     } else {
         concurrency_limit_env

--- a/http_client/src/client.rs
+++ b/http_client/src/client.rs
@@ -706,12 +706,20 @@ pub async fn http_get_job_status(project: &str, region: &str, job_id: &str) -> R
     http_get(&path).await
 }
 
-/// Check if HTTP mode is enabled (via env var or config file)
+/// Check if HTTP mode is enabled.
+///
+/// An explicit INFRAWEAVE_API_ENDPOINT always opts into HTTP mode. Stored
+/// login config is ignored when local provider endpoints are configured, so
+/// local scaffolds do not accidentally use a developer's login state.
 pub fn is_http_mode_enabled() -> bool {
-    // Integration tests use direct Lambda invocations, so never use HTTP mode there.
-    if std::env::var("TEST_MODE").is_ok() {
+    if std::env::var("INFRAWEAVE_API_ENDPOINT").is_ok() {
+        return true;
+    }
+
+    if env_utils::runtime_env::has_local_provider_endpoints() {
         return false;
     }
+
     get_api_endpoint().is_ok()
 }
 

--- a/integration-tests/tests/cli_http.rs
+++ b/integration-tests/tests/cli_http.rs
@@ -57,8 +57,6 @@ mod cli_http_tests {
 
                 let port = internal_api::local_setup::start_test_server();
 
-                // Remove TEST_MODE so is_http_mode_enabled() returns true.
-                std::env::remove_var("TEST_MODE");
                 std::env::set_var(
                     "INFRAWEAVE_API_ENDPOINT",
                     format!("http://127.0.0.1:{}", port),

--- a/internal-api/src/local_setup.rs
+++ b/internal-api/src/local_setup.rs
@@ -75,11 +75,6 @@ pub async fn start_local_infrastructure() -> anyhow::Result<LocalInfra> {
     if std::env::var("AWS_REGION").is_err() {
         std::env::set_var("AWS_REGION", "us-west-2");
     }
-    // Enable TEST_MODE so env_aws_direct uses local DynamoDB/MinIO endpoints
-    // and is_http_mode_enabled() returns false (avoids stale ~/.infraweave/tokens.json)
-    if std::env::var("TEST_MODE").is_err() {
-        std::env::set_var("TEST_MODE", "true");
-    }
     if std::env::var("ENVIRONMENT").is_err() {
         std::env::set_var("ENVIRONMENT", "dev");
     }

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -742,17 +742,15 @@ async fn download_all_providers(
         })
         .collect::<Vec<_>>();
 
-    let is_test_mode = std::env::var("TEST_MODE")
-        .map(|val| val.to_lowercase() == "true" || val == "1")
-        .unwrap_or(false);
-
     let concurrency_limit_env = std::env::var("CONCURRENCY_LIMIT")
         .unwrap_or_else(|_| "".to_string())
         .parse::<usize>()
         .unwrap_or(10);
 
-    let effective_concurrency_limit = if is_test_mode {
-        log::info!("TEST_MODE enabled, limiting all download operations to concurrency of 1");
+    let effective_concurrency_limit = if env_utils::runtime_env::has_local_provider_endpoints() {
+        log::info!(
+            "Local endpoints configured, limiting all download operations to concurrency of 1"
+        );
         1
     } else {
         concurrency_limit_env
@@ -776,7 +774,7 @@ async fn download_provider(
     target: &str,
     category: &str,
 ) -> Result<()> {
-    let mirror_dir = if std::env::var("TEST_MODE").is_ok() {
+    let mirror_dir = if env_utils::runtime_env::has_local_provider_endpoints() {
         env::temp_dir()
             .join(".provider-mirror")
             .to_string_lossy()
@@ -813,7 +811,7 @@ pub async fn set_up_provider_mirror(
     provider_versions: &[TfLockProvider],
     target: &str,
 ) -> Result<(), anyhow::Error> {
-    let mirror_dir = if std::env::var("TEST_MODE").is_ok() {
+    let mirror_dir = if env_utils::runtime_env::has_local_provider_endpoints() {
         env::temp_dir()
             .join(".provider-mirror")
             .to_string_lossy()
@@ -839,7 +837,7 @@ provider_installation {{
 "#,
         mirror_dir
     );
-    let provider_mirror_file = if std::env::var("TEST_MODE").is_ok() {
+    let provider_mirror_file = if env_utils::runtime_env::has_local_provider_endpoints() {
         env::temp_dir()
             .join(".terraformrc")
             .to_string_lossy()

--- a/utils/src/config_path.rs
+++ b/utils/src/config_path.rs
@@ -10,14 +10,13 @@ struct StoredConfig {
 /// Check if HTTP mode is enabled (cloud-agnostic).
 /// Returns true if an API endpoint is configured via INFRAWEAVE_API_ENDPOINT
 /// environment variable or the config file (from `infraweave login`).
-/// Returns false if TEST_MODE is set (used by the local scaffold to force direct DB access).
+/// Ignores stored login config when local provider endpoints are configured.
 pub fn is_http_mode_enabled() -> bool {
-    // TEST_MODE explicitly disables HTTP mode (used by the local scaffold during seeding)
-    if std::env::var("TEST_MODE").is_ok() {
-        return false;
-    }
     if std::env::var("INFRAWEAVE_API_ENDPOINT").is_ok() {
         return true;
+    }
+    if crate::runtime_env::has_local_provider_endpoints() {
+        return false;
     }
     if let Ok(path) = get_token_path() {
         if path.exists() {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -12,6 +12,7 @@ mod oci;
 #[cfg(feature = "otel")]
 pub mod otel_tracing;
 mod provider_util;
+pub mod runtime_env;
 mod schema_validation;
 mod stack;
 mod string_utils;

--- a/utils/src/runtime_env.rs
+++ b/utils/src/runtime_env.rs
@@ -1,0 +1,51 @@
+pub fn dynamodb_endpoint() -> Option<String> {
+    std::env::var("DYNAMODB_ENDPOINT")
+        .or_else(|_| std::env::var("AWS_ENDPOINT_URL_DYNAMODB"))
+        .ok()
+}
+
+pub fn s3_endpoint() -> Option<String> {
+    std::env::var("AWS_ENDPOINT_URL_S3")
+        .or_else(|_| std::env::var("MINIO_ENDPOINT"))
+        .ok()
+}
+
+pub fn has_local_dynamodb() -> bool {
+    dynamodb_endpoint().is_some()
+}
+
+pub fn has_local_s3() -> bool {
+    s3_endpoint().is_some()
+}
+
+pub fn has_local_azure_storage() -> bool {
+    std::env::var("AZURE_STORAGE_CONNECTION_STRING")
+        .or_else(|_| std::env::var("AZURITE_CONNECTION_STRING"))
+        .ok()
+        .map(|value| {
+            value.contains("127.0.0.1")
+                || value.contains("localhost")
+                || value.contains("azurite")
+                || value == "UseDevelopmentStorage=true"
+        })
+        .unwrap_or(false)
+}
+
+pub fn has_local_cosmos() -> bool {
+    std::env::var("COSMOS_DB_ENDPOINT")
+        .ok()
+        .map(|value| {
+            value.contains("127.0.0.1") || value.contains("localhost") || value.contains("cosmos")
+        })
+        .unwrap_or(false)
+}
+
+pub fn has_local_provider_endpoints() -> bool {
+    has_local_dynamodb() || has_local_s3() || has_local_azure_storage() || has_local_cosmos()
+}
+
+pub fn is_running_in_ecs() -> bool {
+    std::env::var("ECS_CONTAINER_METADATA_URI_V4")
+        .or_else(|_| std::env::var("ECS_CONTAINER_METADATA_URI"))
+        .is_ok()
+}


### PR DESCRIPTION
Refactors local development detection to use explicit local provider endpoints instead of the `TEST_MODE` environment variable.

Adds shared runtime environment helpers for DynamoDB, S3/MinIO, Azure storage, Cosmos, and ECS detection, then applies them across AWS direct access, HTTP mode detection, publishing concurrency, provider mirror setup, job status handling, and local infrastructure setup.

Also updates docs and removes stale `TEST_MODE` references so local scaffolds behave consistently and do not accidentally use stored login config unless `INFRAWEAVE_API_ENDPOINT` is explicitly set.