### PR TITLE
fix: update deployment query to sort by epoch

### DIFF
--- a/env_aws_direct/src/api.rs
+++ b/env_aws_direct/src/api.rs
@@ -1069,6 +1069,7 @@ pub fn get_change_records_for_deployment_query(
     change_type: &str,
 ) -> Value {
     json!({
+        "IndexName": "EpochIndex", // Sorted by epoch instead of job_id
         "KeyConditionExpression": "PK = :pk",
         "ExpressionAttributeValues": {
             ":pk": format!("{}#{}", change_type, get_change_record_identifier(project_id, region, deployment_id, environment)),


### PR DESCRIPTION
Fixes a bug where we expect it to be sorted by time, not job-id