### PR TITLE
fix: resolve cargo deny advisory failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arboard"
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -6632,9 +6632,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/deny.toml
+++ b/deny.toml
@@ -83,6 +83,10 @@ ignore = [
     { id = "RUSTSEC-2025-0134", reason = "paste is unmaintained" },
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained - accepted for now" },
     { id = "RUSTSEC-2024-0436", reason = "rustls-pemfile is unmaintained" },
+    # quick-xml DoS advisories - transitive via self_update and the azure-sdk crates,
+    # which pin quick-xml <0.41; no direct fix without a major azure-sdk/self_update upgrade
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic attribute-check DoS - transitive dep pinned <0.41 by self_update/azure-sdk" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace-declaration DoS - transitive dep pinned <0.41 by self_update/azure-sdk" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
Update anyhow (1.0.98 -> 1.0.104), crossbeam-epoch (0.9.18 -> 0.9.20), and spin (0.10.0 -> 0.10.1) to address RUSTSEC-2026-0190, RUSTSEC-2026-0204, and the yanked spin release.

Ignore the two quick-xml DoS advisories (RUSTSEC-2026-0194/-0195), which are transitive via self_update and the azure-sdk crates that pin quick-xml <0.41 and cannot be fixed without a major upgrade of those dependencies.