### PR TITLE
feat: implement new deployment commands and update API routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,6 +3943,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "testcontainers",
  "testcontainers-modules",
  "tokio",

--- a/env_common/src/logic/api_infra.rs
+++ b/env_common/src/logic/api_infra.rs
@@ -61,7 +61,7 @@ pub async fn validate_and_prepare_claim(
         return Err(anyhow::anyhow!("Unsupported API version: {}", api_version));
     }
     let deployment_manifest: DeploymentManifest = serde_yaml::from_value(yaml.clone())
-        .expect("Failed to parse claim YAML to DeploymentManifest"); // TODO: Propagate error
+        .map_err(|e| anyhow::anyhow!("Failed to parse claim YAML to DeploymentManifest: {}", e))?;
 
     let claim = deployment_manifest.clone();
 

--- a/http_client/src/client.rs
+++ b/http_client/src/client.rs
@@ -962,12 +962,21 @@ pub async fn http_submit_claim_job(
         ));
     }
 
-    let response = http_post(
-        "/api/v1/claim/run",
-        &serde_json::to_value(payload_with_variables)?,
-    )
-    .await
-    .map_err(|e| anyhow!("Failed to submit claim via HTTP: {}", e))?;
+    let path = match payload.command.as_str() {
+        "apply" => "/api/v1/apply",
+        "plan" => "/api/v1/plan",
+        "destroy" => "/api/v1/destroy",
+        command => {
+            return Err(anyhow!(
+                "Unsupported deployment command for HTTP API: {}",
+                command
+            ))
+        }
+    };
+
+    let response = http_post(path, &serde_json::to_value(payload_with_variables)?)
+        .await
+        .map_err(|e| anyhow!("Failed to submit claim via HTTP: {}", e))?;
 
     let job_id = response["job_id"]
         .as_str()

