### PR TITLE
fix: remove stale advisory ignore entries from deny.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c115d4f30f52c67202f079c5f9d8b49db4691f460fdb0b4c2e838261b2ba5"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3720,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.8"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -4566,9 +4566,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.7"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c588e11a3082784af229e23e8e4ecf5bcc6fbe4f69101e0421ce8d79da7f0b40"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -6976,9 +6976,9 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
@@ -8656,15 +8656,15 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.21"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -83,8 +83,6 @@ ignore = [
     { id = "RUSTSEC-2025-0134", reason = "paste is unmaintained" },
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained - accepted for now" },
     { id = "RUSTSEC-2024-0436", reason = "rustls-pemfile is unmaintained" },
-    # Yanked crate
-    { crate = "half@2.7.0", reason = "yanked version, pending cargo update" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/deny.toml
+++ b/deny.toml
@@ -70,12 +70,6 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # TODO: Fix these vulnerabilities by upgrading dependencies
-    { id = "RUSTSEC-2023-0071", reason = "rsa: Marvin Attack timing sidechannel - pending upgrade" },
-    { id = "RUSTSEC-2026-0097", reason = "rand: unsound with custom logger - pending upgrade" },
-    { id = "RUSTSEC-2026-0098", reason = "webpki: URI name constraints bug - pending upgrade" },
-    { id = "RUSTSEC-2026-0099", reason = "webpki: wildcard name constraints bug - pending upgrade" },
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic: only reachable when parsing CRLs, which we don't do. Transitive via aws-smithy-http-client's legacy-rustls-ring feature (rustls 0.21); no patched 0.101.x exists." },
     # Unmaintained crates (transitive dependencies, no direct fix available)
     { id = "RUSTSEC-2024-0384", reason = "instant is unmaintained" },
     { id = "RUSTSEC-2025-0012", reason = "backoff is unmaintained" },
@@ -87,10 +81,8 @@ ignore = [
     { id = "RUSTSEC-2025-0104", reason = "unic-ucd-version is unmaintained" },
     { id = "RUSTSEC-2025-0119", reason = "number_prefix is unmaintained" },
     { id = "RUSTSEC-2025-0134", reason = "paste is unmaintained" },
-    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained" },
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained - accepted for now" },
     { id = "RUSTSEC-2024-0436", reason = "rustls-pemfile is unmaintained" },
-    { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained" },
     # Yanked crate
     { crate = "half@2.7.0", reason = "yanked version, pending cargo update" },
 ]


### PR DESCRIPTION
No longer required since we've updated dependencies