### PR TITLE
fix: add proc-macro-error2 to ignore list as unmaintained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -88,6 +88,7 @@ ignore = [
     { id = "RUSTSEC-2025-0119", reason = "number_prefix is unmaintained" },
     { id = "RUSTSEC-2025-0134", reason = "paste is unmaintained" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained - accepted for now" },
     { id = "RUSTSEC-2024-0436", reason = "rustls-pemfile is unmaintained" },
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained" },
     # Yanked crate


### PR DESCRIPTION
No current vulnerabilities, look for an active fork when community decides where to go