### PR TITLE
feat: prepare aws direct local bootstrap

### DIFF
--- a/env_aws_direct/src/api.rs
+++ b/env_aws_direct/src/api.rs
@@ -87,7 +87,8 @@ pub async fn run_function(
 ) -> Result<GenericFunctionResponse, CloudHandlerError> {
     use crate::direct_impl::{
         get_environment_variables_direct, get_job_status_direct, insert_db_direct,
-        publish_notification_direct, read_db_direct, read_logs_direct, transact_write_direct,
+        publish_notification_direct, read_db_direct, read_logs_direct, start_runner_cross_account,
+        transact_write_direct,
     };
     use crate::utils::get_bucket_name_for_region;
     use aws_sdk_s3::primitives::ByteStream;
@@ -124,8 +125,45 @@ pub async fn run_function(
                 .and_then(|j| j.as_str())
                 .ok_or_else(|| CloudHandlerError::OtherError("Missing job_id field".to_string()))?;
 
+            if std::env::var("TEST_MODE").is_ok() {
+                return Ok(GenericFunctionResponse {
+                    payload: serde_json::to_value(env_defs::JobStatus {
+                        job_id: job_id.to_string(),
+                        is_running: job_id.starts_with("running-"),
+                    })
+                    .map_err(|e| {
+                        CloudHandlerError::OtherError(format!(
+                            "Failed to serialize job status: {}",
+                            e
+                        ))
+                    })?,
+                });
+            }
+
             match get_job_status_direct(job_id, Some(region)).await {
-                Ok(data) => Ok(GenericFunctionResponse { payload: data }),
+                Ok(data) => {
+                    let status = data
+                        .get("status")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("UNKNOWN");
+                    let is_running = matches!(
+                        status,
+                        "PROVISIONING" | "PENDING" | "ACTIVATING" | "RUNNING"
+                    );
+
+                    Ok(GenericFunctionResponse {
+                        payload: serde_json::to_value(env_defs::JobStatus {
+                            job_id: job_id.to_string(),
+                            is_running,
+                        })
+                        .map_err(|e| {
+                            CloudHandlerError::OtherError(format!(
+                                "Failed to serialize job status: {}",
+                                e
+                            ))
+                        })?,
+                    })
+                }
                 Err(e) => Err(CloudHandlerError::OtherError(format!(
                     "Direct get_job_status failed: {}",
                     e
@@ -147,6 +185,25 @@ pub async fn run_function(
                 Ok(data) => Ok(GenericFunctionResponse { payload: data }),
                 Err(e) => Err(CloudHandlerError::OtherError(format!(
                     "Direct read_logs failed: {}",
+                    e
+                ))),
+            }
+        }
+        "start_runner" => {
+            if std::env::var("TEST_MODE").is_ok() {
+                return Ok(GenericFunctionResponse {
+                    payload: json!({ "job_id": "running-test-job-id" }),
+                });
+            }
+
+            let data = payload
+                .get("data")
+                .ok_or_else(|| CloudHandlerError::OtherError("Missing data field".to_string()))?;
+
+            match start_runner_cross_account(data).await {
+                Ok(data) => Ok(GenericFunctionResponse { payload: data }),
+                Err(e) => Err(CloudHandlerError::OtherError(format!(
+                    "Direct start_runner failed: {}",
                     e
                 ))),
             }
@@ -409,6 +466,58 @@ pub async fn run_function(
                 Ok(data) => Ok(GenericFunctionResponse { payload: data }),
                 Err(e) => Err(CloudHandlerError::OtherError(format!(
                     "Direct insert_db failed: {}",
+                    e
+                ))),
+            }
+        }
+        "bootstrap_tables" => {
+            if std::env::var("TEST_MODE").is_err() {
+                return Err(CloudHandlerError::OtherError(
+                    "bootstrap_tables is only supported in TEST_MODE".to_string(),
+                ));
+            }
+
+            let dynamodb_endpoint = std::env::var("DYNAMODB_ENDPOINT")
+                .or_else(|_| std::env::var("AWS_ENDPOINT_URL_DYNAMODB"))
+                .map_err(|_| {
+                    CloudHandlerError::OtherError(
+                        "DYNAMODB_ENDPOINT or AWS_ENDPOINT_URL_DYNAMODB must be set".to_string(),
+                    )
+                })?;
+
+            match crate::local_bootstrap::bootstrap_dynamodb_tables(&dynamodb_endpoint, region)
+                .await
+            {
+                Ok(_) => Ok(GenericFunctionResponse {
+                    payload: json!({ "status": "success" }),
+                }),
+                Err(e) => Err(CloudHandlerError::OtherError(format!(
+                    "Direct bootstrap_tables failed: {}",
+                    e
+                ))),
+            }
+        }
+        "bootstrap_buckets" => {
+            if std::env::var("TEST_MODE").is_err() {
+                return Err(CloudHandlerError::OtherError(
+                    "bootstrap_buckets is only supported in TEST_MODE".to_string(),
+                ));
+            }
+
+            let s3_endpoint = std::env::var("MINIO_ENDPOINT")
+                .or_else(|_| std::env::var("AWS_ENDPOINT_URL_S3"))
+                .map_err(|_| {
+                    CloudHandlerError::OtherError(
+                        "MINIO_ENDPOINT or AWS_ENDPOINT_URL_S3 must be set".to_string(),
+                    )
+                })?;
+
+            match crate::local_bootstrap::create_s3_buckets(&s3_endpoint, region).await {
+                Ok(_) => Ok(GenericFunctionResponse {
+                    payload: json!({ "status": "success" }),
+                }),
+                Err(e) => Err(CloudHandlerError::OtherError(format!(
+                    "Direct bootstrap_buckets failed: {}",
                     e
                 ))),
             }

--- a/env_aws_direct/src/backend.rs
+++ b/env_aws_direct/src/backend.rs
@@ -15,6 +15,26 @@ pub async fn set_backend(
     exec.arg(format!("-backend-config=bucket={}", tf_bucket));
     exec.arg(format!("-backend-config=key={}", key));
     exec.arg(format!("-backend-config=region={}", region));
+
+    if let Some(s3_endpoint) = env_utils::runtime_env::s3_endpoint() {
+        let access_key = env::var("AWS_ACCESS_KEY_ID")
+            .or_else(|_| env::var("MINIO_ACCESS_KEY"))
+            .unwrap_or_else(|_| "minio".to_string());
+        let secret_key = env::var("AWS_SECRET_ACCESS_KEY")
+            .or_else(|_| env::var("MINIO_SECRET_KEY"))
+            .unwrap_or_else(|_| "minio123".to_string());
+
+        exec.arg(format!("-backend-config=endpoint={}", s3_endpoint));
+        exec.arg(format!("-backend-config=access_key={}", access_key));
+        exec.arg(format!("-backend-config=secret_key={}", secret_key));
+
+        if env_utils::runtime_env::is_local_s3_endpoint(&s3_endpoint) {
+            exec.arg("-backend-config=skip_credentials_validation=true");
+            exec.arg("-backend-config=skip_metadata_api_check=true");
+            exec.arg("-backend-config=skip_requesting_account_id=true");
+            exec.arg("-backend-config=use_path_style=true");
+        }
+    }
 }
 
 fn get_env_var(key: &str) -> String {

--- a/env_aws_direct/src/central_creds.rs
+++ b/env_aws_direct/src/central_creds.rs
@@ -109,8 +109,18 @@ pub async fn init_central_credentials(region: &str) -> Result<()> {
         .load()
         .await;
 
+    let sts = aws_sdk_sts::Client::new(&bootstrap);
+    let identity = sts.get_caller_identity().send().await.map_err(|e| {
+        anyhow!(
+            "Failed to verify central role assumption {}: {:?}",
+            role_arn,
+            e
+        )
+    })?;
+
     let provider = AssumeRoleProvider::builder(role_arn.clone())
         .session_name("infraweave-central-session")
+        .tags([("WorkloadAccount", identity.account().unwrap_or_default())])
         .configure(&bootstrap)
         .build()
         .await;
@@ -130,10 +140,9 @@ pub async fn init_central_credentials(region: &str) -> Result<()> {
         )
     })?;
     log::info!(
-        "Assumed central role {} (arn={:?}, account={:?})",
+        "Assumed central role {} (arn={:#?})",
         role_arn,
-        identity.arn(),
-        identity.account()
+        identity.arn()
     );
 
     CENTRAL_CONFIG

--- a/env_aws_direct/src/direct_impl.rs
+++ b/env_aws_direct/src/direct_impl.rs
@@ -1271,6 +1271,16 @@ pub async fn read_logs_cross_account(
 }
 
 pub async fn publish_notification_direct(message: &str, subject: Option<&str>) -> Result<Value> {
+    if std::env::var("TEST_MODE").is_ok() && std::env::var("AWS_ENDPOINT_URL_SNS").is_err() {
+        log::info!(
+            "TEST_MODE enabled; skipping SNS notification publish. subject={:?}",
+            subject
+        );
+        return Ok(json!({
+            "message_id": "local-test-notification"
+        }));
+    }
+
     let topic_arn = get_env_var("NOTIFICATION_TOPIC_ARN")?;
     let config = get_aws_config(None).await;
     let sns_client = aws_sdk_sns::Client::new(&config);

--- a/env_aws_direct/src/local_bootstrap.rs
+++ b/env_aws_direct/src/local_bootstrap.rs
@@ -1,6 +1,8 @@
 // Local development bootstrap - creates DynamoDB tables and S3 buckets for local testing
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use aws_sdk_dynamodb::Client;
 use std::collections::HashMap;
+use tokio::time::{sleep, Duration};
 
 pub async fn bootstrap_dynamodb_tables(dynamodb_endpoint: &str, region: &str) -> Result<()> {
     use aws_sdk_dynamodb::types::{
@@ -8,8 +10,13 @@ pub async fn bootstrap_dynamodb_tables(dynamodb_endpoint: &str, region: &str) ->
         Projection, ProjectionType, ScalarAttributeType,
     };
 
-    let creds =
-        aws_sdk_dynamodb::config::Credentials::new("minio", "minio123", None, None, "static");
+    let creds = aws_sdk_dynamodb::config::Credentials::new(
+        std::env::var("AWS_ACCESS_KEY_ID").unwrap_or_else(|_| "minio".to_string()),
+        std::env::var("AWS_SECRET_ACCESS_KEY").unwrap_or_else(|_| "minio123".to_string()),
+        None,
+        None,
+        "static",
+    );
     let config = aws_sdk_dynamodb::Config::builder()
         .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
         .endpoint_url(dynamodb_endpoint)
@@ -240,9 +247,12 @@ pub async fn bootstrap_dynamodb_tables(dynamodb_endpoint: &str, region: &str) ->
                 let err_str = e.to_string();
                 if !err_str.contains("ResourceInUseException") {
                     println!("Error creating table {}: {}", table_name, e);
+                    return Err(e.into());
                 }
             }
         }
+
+        wait_for_table_active(&dynamodb, table_name).await?;
     }
 
     // Seed config table
@@ -334,8 +344,37 @@ pub async fn bootstrap_dynamodb_tables(dynamodb_endpoint: &str, region: &str) ->
     Ok(())
 }
 
+async fn wait_for_table_active(dynamodb: &Client, table_name: &str) -> Result<()> {
+    for _ in 0..50 {
+        let status = dynamodb
+            .describe_table()
+            .table_name(table_name)
+            .send()
+            .await?
+            .table()
+            .and_then(|table| table.table_status())
+            .map(|status| status.as_str().to_string());
+
+        if status.as_deref() == Some("ACTIVE") {
+            return Ok(());
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(anyhow!(
+        "Timed out waiting for DynamoDB table {table_name} to become ACTIVE"
+    ))
+}
+
 pub async fn create_s3_buckets(s3_endpoint: &str, region: &str) -> Result<()> {
-    let creds = aws_sdk_s3::config::Credentials::new("minio", "minio123", None, None, "static");
+    let creds = aws_sdk_s3::config::Credentials::new(
+        std::env::var("AWS_ACCESS_KEY_ID").unwrap_or_else(|_| "minio".to_string()),
+        std::env::var("AWS_SECRET_ACCESS_KEY").unwrap_or_else(|_| "minio123".to_string()),
+        None,
+        None,
+        "static",
+    );
     let config = aws_sdk_s3::Config::builder()
         .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
         .endpoint_url(s3_endpoint)

--- a/env_aws_direct/src/utils.rs
+++ b/env_aws_direct/src/utils.rs
@@ -17,6 +17,7 @@ pub const DEFAULT_BUCKET_NAMES: &[(&str, &str)] = &[
     ("POLICY_S3_BUCKET", "policies"),
     ("CHANGE_RECORD_S3_BUCKET", "change-records"),
     ("PROVIDERS_S3_BUCKET", "providers"),
+    ("TF_STATE_S3_BUCKET", "tf-state"),
 ];
 
 #[allow(dead_code)]

--- a/integration-tests/src/scaffold.rs
+++ b/integration-tests/src/scaffold.rs
@@ -79,6 +79,8 @@ where
     env::set_var("MINIO_ENDPOINT", &minio_host_endpoint);
     env::set_var("MINIO_ACCESS_KEY", "minio");
     env::set_var("MINIO_SECRET_KEY", "minio123");
+    env::set_var("AWS_ACCESS_KEY_ID", "minio");
+    env::set_var("AWS_SECRET_ACCESS_KEY", "minio123");
     env::set_var("DYNAMODB_ENDPOINT", &dynamodb_endpoint);
     println!(
         "MinIO started at: {} (host), {} (containers)",

--- a/integration-tests/tests/operator.rs
+++ b/integration-tests/tests/operator.rs
@@ -156,7 +156,7 @@ spec:
             deployment.status = DeploymentStatus::Successful;
             handler2.set_deployment(&deployment, false).await.unwrap();
 
-            sleep(Duration::from_secs(11)).await; // Refreshes every 10 seconds, hence guaranteeing a refresh
+            sleep(Duration::from_secs(35)).await;
 
             let claim_res = crd_api.get(deployment_id).await;
             assert_eq!(claim_res.is_ok(), true);

--- a/reconciler/src/main.rs
+++ b/reconciler/src/main.rs
@@ -31,11 +31,11 @@ async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
         let deployment_id = deployment.deployment_id.clone();
         let environment = deployment.environment.clone();
         async move {
-            println!(
-                "Deploymentid: {}, environment: {}",
-                deployment_id, environment
-            );
             let remediate = deployment.drift_detection.auto_remediate;
+            info!(
+                "Starting scheduled drift check for {} in {} with auto_remediate={}",
+                deployment_id, environment, remediate
+            );
             let handler = GenericCloudHandler::default().await;
             match driftcheck_infra(
                 &handler,

--- a/utils/src/runtime_env.rs
+++ b/utils/src/runtime_env.rs
@@ -15,7 +15,11 @@ pub fn has_local_dynamodb() -> bool {
 }
 
 pub fn has_local_s3() -> bool {
-    s3_endpoint().is_some()
+    s3_endpoint().is_some_and(|endpoint| is_local_s3_endpoint(&endpoint))
+}
+
+pub fn is_local_s3_endpoint(endpoint: &str) -> bool {
+    endpoint.contains("127.0.0.1") || endpoint.contains("localhost") || endpoint.contains("minio")
 }
 
 pub fn has_local_azure_storage() -> bool {


### PR DESCRIPTION
Add missing direct-provider support needed before removing env_aws, including local bootstrap events, runner/job-status handling, local S3 backend configuration, and test-mode defaults for local AWS credentials.