### PR TITLE
feat: propagate ECS tags from task definition in start_runner function

### DIFF
--- a/env_aws_direct/src/api.rs
+++ b/env_aws_direct/src/api.rs
@@ -626,6 +626,7 @@ pub async fn start_runner(event: &Value) -> Result<Value, anyhow::Error> {
                 )
                 .build(),
         )
+        .propagate_tags(aws_sdk_ecs::types::PropagateTags::TaskDefinition)
         .count(1)
         .send()
         .await?;


### PR DESCRIPTION
Allows to track cost