--- a/internal-api/Cargo.toml
+++ b/internal-api/Cargo.toml
@@ -17,6 +17,7 @@ testcontainers-modules = { workspace = true, features = ["dynamodb"], optional =
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 env_common = { path = "../env_common" }
 env_defs = { path = "../defs" }
 env_utils = { path = "../utils", features = ["otel"] }

--- a/internal-api/README.md
+++ b/internal-api/README.md
@@ -133,7 +133,7 @@ In HTTP mode, the CLI cannot auto-discover project and region from the cloud pro
 
 All routes return JSON. See [API_EXAMPLES.md](./API_EXAMPLES.md).
 
-Routes under `/api/v1/deployment*`, `/api/v1/deployments*`, `/api/v1/plan*`, `/api/v1/logs*`, `/api/v1/events*`, `/api/v1/change_record*`, `/api/v1/change_record_graph*`, `/api/v1/deployment_graph*`, `/api/v1/job_status*`, `/api/v1/provider/download`, and `/api/v1/claim/run` require project-level JWT authorization.
+Routes under `/api/v1/deployment*`, `/api/v1/deployments*`, `/api/v1/plan*`, `/api/v1/logs*`, `/api/v1/events*`, `/api/v1/change_record*`, `/api/v1/change_record_graph*`, `/api/v1/deployment_graph*`, `/api/v1/job_status*`, `/api/v1/provider/download`, `/api/v1/apply`, `/api/v1/destroy`, and `/api/v1/reapply` require project-level JWT authorization.
 
 Publish and deprecate routes (`/api/v1/module/publish`, `/api/v1/stack/publish`, `/api/v1/provider/publish`, and `*/deprecate`) require publish-level JWT authorization. Publish rights are derived from CI/CD identity-provider claims (GitHub Actions OIDC today) and evaluated by the Rego publish policy.
 
@@ -149,6 +149,10 @@ The full design, configuration reference, and GitHub OIDC examples for single-re
 - `GET /api/v1/change_record/{project}/{region}/*rest`
 - `GET /api/v1/change_record_graph/{project}/{region}/*rest`
 - `GET /api/v1/deployment_graph/{project}/{region}/*rest`
+- `POST /api/v1/apply` *(auth required; JSON body with `project`/`project_id`, `environment`/`environment_id`, and `claim`/`manifest`)*
+- `POST /api/v1/plan` *(auth required; JSON body with `project`/`project_id`, `environment`/`environment_id`, and `claim`/`manifest`)*
+- `POST /api/v1/destroy` *(auth required; JSON body with `project`/`project_id`, `region`, `environment`/`environment_id`, and `deployment_id`)*
+- `POST /api/v1/reapply` *(auth required; JSON body with `project`/`project_id`, `region`, `environment`/`environment_id`, and `deployment_id`)*
 
 **Modules & Stacks:**
 - `GET /api/v1/modules`
@@ -179,9 +183,6 @@ The full design, configuration reference, and GitHub OIDC examples for single-re
 **Logs & Jobs:**
 - `GET /api/v1/logs/{project}/{region}/{job_id}?limit=100&next_token=...`
 - `GET /api/v1/job_status/{project}/{region}/*rest`
-
-**Operations:**
-- `POST /api/v1/claim/run` *(auth required)*
 
 **Auth & Meta:**
 - `POST /api/v1/auth/token`

--- a/internal-api/src/deployment_routes.rs
+++ b/internal-api/src/deployment_routes.rs
@@ -5,15 +5,468 @@ use axum::{
 };
 use serde_json::{json, Value};
 
-use crate::{handlers, http_authz::ensure_access, http_response::handle_result};
+use crate::{
+    handlers,
+    http_authz::ensure_access,
+    http_response::{bad_request, conflict, handle_result},
+};
 
-pub(crate) async fn run_claim(headers: HeaderMap, Json(body): Json<Value>) -> Response {
-    log::info!("Received run_claim request");
+fn body_string_param(body: &Value, names: &[&str]) -> Result<String, anyhow::Error> {
+    names
+        .iter()
+        .find_map(|name| body.get(*name).and_then(|value| value.as_str()))
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| bad_request(format!("Missing '{}' parameter", names.join("' or '"))))
+}
+
+fn optional_body_string_param(body: &Value, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|name| body.get(*name).and_then(|value| value.as_str()))
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+}
+
+fn body_string_array_param(body: &Value, name: &str) -> Result<Vec<String>, anyhow::Error> {
+    match body.get(name) {
+        Some(Value::Array(values)) => values
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| bad_request(format!("'{}' must contain only strings", name)))
+            })
+            .collect(),
+        Some(_) => Err(bad_request(format!(
+            "'{}' must be an array of strings",
+            name
+        ))),
+        None => Ok(vec![]),
+    }
+}
+
+fn body_claim_param(body: &Value) -> Result<serde_yaml::Value, anyhow::Error> {
+    let claim = body
+        .get("claim")
+        .or_else(|| body.get("manifest"))
+        .or_else(|| body.get("deployment"))
+        .ok_or_else(|| bad_request("Missing 'claim' or 'manifest' parameter"))?;
+
+    if let Some(claim_yaml) = claim.as_str() {
+        serde_yaml::from_str(claim_yaml)
+            .map_err(|e| bad_request(format!("Invalid claim YAML: {}", e)))
+    } else {
+        serde_yaml::to_value(claim)
+            .map_err(|e| bad_request(format!("Invalid claim manifest: {}", e)))
+    }
+}
+
+fn region_from_claim_or_body(
+    body: &Value,
+    claim: &serde_yaml::Value,
+) -> Result<String, anyhow::Error> {
+    if let Some(region) = optional_body_string_param(body, &["region"]) {
+        return Ok(region);
+    }
+
+    claim
+        .get("spec")
+        .and_then(|spec| spec.get("region"))
+        .and_then(|region| region.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| bad_request("Missing 'region' parameter"))
+}
+
+fn deployment_selector_from_body(
+    body: &Value,
+) -> Result<(String, String, String, String), anyhow::Error> {
+    Ok((
+        body_string_param(body, &["project", "project_id"])?,
+        body_string_param(body, &["region"])?,
+        body_string_param(body, &["environment", "environment_id"])?,
+        body_string_param(body, &["deployment_id"])?,
+    ))
+}
+
+pub(crate) async fn apply_deployment_from_body(
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    run_claim_action_from_body(headers, body, "apply").await
+}
+
+pub(crate) async fn plan_deployment_from_body(
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    run_claim_action_from_body(headers, body, "plan").await
+}
+
+async fn run_claim_action_from_body(headers: HeaderMap, body: Value, command: &str) -> Response {
+    use env_common::interface::GenericCloudHandler;
+    use env_common::logic::validate_and_prepare_claim;
+    use env_defs::ExtraData;
+
+    if body.get("payload").is_some() || body.get("variables").is_some() {
+        return run_prepared_deployment_action(headers, body, command).await;
+    }
+
+    let project = match body_string_param(&body, &["project", "project_id"]) {
+        Ok(project) => project,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+    let environment = match body_string_param(&body, &["environment", "environment_id"]) {
+        Ok(environment) => environment,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+    let claim = match body_claim_param(&body) {
+        Ok(claim) => claim,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+    let region = match region_from_claim_or_body(&body, &claim) {
+        Ok(region) => region,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+    let flags = match body_string_array_param(&body, "flags") {
+        Ok(flags) => flags,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    if let Err(e) = ensure_access(&headers, &project).await {
+        return e.into_response();
+    }
+
+    let handler = GenericCloudHandler::workload(&project, &region).await;
+    let reference_fallback = optional_body_string_param(&body, &["reference"])
+        .unwrap_or_else(|| format!("api-{}", command));
+
+    let (_, payload_with_variables) = match validate_and_prepare_claim(
+        &handler,
+        &claim,
+        &environment,
+        command,
+        flags,
+        ExtraData::None,
+        &reference_fallback,
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(e) => {
+            return handle_result(Err(bad_request(e.to_string())))
+                .await
+                .into_response()
+        }
+    };
+
+    let payload_value = match serde_json::to_value(&payload_with_variables.payload) {
+        Ok(value) => value,
+        Err(e) => {
+            return handle_result(Err(anyhow::anyhow!(
+                "Failed to serialize {} payload: {}",
+                command,
+                e
+            )))
+            .await
+            .into_response()
+        }
+    };
+
+    handlers::with_workload_account(
+        project,
+        run_claim_authorized(
+            payload_value,
+            payload_with_variables.variables,
+            payload_with_variables.payload,
+        ),
+    )
+    .await
+}
+
+pub(crate) async fn reapply_deployment_from_body(
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    let (project, region, environment, deployment_id) = match deployment_selector_from_body(&body) {
+        Ok(selector) => selector,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    reapply_deployment(headers, project, region, environment, deployment_id).await
+}
+
+pub(crate) async fn destroy_deployment_from_body(
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    if body.get("payload").is_some() || body.get("variables").is_some() {
+        return run_prepared_deployment_action(headers, body, "destroy").await;
+    }
+
+    let (project, region, environment, deployment_id) = match deployment_selector_from_body(&body) {
+        Ok(selector) => selector,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    deployment_action_from_existing(
+        headers,
+        project,
+        region,
+        environment,
+        deployment_id,
+        "destroy",
+    )
+    .await
+}
+
+async fn reapply_deployment(
+    headers: HeaderMap,
+    project: String,
+    region: String,
+    environment: String,
+    deployment_id: String,
+) -> Response {
+    if let Err(e) = ensure_access(&headers, &project).await {
+        return e.into_response();
+    }
+
+    let workload = project.clone();
+    handlers::with_workload_account(
+        workload,
+        reapply_deployment_authorized(project, region, environment, deployment_id),
+    )
+    .await
+}
+
+async fn deployment_action_from_existing(
+    headers: HeaderMap,
+    project: String,
+    region: String,
+    environment: String,
+    deployment_id: String,
+    command: &'static str,
+) -> Response {
+    if let Err(e) = ensure_access(&headers, &project).await {
+        return e.into_response();
+    }
+
+    let workload = project.clone();
+    handlers::with_workload_account(
+        workload,
+        deployment_action_from_existing_authorized(
+            project,
+            region,
+            environment,
+            deployment_id,
+            command,
+        ),
+    )
+    .await
+}
+
+async fn load_deployment(
+    project: &str,
+    region: &str,
+    environment: &str,
+    deployment_id: &str,
+) -> Result<env_defs::DeploymentResp, anyhow::Error> {
+    let deployment_value = handlers::describe_deployment(&json!({
+        "project": project,
+        "region": region,
+        "environment": environment,
+        "deployment_id": deployment_id
+    }))
+    .await?;
+
+    serde_json::from_value(deployment_value)
+        .map_err(|e| anyhow::anyhow!("Invalid deployment record: {}", e))
+}
+
+async fn deployment_action_from_existing_authorized(
+    project: String,
+    region: String,
+    environment: String,
+    deployment_id: String,
+    command: &'static str,
+) -> Response {
+    use env_common::interface::GenericCloudHandler;
+    use env_defs::{ApiInfraPayload, ApiInfraPayloadWithVariables, CloudProvider, ExtraData};
+
+    let deployment = match load_deployment(&project, &region, &environment, &deployment_id).await {
+        Ok(deployment) => deployment,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    let handler = GenericCloudHandler::workload(&deployment.project_id, &deployment.region).await;
+    let payload = ApiInfraPayload {
+        command: command.to_string(),
+        flags: vec![],
+        module: deployment.module.to_lowercase(),
+        module_version: deployment.module_version.clone(),
+        module_type: deployment.module_type.clone(),
+        module_track: deployment.module_track.clone(),
+        name: String::new(),
+        environment: deployment.environment.clone(),
+        deployment_id: deployment.deployment_id.clone(),
+        project_id: deployment.project_id.clone(),
+        region: deployment.region.clone(),
+        drift_detection: deployment.drift_detection.clone(),
+        next_drift_check_epoch: -1,
+        annotations: serde_json::json!({}),
+        dependencies: deployment.dependencies.clone(),
+        initiated_by: handler.get_user_id().await.unwrap_or("api".into()),
+        cpu: deployment.cpu.clone(),
+        memory: deployment.memory.clone(),
+        reference: deployment.reference.clone(),
+        extra_data: ExtraData::None,
+    };
+
+    let payload_with_variables = ApiInfraPayloadWithVariables {
+        payload,
+        variables: deployment.variables.clone(),
+    };
+    let payload_value = match serde_json::to_value(&payload_with_variables.payload) {
+        Ok(value) => value,
+        Err(e) => {
+            return handle_result(Err(anyhow::anyhow!(
+                "Failed to serialize {} payload: {}",
+                command,
+                e
+            )))
+            .await
+            .into_response()
+        }
+    };
+
+    run_claim_authorized(
+        payload_value,
+        payload_with_variables.variables,
+        payload_with_variables.payload,
+    )
+    .await
+}
+
+async fn reapply_deployment_authorized(
+    project: String,
+    region: String,
+    environment: String,
+    deployment_id: String,
+) -> Response {
+    use env_common::interface::GenericCloudHandler;
+    use env_common::logic::validate_and_prepare_claim;
+    use env_defs::{DeploymentResp, ExtraData, ModuleResp};
+
+    let deployment: DeploymentResp =
+        match load_deployment(&project, &region, &environment, &deployment_id).await {
+            Ok(deployment) => deployment,
+            Err(e) => return handle_result(Err(e)).await.into_response(),
+        };
+
+    let module_track = deployment.module_track.clone();
+    let module_name = deployment.module.clone();
+    let module_version = deployment.module_version.clone();
+    let module_value = match deployment.module_type.as_str() {
+        "stack" => {
+            handlers::get_stack_version(&json!({
+                "track": module_track,
+                "stack_name": module_name,
+                "stack_version": module_version
+            }))
+            .await
+        }
+        "module" => {
+            handlers::get_module_version(&json!({
+                "track": module_track,
+                "module_name": module_name,
+                "module_version": module_version
+            }))
+            .await
+        }
+        other => Err(anyhow::anyhow!("Unsupported module type: {}", other)),
+    };
+
+    let module_value = match module_value {
+        Ok(value) => value,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    let module: ModuleResp = match serde_json::from_value(module_value) {
+        Ok(module) => module,
+        Err(e) => {
+            return handle_result(Err(anyhow::anyhow!("Invalid module record: {}", e)))
+                .await
+                .into_response()
+        }
+    };
+
+    let claim_yaml = env_utils::generate_deployment_claim(&deployment, &module);
+    let yaml: serde_yaml::Value = match serde_yaml::from_str(&claim_yaml) {
+        Ok(yaml) => yaml,
+        Err(e) => {
+            return handle_result(Err(anyhow::anyhow!(
+                "Failed to regenerate deployment claim: {}",
+                e
+            )))
+            .await
+            .into_response()
+        }
+    };
+
+    let handler = GenericCloudHandler::workload(&deployment.project_id, &deployment.region).await;
+    let reference_fallback = if deployment.reference.is_empty() {
+        "api-reapply"
+    } else {
+        &deployment.reference
+    };
+
+    let (_, payload_with_variables) = match validate_and_prepare_claim(
+        &handler,
+        &yaml,
+        &deployment.environment,
+        "apply",
+        vec![],
+        ExtraData::None,
+        reference_fallback,
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    let payload_value = match serde_json::to_value(&payload_with_variables.payload) {
+        Ok(value) => value,
+        Err(e) => {
+            return handle_result(Err(anyhow::anyhow!(
+                "Failed to serialize reapply payload: {}",
+                e
+            )))
+            .await
+            .into_response()
+        }
+    };
+
+    run_claim_authorized(
+        payload_value,
+        payload_with_variables.variables,
+        payload_with_variables.payload,
+    )
+    .await
+}
+
+async fn run_prepared_deployment_action(
+    headers: HeaderMap,
+    body: Value,
+    expected_command: &str,
+) -> Response {
+    log::info!("Received prepared deployment {} request", expected_command);
 
     let payload_value = match body.get("payload") {
         Some(p) => p.clone(),
         None => {
-            return handle_result(Err(anyhow::anyhow!("Missing 'payload' field")))
+            return handle_result(Err(bad_request("Missing 'payload' field")))
                 .await
                 .into_response()
         }
@@ -22,7 +475,7 @@ pub(crate) async fn run_claim(headers: HeaderMap, Json(body): Json<Value>) -> Re
     let variables = match body.get("variables") {
         Some(v) => v.clone(),
         None => {
-            return handle_result(Err(anyhow::anyhow!("Missing 'variables' field")))
+            return handle_result(Err(bad_request("Missing 'variables' field")))
                 .await
                 .into_response()
         }
@@ -31,11 +484,20 @@ pub(crate) async fn run_claim(headers: HeaderMap, Json(body): Json<Value>) -> Re
     let payload: env_defs::ApiInfraPayload = match serde_json::from_value(payload_value.clone()) {
         Ok(p) => p,
         Err(e) => {
-            return handle_result(Err(anyhow::anyhow!("Invalid payload: {}", e)))
+            return handle_result(Err(bad_request(format!("Invalid payload: {}", e))))
                 .await
                 .into_response()
         }
     };
+
+    if payload.command != expected_command {
+        return handle_result(Err(bad_request(format!(
+            "Payload command '{}' does not match endpoint command '{}'",
+            payload.command, expected_command
+        ))))
+        .await
+        .into_response();
+    }
 
     if let Err(e) = ensure_access(&headers, &payload.project_id).await {
         return e.into_response();
@@ -53,46 +515,84 @@ async fn run_claim_authorized(
     variables: Value,
     payload: env_defs::ApiInfraPayload,
 ) -> Response {
+    use env_common::interface::GenericCloudHandler;
+    use env_common::logic::is_deployment_in_progress;
+
+    let handler = GenericCloudHandler::workload(&payload.project_id, &payload.region).await;
+    let (in_progress, job_id, _, _) = is_deployment_in_progress(
+        &handler,
+        &payload.deployment_id,
+        &payload.environment,
+        true,
+        false,
+    )
+    .await;
+    if in_progress {
+        return handle_result(Err(conflict(format!(
+            "Deployment '{}' in environment '{}' already has job '{}' in progress",
+            payload.deployment_id, payload.environment, job_id
+        ))))
+        .await
+        .into_response();
+    }
+
     let result = handlers::start_runner(&json!({
         "data": payload_value
     }))
     .await;
 
-    let task_arn = match result {
-        Ok(resp) => resp["task_arn"].as_str().unwrap_or("").to_string(),
+    let runner_response = match result {
+        Ok(resp) => resp,
         Err(e) => return handle_result(Err(e)).await.into_response(),
     };
 
-    let task_id = task_arn.split('/').last().unwrap_or(&task_arn).to_string();
+    let task_arn = runner_response["task_arn"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    let job_id = runner_response["job_id"]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| task_arn.split('/').last().unwrap_or(&task_arn).to_string());
 
-    log::info!("Task ARN: {}, Task ID: {}", task_arn, task_id);
+    if job_id.is_empty() {
+        return handle_result(Err(anyhow::anyhow!(
+            "Runner response did not include a job identifier"
+        )))
+        .await
+        .into_response();
+    }
 
-    if let Err(e) = insert_deployment_record(&payload, &variables, &task_id).await {
+    log::info!("Task ARN: {}, Job ID: {}", task_arn, job_id);
+
+    if let Err(e) = insert_deployment_record(&handler, &payload, &variables, &job_id).await {
         log::error!("Failed to insert deployment record: {}", e);
         return handle_result(Err(e)).await.into_response();
     }
 
     handle_result(Ok(json!({
         "task_arn": task_arn,
-        "job_id": task_id
+        "job_id": job_id,
+        "deployment_id": payload.deployment_id,
+        "environment": payload.environment,
+        "project_id": payload.project_id,
+        "region": payload.region
     })))
     .await
     .into_response()
 }
 
 async fn insert_deployment_record(
+    handler: &env_common::interface::GenericCloudHandler,
     payload: &env_defs::ApiInfraPayload,
     variables: &serde_json::Value,
     job_id: &str,
 ) -> Result<(), anyhow::Error> {
-    use env_common::interface::GenericCloudHandler;
-
-    let handler = GenericCloudHandler::workload(&payload.project_id, &payload.region).await;
-
     let payload_with_variables = env_defs::ApiInfraPayloadWithVariables {
         payload: payload.clone(),
         variables: variables.clone(),
     };
 
-    env_common::insert_request_event(&handler, &payload_with_variables, job_id).await
+    env_common::insert_request_event(handler, &payload_with_variables, job_id).await
 }

--- a/internal-api/src/http_authz.rs
+++ b/internal-api/src/http_authz.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Path, Request},
-    http::{HeaderMap, Method, StatusCode},
+    http::{HeaderMap, StatusCode},
     middleware::Next,
     response::{IntoResponse, Json, Response},
 };
@@ -31,138 +31,10 @@ pub(crate) async fn auth_middleware(
     next.run(request).await
 }
 
-pub(crate) async fn publish_auth_middleware(
-    headers: HeaderMap,
-    request: Request,
-    next: Next,
-) -> Response {
-    let path = request.uri().path().to_string();
-    let method = request.method().clone();
-
-    let (resource_type, resource_name, resource_track) =
-        if method == Method::PUT && path.contains("/deprecate") {
-            let segments: Vec<&str> = path.split('/').collect();
-            if segments.len() >= 6 {
-                let res_type = if segments[3] == "stack" {
-                    "stack"
-                } else {
-                    "module"
-                };
-                (
-                    res_type.to_string(),
-                    segments[5].to_string(),
-                    Some(segments[4].to_string()),
-                )
-            } else {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({ "error": "Invalid deprecate path" })),
-                )
-                    .into_response();
-            }
-        } else if method == Method::POST {
-            let (parts, body) = request.into_parts();
-            let bytes = match axum::body::to_bytes(body, 512 * 1024 * 1024).await {
-                Ok(b) => b,
-                Err(e) => {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(json!({ "error": format!("Failed to read request body: {}", e) })),
-                    )
-                        .into_response();
-                }
-            };
-
-            let body_json: Value = match serde_json::from_slice(&bytes) {
-                Ok(v) => v,
-                Err(e) => {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(json!({ "error": format!("Invalid JSON body: {}", e) })),
-                    )
-                        .into_response();
-                }
-            };
-
-            let (res_type, res_name) = if path.contains("/module/publish") {
-                let name = body_json
-                    .get("module")
-                    .and_then(|m| m.get("module").or_else(|| m.get("module_name")))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                ("module".to_string(), name)
-            } else if path.contains("/stack/publish") {
-                let name = body_json
-                    .get("module")
-                    .and_then(|m| m.get("module").or_else(|| m.get("module_name")))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                ("stack".to_string(), name)
-            } else if path.contains("/provider/publish") {
-                let name = body_json
-                    .get("provider")
-                    .and_then(|p| p.get("name"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                ("provider".to_string(), name)
-            } else if path.contains("/policy/publish") {
-                let name = body_json
-                    .get("policy")
-                    .and_then(|p| p.get("policy"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                ("policy".to_string(), name)
-            } else {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({ "error": "Unknown publish endpoint" })),
-                )
-                    .into_response();
-            };
-            let track = body_json
-                .get("track")
-                .and_then(|v| v.as_str())
-                .map(str::to_string)
-                .or_else(|| {
-                    body_json
-                        .get("module")
-                        .and_then(|m| m.get("track"))
-                        .and_then(|v| v.as_str())
-                        .map(str::to_string)
-                });
-
-            let request = Request::from_parts(parts, axum::body::Body::from(bytes));
-            if let Err(e) =
-                ensure_publish_access(&headers, &res_type, &res_name, track.as_deref()).await
-            {
-                return e.into_response();
-            }
-            return next.run(request).await;
-        } else {
-            return (
-                StatusCode::METHOD_NOT_ALLOWED,
-                Json(json!({ "error": "Unsupported method for publish endpoint" })),
-            )
-                .into_response();
-        };
-
-    if let Err(e) = ensure_publish_access(
-        &headers,
-        &resource_type,
-        &resource_name,
-        resource_track.as_deref(),
-    )
-    .await
-    {
-        return e.into_response();
-    }
-    next.run(request).await
-}
-
+/// Extract and decode JWT token from Authorization header without signature validation.
+/// We only read the claims without verifying the signature; the signature is validated
+/// upstream by the platform (API Gateway on AWS, or Azure App Service EasyAuth on Azure)
+/// before the request ever reaches this service.
 pub(crate) fn extract_jwt_claims(headers: &HeaderMap) -> Option<Value> {
     if let Some(claims) = extract_verified_claims(headers) {
         return Some(claims);
@@ -243,14 +115,14 @@ pub(crate) async fn ensure_access(
 
                 if allowed_projects.contains(&project_id.to_string()) {
                     return Ok(());
-                } else {
-                    return Err((
-                        StatusCode::FORBIDDEN,
-                        Json(json!({
-                            "error": "Access denied to this project"
-                        })),
-                    ));
                 }
+
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    Json(json!({
+                        "error": "Access denied to this project"
+                    })),
+                ));
             }
         }
 
@@ -314,7 +186,8 @@ fn ensure_authenticated_user(
     }
 }
 
-async fn ensure_publish_access(
+/// Ensure the authenticated user has permission to publish a specific resource.
+pub(crate) async fn ensure_publish_access(
     headers: &HeaderMap,
     resource_type: &str,
     resource_name: &str,

--- a/internal-api/src/http_response.rs
+++ b/internal-api/src/http_response.rs
@@ -4,8 +4,39 @@ use axum::{
 };
 use log::error;
 use serde_json::{json, Value};
+use std::{error::Error as StdError, fmt};
 
 use env_common::errors::ModuleError;
+
+#[derive(Debug)]
+struct BadRequestError(String);
+
+impl fmt::Display for BadRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl StdError for BadRequestError {}
+
+#[derive(Debug)]
+struct ConflictError(String);
+
+impl fmt::Display for ConflictError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl StdError for ConflictError {}
+
+pub(crate) fn bad_request(message: impl Into<String>) -> anyhow::Error {
+    BadRequestError(message.into()).into()
+}
+
+pub(crate) fn conflict(message: impl Into<String>) -> anyhow::Error {
+    ConflictError(message.into()).into()
+}
 
 fn status_code_for_module_error(e: &ModuleError) -> StatusCode {
     match e {
@@ -67,6 +98,10 @@ pub(crate) async fn handle_result(result: anyhow::Result<Value>) -> impl IntoRes
             let err_msg = e.to_string();
             let status = if let Some(module_err) = e.downcast_ref::<ModuleError>() {
                 status_code_for_module_error(module_err)
+            } else if e.downcast_ref::<BadRequestError>().is_some() {
+                StatusCode::BAD_REQUEST
+            } else if e.downcast_ref::<ConflictError>().is_some() {
+                StatusCode::CONFLICT
             } else if err_msg.to_lowercase().contains("not found") {
                 StatusCode::NOT_FOUND
             } else {

--- a/internal-api/src/http_router.rs
+++ b/internal-api/src/http_router.rs
@@ -11,9 +11,12 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use tower_http::cors::{Any, CorsLayer};
 
-use crate::deployment_routes::run_claim;
+use crate::deployment_routes::{
+    apply_deployment_from_body, destroy_deployment_from_body, plan_deployment_from_body,
+    reapply_deployment_from_body,
+};
 use crate::handlers;
-use crate::http_authz::{auth_middleware, extract_jwt_claims, publish_auth_middleware};
+use crate::http_authz::{auth_middleware, extract_jwt_claims};
 use crate::http_response::handle_result;
 use crate::publish_routes::{
     deprecate_module, deprecate_stack, download_provider, publish_module, publish_policy,
@@ -79,7 +82,10 @@ pub fn create_router() -> Router {
         // Provider download route - returns base64 content (requires auth)
         .route("/api/v1/provider/download", post(download_provider))
         // Plan/Apply/Destroy operations
-        .route("/api/v1/claim/run", post(run_claim))
+        .route("/api/v1/apply", post(apply_deployment_from_body))
+        .route("/api/v1/plan", post(plan_deployment_from_body))
+        .route("/api/v1/destroy", post(destroy_deployment_from_body))
+        .route("/api/v1/reapply", post(reapply_deployment_from_body))
         // Job status route - use wildcard to handle ARNs with slashes
         .route(
             "/api/v1/job_status/{project}/{region}/{*rest}",
@@ -161,8 +167,7 @@ pub fn create_router() -> Router {
         // Provider publish route - accepts pre-built providers
         .route("/api/v1/provider/publish", post(publish_provider))
         // Policy publish route - accepts pre-built policies
-        .route("/api/v1/policy/publish", post(publish_policy))
-        .layer(middleware::from_fn(publish_auth_middleware));
+        .route("/api/v1/policy/publish", post(publish_policy));
 
     open_routes
         .merge(protected_routes)
@@ -1089,6 +1094,134 @@ mod tests {
             .unwrap();
 
         assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn deployment_action_missing_body_field_returns_bad_request() {
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/apply")
+                    .header("x-auth-user", "test-user")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"environment":"cli/default"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn prepared_deployment_command_mismatch_returns_bad_request() {
+        let payload = serde_json::to_value(env_defs::ApiInfraPayload {
+            command: "plan".to_string(),
+            flags: vec![],
+            module: "s3bucket".to_string(),
+            module_version: "1.0.0".to_string(),
+            module_type: "module".to_string(),
+            module_track: "stable".to_string(),
+            name: "bucket1".to_string(),
+            environment: "cli/default".to_string(),
+            deployment_id: "s3bucket/bucket1".to_string(),
+            project_id: "123456789012".to_string(),
+            region: "us-west-2".to_string(),
+            drift_detection: env_defs::DriftDetection {
+                enabled: false,
+                interval: env_defs::DEFAULT_DRIFT_DETECTION_INTERVAL.to_string(),
+                auto_remediate: false,
+                webhooks: vec![],
+            },
+            next_drift_check_epoch: -1,
+            annotations: json!({}),
+            dependencies: vec![],
+            initiated_by: "test-user".to_string(),
+            cpu: "256".to_string(),
+            memory: "512".to_string(),
+            reference: "test".to_string(),
+            extra_data: env_defs::ExtraData::None,
+        })
+        .unwrap();
+
+        let body = json!({
+            "payload": payload,
+            "variables": {}
+        });
+
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/apply")
+                    .header("x-auth-user", "test-user")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn publish_rejects_top_level_track_mismatch() {
+        let body = json!({
+            "zip_base64": "AA==",
+            "track": "dev",
+            "version": "1.0.0-dev",
+            "job_id": "job-1",
+            "module": {
+                "module": "s3bucket",
+                "module_name": "S3Bucket",
+                "track": "stable",
+                "version": "1.0.0"
+            }
+        });
+
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/module/publish")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[cfg(not(feature = "local"))]
+    #[tokio::test]
+    async fn stack_publish_accepts_embedded_track_without_top_level_fields() {
+        let body = json!({
+            "zip_base64": "AA==",
+            "module": {
+                "module": "bucketcollection",
+                "module_name": "BucketCollection",
+                "track": "dev",
+                "version": "1.0.0-dev"
+            }
+        });
+
+        let response = create_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/stack/publish")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     // The `local` feature compiles in an auth bypass (missing x-auth-user is

--- a/internal-api/src/publish_routes.rs
+++ b/internal-api/src/publish_routes.rs
@@ -1,11 +1,16 @@
 use axum::{
     extract::{Json, Path},
-    response::IntoResponse,
+    http::HeaderMap,
+    response::{IntoResponse, Response},
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use crate::{handlers, http_response::handle_result};
+use crate::{
+    handlers,
+    http_authz::ensure_publish_access,
+    http_response::{bad_request, handle_result},
+};
 
 #[derive(Deserialize)]
 pub(crate) struct DeprecateModuleBody {
@@ -13,9 +18,14 @@ pub(crate) struct DeprecateModuleBody {
 }
 
 pub(crate) async fn deprecate_module(
+    headers: HeaderMap,
     Path((track, module, version)): Path<(String, String, String)>,
     Json(body): Json<DeprecateModuleBody>,
-) -> impl IntoResponse {
+) -> Response {
+    if let Err(e) = ensure_publish_access(&headers, "module", &module, Some(&track)).await {
+        return e.into_response();
+    }
+
     handle_result(
         handlers::deprecate_module(&json!({
             "track": track,
@@ -26,12 +36,18 @@ pub(crate) async fn deprecate_module(
         .await,
     )
     .await
+    .into_response()
 }
 
 pub(crate) async fn deprecate_stack(
+    headers: HeaderMap,
     Path((track, stack, version)): Path<(String, String, String)>,
     Json(body): Json<DeprecateModuleBody>,
-) -> impl IntoResponse {
+) -> Response {
+    if let Err(e) = ensure_publish_access(&headers, "stack", &stack, Some(&track)).await {
+        return e.into_response();
+    }
+
     handle_result(
         handlers::deprecate_stack(&json!({
             "track": track,
@@ -42,15 +58,57 @@ pub(crate) async fn deprecate_stack(
         .await,
     )
     .await
+    .into_response()
 }
 
 #[derive(Deserialize)]
 pub(crate) struct PublishModuleBody {
     zip_base64: String,
     module: Value,
-    track: String,
-    version: String,
-    job_id: String,
+    track: Option<String>,
+    version: Option<String>,
+    job_id: Option<String>,
+}
+
+fn required_string_field<'a>(
+    value: &'a Value,
+    field: &str,
+    resource_type: &str,
+) -> Result<&'a str, anyhow::Error> {
+    value
+        .get(field)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| bad_request(format!("Missing '{}.{}' parameter", resource_type, field)))
+}
+
+fn publish_module_resource(
+    body: &PublishModuleBody,
+    resource_type: &str,
+) -> Result<(String, String, String), anyhow::Error> {
+    let name = required_string_field(&body.module, "module", resource_type)?.to_string();
+    let track = required_string_field(&body.module, "track", resource_type)?.to_string();
+    let version = required_string_field(&body.module, "version", resource_type)?.to_string();
+
+    if let Some(body_track) = &body.track {
+        if body_track != &track {
+            return Err(bad_request(format!(
+                "Top-level track '{}' does not match {} track '{}'",
+                body_track, resource_type, track
+            )));
+        }
+    }
+
+    if let Some(body_version) = &body.version {
+        if body_version != &version {
+            return Err(bad_request(format!(
+                "Top-level version '{}' does not match {} version '{}'",
+                body_version, resource_type, version
+            )));
+        }
+    }
+
+    Ok((name, track, version))
 }
 
 pub(crate) async fn download_provider(Json(body): Json<Value>) -> impl IntoResponse {
@@ -64,32 +122,66 @@ pub(crate) async fn download_provider(Json(body): Json<Value>) -> impl IntoRespo
     .into_response()
 }
 
-pub(crate) async fn publish_module(Json(body): Json<PublishModuleBody>) -> impl IntoResponse {
+pub(crate) async fn publish_module(
+    headers: HeaderMap,
+    Json(body): Json<PublishModuleBody>,
+) -> Response {
+    let (module_name, module_track, module_version) = match publish_module_resource(&body, "module")
+    {
+        Ok(resource) => resource,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    if let Err(e) =
+        ensure_publish_access(&headers, "module", &module_name, Some(&module_track)).await
+    {
+        return e.into_response();
+    }
+
+    let job_id = body.job_id.unwrap_or_default();
+
     handle_result(
         handlers::publish_module(&json!({
             "zip_base64": body.zip_base64,
             "module": body.module,
-            "track": body.track,
-            "version": body.version,
-            "job_id": body.job_id
+            "track": module_track,
+            "version": module_version,
+            "job_id": job_id
         }))
         .await,
     )
     .await
+    .into_response()
 }
 
-pub(crate) async fn publish_stack(Json(body): Json<PublishModuleBody>) -> impl IntoResponse {
+pub(crate) async fn publish_stack(
+    headers: HeaderMap,
+    Json(body): Json<PublishModuleBody>,
+) -> Response {
+    let (stack_name, stack_track, stack_version) = match publish_module_resource(&body, "stack") {
+        Ok(resource) => resource,
+        Err(e) => return handle_result(Err(e)).await.into_response(),
+    };
+
+    if let Err(e) = ensure_publish_access(&headers, "stack", &stack_name, Some(&stack_track)).await
+    {
+        return e.into_response();
+    }
+
+    let job_id = body.job_id.unwrap_or_default();
+
     handle_result(
         handlers::publish_stack(&json!({
             "zip_base64": body.zip_base64,
             "module": body.module,
-            "track": body.track,
-            "version": body.version,
-            "job_id": body.job_id
+            "track": stack_track,
+            "version": stack_version,
+            "job_id": job_id
         }))
         .await,
     )
     .await
+    .into_response()
 }
 
 #[derive(Deserialize)]
@@ -104,7 +196,21 @@ pub(crate) struct PublishPolicyBody {
     policy: Value,
 }
 
-pub(crate) async fn publish_provider(Json(body): Json<PublishProviderBody>) -> impl IntoResponse {
+pub(crate) async fn publish_provider(
+    headers: HeaderMap,
+    Json(body): Json<PublishProviderBody>,
+) -> Response {
+    let provider_name = body
+        .provider
+        .get("name")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    if let Err(e) = ensure_publish_access(&headers, "provider", &provider_name, None).await {
+        return e.into_response();
+    }
+
     handle_result(
         handlers::publish_provider(&json!({
             "zip_base64": body.zip_base64,
@@ -113,9 +219,24 @@ pub(crate) async fn publish_provider(Json(body): Json<PublishProviderBody>) -> i
         .await,
     )
     .await
+    .into_response()
 }
 
-pub(crate) async fn publish_policy(Json(body): Json<PublishPolicyBody>) -> impl IntoResponse {
+pub(crate) async fn publish_policy(
+    headers: HeaderMap,
+    Json(body): Json<PublishPolicyBody>,
+) -> Response {
+    let policy_name = body
+        .policy
+        .get("policy")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    if let Err(e) = ensure_publish_access(&headers, "policy", &policy_name, None).await {
+        return e.into_response();
+    }
+
     handle_result(
         handlers::publish_policy(&json!({
             "zip_base64": body.zip_base64,
@@ -124,4 +245,5 @@ pub(crate) async fn publish_policy(Json(body): Json<PublishPolicyBody>) -> impl 
         .await,
     )
     .await
+    .into_response()
 }


### PR DESCRIPTION
Replace the legacy /api/v1/claim/run HTTP submission route with command-specific /api/v1/plan, /api/v1/apply, and /api/v1/destroy endpoints.

Note: this is a breaking API change for clients that still call /api/v1/claim/run; since this was not a good idea, however it doesnt exist in any official release yet