### PR TITLE
feat(utils): take a span exporter instead of inventing one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,6 +4999,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5008,9 +5021,11 @@ dependencies = [
  "futures-core",
  "http 1.3.1",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
+ "reqwest",
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",

--- a/internal-api/src/main_aws_unified.rs
+++ b/internal-api/src/main_aws_unified.rs
@@ -350,7 +350,7 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize OTEL tracing first
-    if let Err(e) = otel_tracing::init_tracing("internal-api") {
+    if let Err(e) = otel_tracing::init_tracing("internal-api", None) {
         eprintln!("Failed to initialize OpenTelemetry: {}", e);
         // Fall back to env_logger if OTEL init fails
         env_logger::init();

--- a/internal-api/src/main_azure_unified.rs
+++ b/internal-api/src/main_azure_unified.rs
@@ -37,7 +37,7 @@ async fn normalize_azure_headers(mut req: Request, next: Next) -> Response {
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    if let Err(e) = otel_tracing::init_tracing("internal-api-azure") {
+    if let Err(e) = otel_tracing::init_tracing("internal-api-azure", None) {
         eprintln!("Failed to initialize OpenTelemetry: {}", e);
         env_logger::init();
     }

--- a/terraform_runner/src/main.rs
+++ b/terraform_runner/src/main.rs
@@ -8,7 +8,7 @@ use tracing::Instrument;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    otel_tracing::init_tracing("terraform-runner").expect("Failed to initialize tracing");
+    otel_tracing::init_tracing("terraform-runner", None).expect("Failed to initialize tracing");
 
     // Wrap the whole runner in a span carrying the upstream trace id so
     // every log line / OTel span is tagged with it. The API sets TRACE_ID

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,7 +11,8 @@ ignored = ["hcl-rs"]
 [features]
 # Pulls in OpenTelemetry + tracing-subscriber so binaries can call
 # `otel_tracing::init_tracing`. Off by default to keep the dep tree light
-# for utility-only consumers (cli, gitops, etc.).
+# for utility-only consumers (cli, gitops, etc.). Cloud-specific exporters
+# (e.g. AWS X-Ray SigV4) live in the respective `env_*_direct` crate.
 otel = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -24,7 +25,7 @@ otel = [
 [dependencies]
 opentelemetry = { version = "0.27", optional = true }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic", "trace"], optional = true }
+opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic", "http-proto", "reqwest-client", "trace"], optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"], optional = true }
 tracing-opentelemetry = { version = "0.28", optional = true }
@@ -54,7 +55,7 @@ tempfile = { workspace = true }
 bollard = { workspace = true }
 uuid = { workspace = true }
 futures-util = "0"
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tokio-util = "0.7.16"
 deunicode = "1.6"
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,3 +1,131 @@
 # Utils
 
 This package contains all small utilities that are common for multiple packages; file-handling, json parsing, logging etc.
+
+## OpenTelemetry tracing
+
+The `otel` feature enables `env_utils::otel_tracing`, which initializes:
+
+- `tracing`/`log` output for local and CloudWatch logs
+- optional OpenTelemetry span export
+- graceful span flushing via `shutdown_tracing()`
+
+Telemetry export is disabled by default. This keeps the default runtime path at zero extra infrastructure and avoids trying to contact a local collector when no exporter is configured.
+
+### Basic usage
+
+`env_utils::otel_tracing` is the low-level, cloud-agnostic API: it sets up log
+formatting and takes an already-built span exporter
+(`init_tracing(service_name, exporter)`). It pulls in no cloud SDK — a
+cloud-specific exporter belongs in the matching `env_*_direct` crate.
+
+```rust
+use env_utils::otel_tracing;
+
+// Logging only.
+otel_tracing::init_tracing("my-service", None)?;
+
+// Or exporting spans to a collector.
+let exporter = otel_tracing::otlp_http_exporter("http://localhost:4318")?;
+otel_tracing::init_tracing("my-service", Some(exporter))?;
+
+// Run application work here.
+
+// Blocking, and off the async worker — see below.
+let _ = tokio::task::spawn_blocking(otel_tracing::shutdown_tracing).await;
+```
+
+Call `shutdown_tracing()` once before process exit so batched spans can be
+flushed. It blocks until the batch processor drains, so from an async context
+run it on `tokio::task::spawn_blocking` — the processor lives on the same
+runtime, and calling it inline deadlocks on a current-thread runtime and starves
+a worker on a multi-threaded one.
+
+This matters most for the *root* span, which closes last and so is still queued
+at exit. A process that shuts down without a working flush still looks healthy —
+the batch processor's periodic flush already shipped every child span — but the
+entry-point span is lost, and CloudWatch Application Signals derives a service's
+existence from entry-point (`SERVER`-kind) spans, so the service silently never
+appears in the Services list.
+
+### Log output
+
+Set `LOG_FORMAT=plain` for human-readable logs in CloudWatch/ECS/Lambda. Plain logs are a minimal one-liner — `<timestamp> <LEVEL> <message>` — with no span context, module target, or ANSI color codes, since that detail is available in the exported traces. Set `LOG_FORMAT=json` for compact JSON logs. If `LOG_FORMAT` is not set, logs are JSON when stderr is not a TTY and pretty/ANSI locally.
+
+Trace export is independent from log formatting, so `LOG_FORMAT=plain` can be used together with any exporter.
+
+JSON logs do not include the full active span stack by default.
+
+Optional log verbosity, both of which apply to **JSON logs only**:
+
+```sh
+LOG_INCLUDE_SPANS=true       # include current span and span list on each log event
+LOG_SPAN_CLOSE_EVENTS=true   # emit span close timing events
+```
+
+`plain` is deliberately fixed at `<timestamp> <LEVEL> <message>` and ignores
+both; the pretty local format always emits span close events. Accepted truthy
+values are `1`, `true`, `TRUE`, `yes`, and `YES`.
+
+### Associating logs with the service
+
+```sh
+TELEMETRY_LOG_GROUP_NAMES=/infraweave/us-west-2/prod/runner   # comma-separated
+```
+
+Sets the `aws.log.group.names` resource attribute. The Logs tab of a CloudWatch
+Application Signals service page follows that attribute rather than searching
+for anything, so without it the tab is empty however healthy the log group is.
+
+On Lambda this defaults to `AWS_LAMBDA_LOG_GROUP_NAME`, which the runtime sets
+itself — nothing to configure. On ECS the group is only reachable through the
+task metadata endpoint, so the task definition passes it in instead of the
+process making an HTTP call at startup.
+
+These are useful while debugging tracing, but they make CloudWatch log lines much noisier.
+## Redaction
+
+`env_utils::redact` (always available, no feature flag) masks values that would
+otherwise reach logs or span attributes. Spans are useful in proportion to the
+context they carry, and some of that context is secret: terraform is invoked
+with credentials inline (`-backend-config=secret_key=…`) and with deployment
+variables that can hold anything.
+
+```rust
+use env_utils::redact;
+
+redact::mask_value("AKIAIOSFODNN7EXAMPLE");   // "AKI***PLE(20 chars)"
+redact::mask_value("hunter2");                // "***(7 chars)"
+redact::mask_value("");                       // "(empty)"
+
+redact::is_sensitive_key("secret_key");       // true
+redact::is_sensitive_key("key");              // false — see below
+
+redact::sanitize_cli_args(["terraform", "init", "-backend-config=secret_key=AKIAIOSFODNN7EXAMPLE"]);
+// "terraform init -backend-config=secret_key=AKI***PLE(20 chars)"
+```
+
+The length is kept because it is often the useful signal — an empty or truncated
+credential is visible without exposing the value. Values under 12 characters are
+masked entirely, since revealing three characters from each end of a short
+secret gives away most of it. Masking is char-based, so multi-byte values are
+safe to slice.
+
+`is_sensitive_key` matches substrings (`secret`, `password`, `token`,
+`access_key`, `auth`, …) but deliberately **not** a bare `key`: terraform's
+`-backend-config=key=<state path>` is a non-secret value worth seeing on a span,
+while `access_key` and `secret_key` are caught by their more specific prefixes.
+
+`sanitize_cli_args` splits at the *first* `=` whose left-hand side looks like a
+credential key, and masks everything after it; arguments without `=` pass through
+untouched. Scanning left to right is what keeps a value containing `=` intact —
+splitting from the right lands on base64 padding, mistakes the secret for part of
+the key, and prints it verbatim:
+
+```rust
+// -backend-config=secret_key=aGVsbG93b3JsZHNlY3JldA==
+sanitize_cli_args(args);  // "-backend-config=secret_key=aGV***A==(24 chars)"
+```
+
+Taking the first match also means a needle anywhere in the prefix masks
+everything after it, erring toward hiding too much rather than too little.

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -12,6 +12,7 @@ mod oci;
 #[cfg(feature = "otel")]
 pub mod otel_tracing;
 mod provider_util;
+pub mod redact;
 pub mod runtime_env;
 mod schema_validation;
 mod stack;

--- a/utils/src/otel_tracing.rs
+++ b/utils/src/otel_tracing.rs
@@ -1,100 +1,906 @@
-use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry::trace::{SpanId, TraceContextExt, TraceId, TracerProvider as _};
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::trace::TracerProvider;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator, TracerProvider};
 use opentelemetry_sdk::Resource;
+use std::collections::HashMap;
 use std::io::IsTerminal;
-use std::time::Duration;
-use tracing_subscriber::fmt::format::FmtSpan;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::fmt::format::{FmtSpan, Writer};
+use tracing_subscriber::fmt::time::{FormatTime, SystemTime as FmtSystemTime};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
+
+/// The OTLP span exporter, re-exported so callers don't need a direct
+/// dependency on `opentelemetry-otlp`.
+pub use opentelemetry_otlp::SpanExporter;
+
+/// A span exporter chosen at runtime.
+///
+/// [`init_tracing`] takes one of these rather than a concrete type so a backend
+/// can be anything: OTLP for collectors and vendors, or a cloud-native exporter
+/// from the matching `env_*_direct` crate. The SDK has no blanket
+/// implementation for `Box<dyn SpanExporter>`, hence the wrapper.
+pub struct BoxedSpanExporter(Box<dyn opentelemetry_sdk::export::trace::SpanExporter>);
+
+impl BoxedSpanExporter {
+    pub fn new(exporter: impl opentelemetry_sdk::export::trace::SpanExporter + 'static) -> Self {
+        Self(Box::new(exporter))
+    }
+}
+
+impl std::fmt::Debug for BoxedSpanExporter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("BoxedSpanExporter")
+    }
+}
+
+impl opentelemetry_sdk::export::trace::SpanExporter for BoxedSpanExporter {
+    fn export(
+        &mut self,
+        batch: Vec<opentelemetry_sdk::export::trace::SpanData>,
+    ) -> futures_util::future::BoxFuture<'static, opentelemetry_sdk::export::trace::ExportResult>
+    {
+        self.0.export(batch)
+    }
+
+    fn shutdown(&mut self) {
+        self.0.shutdown()
+    }
+
+    fn force_flush(
+        &mut self,
+    ) -> futures_util::future::BoxFuture<'static, opentelemetry_sdk::export::trace::ExportResult>
+    {
+        self.0.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        self.0.set_resource(resource)
+    }
+}
+
+/// Holds the active provider so [`force_flush_tracing`] can drain it between
+/// Lambda invocations.
+static TRACER_PROVIDER: std::sync::OnceLock<TracerProvider> = std::sync::OnceLock::new();
+
+fn env_flag(name: &str) -> bool {
+    matches!(
+        std::env::var(name).as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("YES")
+    )
+}
+
+/// Resource attributes describing the service and the platform hosting it.
+///
+/// The platform part is not decoration. CloudWatch Application Signals derives
+/// a service's *environment* from these, and with only `service.name` present
+/// it files everything under `generic:default` — a different console page from
+/// the Lambda or ECS task actually running the code, so the spans arrive,
+/// index, and are then effectively invisible in the UI.
+///
+/// Detection is by the environment variables each runtime sets for itself, so
+/// nothing has to be threaded through from the deployment.
+fn platform_resource_attributes(service_name: &str) -> Vec<KeyValue> {
+    let mut attributes = vec![KeyValue::new("service.name", service_name.to_string())];
+
+    if let Ok(function_name) = std::env::var("AWS_LAMBDA_FUNCTION_NAME") {
+        attributes.push(KeyValue::new("cloud.provider", "aws"));
+        attributes.push(KeyValue::new("cloud.platform", "aws_lambda"));
+        attributes.push(KeyValue::new("faas.name", function_name));
+        if let Ok(version) = std::env::var("AWS_LAMBDA_FUNCTION_VERSION") {
+            attributes.push(KeyValue::new("faas.version", version));
+        }
+    } else if std::env::var_os("ECS_CONTAINER_METADATA_URI_V4").is_some()
+        || std::env::var_os("ECS_CONTAINER_METADATA_URI").is_some()
+    {
+        attributes.push(KeyValue::new("cloud.provider", "aws"));
+        attributes.push(KeyValue::new("cloud.platform", "aws_ecs"));
+    }
+
+    if let Some(region) = telemetry_aws_region() {
+        attributes.push(KeyValue::new("cloud.region", region));
+    }
+
+    if let Some(groups) = log_group_names() {
+        attributes.push(KeyValue::new(
+            "aws.log.group.names",
+            opentelemetry::Value::Array(groups.into()),
+        ));
+    }
+
+    attributes
+}
+
+/// The AWS region telemetry is configured for, in the same precedence the X-Ray
+/// exporter uses when it picks an endpoint (`env_aws_direct::telemetry`).
+///
+/// The orders must match. `TELEMETRY_AWS_REGION` exists to override the
+/// ambient region, and Lambda always sets `AWS_REGION` — so consulting
+/// `AWS_REGION` first would export spans to the overridden region while
+/// labelling them `cloud.region` of the other one.
+fn telemetry_aws_region() -> Option<String> {
+    std::env::var("TELEMETRY_AWS_REGION")
+        .or_else(|_| std::env::var("AWS_REGION"))
+        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+        .ok()
+}
+
+/// Log groups to associate the service's spans with, for the Logs tab of a
+/// CloudWatch Application Signals service.
+///
+/// That tab does not search for logs, it follows this attribute. Without it the
+/// service page renders with an empty Logs tab however healthy the log group
+/// is, because nothing tells the console which group belongs to the service.
+///
+/// Lambda publishes its own group as an environment variable. ECS only exposes
+/// it through the task metadata endpoint, which would mean an HTTP call during
+/// startup, so the task definition passes it in instead — it is the same
+/// Terraform that declares the group in the first place.
+fn log_group_names() -> Option<Vec<opentelemetry::StringValue>> {
+    let raw = std::env::var("TELEMETRY_LOG_GROUP_NAMES")
+        .or_else(|_| std::env::var("AWS_LAMBDA_LOG_GROUP_NAME"))
+        .ok()?;
+    let groups: Vec<opentelemetry::StringValue> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .map(|group| group.to_string().into())
+        .collect();
+    (!groups.is_empty()).then_some(groups)
+}
+
+fn build_tracer(
+    service_name: &str,
+    exporter: BoxedSpanExporter,
+) -> opentelemetry_sdk::trace::Tracer {
+    let resource = Resource::new(platform_resource_attributes(service_name));
+    let provider = TracerProvider::builder()
+        .with_resource(resource)
+        .with_id_generator(XrayIdGenerator::default())
+        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+        .build();
+    global::set_tracer_provider(provider.clone());
+    let _ = TRACER_PROVIDER.set(provider.clone());
+    provider.tracer(service_name.to_string())
+}
+
+/// Force-flush buffered spans to the exporter. Call this at the end of each
+/// Lambda invocation: the execution environment freezes right after the
+/// response, so the batch processor would otherwise never push this
+/// invocation's spans to the collector/X-Ray before the freeze — which is why
+/// Lambda OTel traces silently go missing. No-op when no exporter is active.
+pub fn force_flush_tracing() {
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        for result in provider.force_flush() {
+            if let Err(e) = result {
+                eprintln!("OpenTelemetry force_flush error: {e:?}");
+            }
+        }
+    }
+}
+
+/// ID generator producing AWS X-Ray-compatible trace IDs.
+///
+/// X-Ray encodes the trace start time in the high 32 bits of the trace ID
+/// (`1-<epoch>-<random>`) and drops segments whose timestamp is outside a
+/// ~30 day window. OpenTelemetry's default fully-random IDs therefore never
+/// show up in X-Ray. This stamps the current epoch into the first 4 bytes and
+/// keeps the remaining 96 bits random — still a valid OTel trace ID, so it is
+/// safe for non-X-Ray backends too.
+#[derive(Clone, Debug, Default)]
+struct XrayIdGenerator {
+    inner: RandomIdGenerator,
+}
+
+impl IdGenerator for XrayIdGenerator {
+    fn new_trace_id(&self) -> TraceId {
+        let mut bytes = self.inner.new_trace_id().to_bytes();
+        let epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as u32)
+            .unwrap_or(0);
+        bytes[0..4].copy_from_slice(&epoch.to_be_bytes());
+        TraceId::from_bytes(bytes)
+    }
+
+    fn new_span_id(&self) -> SpanId {
+        self.inner.new_span_id()
+    }
+}
+
+/// Build the generic OTLP/gRPC span exporter pointed at `endpoint`
+/// (typically a collector configured via `OTEL_EXPORTER_OTLP_ENDPOINT`).
+///
+/// This is cloud-agnostic; cloud-specific exporters (e.g. AWS X-Ray with
+/// SigV4) live in the respective `env_*_direct` crate.
+pub fn otlp_grpc_exporter(endpoint: &str) -> anyhow::Result<BoxedSpanExporter> {
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .with_timeout(Duration::from_secs(3))
+        .build()?;
+    Ok(BoxedSpanExporter::new(exporter))
+}
+
+/// Build the generic OTLP/HTTP span exporter pointed at `endpoint`. Vendor
+/// neutral: point it at a local collector/agent (`http://localhost:4318`) or
+/// straight at any OTLP/HTTP intake (Datadog, Grafana Cloud, Honeycomb, …).
+///
+/// Authentication is not handled here — the exporter picks up
+/// `OTEL_EXPORTER_OTLP_HEADERS` (or `OTEL_EXPORTER_OTLP_TRACES_HEADERS`) on its
+/// own, which is how vendor API keys are supplied.
+///
+/// `endpoint` must be the full trace URL, because the exporter only appends the
+/// `/v1/traces` path to `OTEL_EXPORTER_OTLP_ENDPOINT` — a value passed here is
+/// used verbatim. We append it when missing so the localhost default doesn't
+/// silently POST to the server root.
+///
+/// That normalization only ever applies to a caller-supplied endpoint, though:
+/// `resolve_http_endpoint` in opentelemetry-otlp returns on
+/// `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, then `OTEL_EXPORTER_OTLP_ENDPOINT`,
+/// before it looks at the builder's value at all. So when either is set this
+/// argument is dead and the SDK's own path handling decides — including
+/// appending `/v1/traces` to an `OTEL_EXPORTER_OTLP_ENDPOINT` that already ends
+/// in it. Nothing here can prevent that; use the `_TRACES_` form for a full URL.
+pub fn otlp_http_exporter(endpoint: &str) -> anyhow::Result<BoxedSpanExporter> {
+    let exporter = SpanExporter::builder()
+        .with_http()
+        .with_endpoint(normalize_traces_endpoint(endpoint))
+        .with_timeout(Duration::from_secs(3))
+        .build()?;
+    Ok(BoxedSpanExporter::new(exporter))
+}
+
+/// Append the OTLP `/v1/traces` signal path unless it is already present.
+fn normalize_traces_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim().trim_end_matches('/');
+    if trimmed.ends_with("/v1/traces") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/v1/traces")
+    }
+}
 
 /// Initialize tracing for a service.
 ///
 /// - Bridges existing `log::*` call sites into `tracing` (default feature
 ///   on `tracing-subscriber`), so callers don't need to migrate.
-/// - Emits JSON to stderr when `LOG_FORMAT=json` or stderr isn't a TTY,
-///   pretty/ANSI otherwise.
-/// - If an OTLP exporter can be built (default endpoint
-///   `http://localhost:4317`, override via `OTEL_EXPORTER_OTLP_ENDPOINT`),
-///   spans are exported. Otherwise tracing/log still works locally — the
-///   batch exporter swallows transient connectivity errors at runtime.
-pub fn init_tracing(service_name: &str) -> anyhow::Result<()> {
-    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
-        .unwrap_or_else(|_| "http://localhost:4317".to_string());
+/// - Emits minimal plain logs (`<timestamp> <LEVEL> <message>`, no span
+///   context/target/ANSI) when `LOG_FORMAT=plain`, JSON logs when
+///   `LOG_FORMAT=json`, JSON logs when stderr isn't a TTY, and pretty/ANSI
+///   logs otherwise.
+/// - When an `exporter` is supplied, spans are batched and exported through it.
+///   Selecting/building the exporter (X-Ray, OTLP gRPC, …) is the caller's
+///   responsibility; see `env_common`'s telemetry orchestration.
+/// - When `exporter` is `None`, tracing/log still works locally without trying
+///   to contact a collector.
+pub fn init_tracing(service_name: &str, exporter: Option<BoxedSpanExporter>) -> anyhow::Result<()> {
+    let telemetry_layer = exporter.map(|exporter| {
+        tracing_opentelemetry::layer().with_tracer(build_tracer(service_name, exporter))
+    });
 
-    let resource = Resource::new(vec![KeyValue::new(
-        "service.name",
-        service_name.to_string(),
-    )]);
+    configure_fmt_layer(telemetry_layer, env_filter_from_env())
+}
 
-    let telemetry_layer = match opentelemetry_otlp::SpanExporter::builder()
-        .with_tonic()
-        .with_endpoint(&otlp_endpoint)
-        .with_timeout(Duration::from_secs(3))
-        .build()
-    {
-        Ok(exporter) => {
-            let provider = TracerProvider::builder()
-                .with_resource(resource)
-                .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
-                .build();
-            global::set_tracer_provider(provider.clone());
-            let tracer = provider.tracer(service_name.to_string());
-            Some(tracing_opentelemetry::layer().with_tracer(tracer))
-        }
-        Err(e) => {
-            eprintln!(
-                "OpenTelemetry exporter init failed ({}); continuing without OTLP export",
-                e
-            );
-            None
-        }
+fn env_filter_from_env() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+}
+
+fn configure_fmt_layer<L>(telemetry_layer: Option<L>, env_filter: EnvFilter) -> anyhow::Result<()>
+where
+    L: tracing_subscriber::Layer<
+            tracing_subscriber::layer::Layered<EnvFilter, tracing_subscriber::Registry>,
+        > + Send
+        + Sync
+        + 'static,
+{
+    let log_format = std::env::var("LOG_FORMAT").ok();
+    let stderr_is_tty = std::io::stderr().is_terminal();
+    let mode = match log_format.as_deref() {
+        Some("plain") => LogMode::Plain,
+        Some("json") => LogMode::Json,
+        // Default to JSON when stderr isn't a real terminal (files, Docker,
+        // collectors); use the human-friendly pretty format interactively.
+        _ if stderr_is_tty => LogMode::Pretty,
+        _ => LogMode::Json,
     };
-
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-
-    let json =
-        std::env::var("LOG_FORMAT").as_deref() == Ok("json") || !std::io::stderr().is_terminal();
+    let include_span_context = env_flag("LOG_INCLUDE_SPANS");
+    let emit_span_close_events = env_flag("LOG_SPAN_CLOSE_EVENTS");
 
     let registry = tracing_subscriber::registry()
         .with(env_filter)
         .with(telemetry_layer);
 
-    if json {
-        registry
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .json()
-                    .flatten_event(true)
-                    // Include the full span chain so fields set on the root
-                    // span (e.g. `trace_id`) appear on every event emitted
-                    // inside nested spans.
-                    .with_current_span(true)
-                    .with_span_list(true)
-                    .with_target(true)
-                    .with_ansi(false)
-                    // Emit one event per span close, with `time.busy` /
-                    // `time.idle` timing — gives you a duration log line
-                    // for every instrumented function.
-                    .with_span_events(FmtSpan::CLOSE),
-            )
-            .init();
-    } else {
-        registry
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .with_ansi(true)
-                    .with_span_events(FmtSpan::CLOSE),
-            )
-            .init();
+    match mode {
+        LogMode::Json => {
+            let fmt_layer = tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(true)
+                .with_current_span(include_span_context)
+                .with_span_list(include_span_context)
+                .with_target(true)
+                .with_ansi(false)
+                .with_span_events(if emit_span_close_events {
+                    FmtSpan::CLOSE
+                } else {
+                    FmtSpan::NONE
+                });
+
+            registry.with(fmt_layer).init();
+        }
+        // Minimal one-liner: timestamp + level + message. Span context (incl.
+        // trace_id) and module target are intentionally dropped here since they
+        // are available in the exported traces; this keeps log files readable.
+        LogMode::Plain => {
+            let fmt_layer = tracing_subscriber::fmt::layer()
+                .event_format(PlainFormat)
+                .with_ansi(false);
+
+            registry.with(fmt_layer).init();
+        }
+        LogMode::Pretty => {
+            registry
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_ansi(true)
+                        .with_span_events(FmtSpan::CLOSE),
+                )
+                .init();
+        }
     }
 
     Ok(())
 }
 
-/// Flush and shut down the global tracer provider. Call once at process exit.
+enum LogMode {
+    Json,
+    Plain,
+    Pretty,
+}
+
+/// Compact event formatter emitting only `<timestamp> <LEVEL> <message>`.
+struct PlainFormat;
+
+impl<S, N> FormatEvent<S, N> for PlainFormat
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        FmtSystemTime.format_time(&mut writer)?;
+        write!(writer, " {:>5} ", event.metadata().level())?;
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
+
+/// Flush and shut down the tracer provider. Call once at process exit.
+///
+/// The flush is done through our own provider handle on purpose.
+/// `global::shutdown_tracer_provider()` sounds like it drains the pipeline, but
+/// in opentelemetry 0.27 it only swaps the global for a no-op provider — it
+/// exports nothing, and it cannot even drop the real provider while
+/// `TRACER_PROVIDER` still holds a clone. Relying on it loses whatever is in
+/// the batch queue at exit, which is precisely the process's root span: it
+/// closes last, so the batch processor's scheduled flush never comes around
+/// again. Long-running services looked fine anyway, because the periodic flush
+/// had already shipped every child span — only the entry-point span went
+/// missing, and with it the service's entry in CloudWatch Application Signals.
 pub fn shutdown_tracing() {
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        force_flush_tracing();
+        if let Err(e) = provider.shutdown() {
+            eprintln!("OpenTelemetry shutdown error: {e:?}");
+        }
+    }
     global::shutdown_tracer_provider();
+}
+
+/// Serialize the current span's trace context as a W3C `traceparent` string,
+/// for carrying the trace across a process boundary (e.g. into an ECS task's
+/// environment when launching the runner). Returns `None` when there is no
+/// active, valid trace to propagate.
+pub fn current_traceparent() -> Option<String> {
+    let cx = tracing::Span::current().context();
+    if !cx.span().span_context().is_valid() {
+        return None;
+    }
+    let mut carrier = HashMap::new();
+    TraceContextPropagator::new().inject_context(&cx, &mut carrier);
+    carrier.remove("traceparent").filter(|tp| !tp.is_empty())
+}
+
+/// Adopt the trace context AWS Lambda puts in `_X_AMZN_TRACE_ID` as `span`'s
+/// parent, so the service's own spans join the trace Lambda already started
+/// rather than beginning a disconnected one.
+///
+/// Without this a single request produces two unrelated traces: Lambda's
+/// built-in active tracing records the invocation under one trace id, and the
+/// SDK mints its own for everything underneath. Both show up, neither contains
+/// the other, and the durations cannot be lined up.
+///
+/// The header is X-Ray's own format rather than W3C:
+/// `Root=1-<8 hex>-<24 hex>;Parent=<16 hex>;Sampled=<0|1>`, with the fields in
+/// any order. No-op when it is absent or unparseable, leaving the span as a
+/// root — which is the right outcome outside Lambda.
+pub fn set_span_parent_from_xray_header(span: &tracing::Span, header: &str) {
+    let Some(span_context) = xray_header_to_span_context(header) else {
+        return;
+    };
+    span.set_parent(opentelemetry::Context::new().with_remote_span_context(span_context));
+}
+
+/// The `Root=` trace id from an `_X_AMZN_TRACE_ID` header, in X-Ray's own
+/// `1-<8 hex>-<24 hex>` punctuation — the form the console and the `x-trace-id`
+/// response header use, so log lines can be correlated with what a caller saw.
+///
+/// Returns `None` for a header that is absent, malformed, or missing `Root`,
+/// rather than passing a half-parsed id on to something that will look it up.
+pub fn xray_root_trace_id(header: &str) -> Option<&str> {
+    let root = header
+        .split(';')
+        .filter_map(|field| field.trim().split_once('='))
+        .find_map(|(name, value)| (name == "Root").then_some(value))?;
+    // Validate through the same parser the span-context path uses, so the two
+    // cannot disagree about what counts as a usable header.
+    xray_header_to_span_context(header).map(|_| root)
+}
+
+/// Parse an `_X_AMZN_TRACE_ID` header into an OpenTelemetry span context.
+fn xray_header_to_span_context(header: &str) -> Option<opentelemetry::trace::SpanContext> {
+    let mut root = None;
+    let mut parent = None;
+    let mut sampled = false;
+
+    for field in header.split(';') {
+        match field.trim().split_once('=') {
+            Some(("Root", value)) => root = Some(value),
+            Some(("Parent", value)) => parent = Some(value),
+            Some(("Sampled", value)) => sampled = value == "1",
+            _ => {}
+        }
+    }
+
+    // `1-<8 hex>-<24 hex>` holds the same 128 bits as an OTel trace id, just
+    // punctuated differently.
+    let root = root?;
+    let mut parts = root.splitn(3, '-');
+    if parts.next()? != "1" {
+        return None;
+    }
+    let (high, low) = (parts.next()?, parts.next()?);
+    if high.len() != 8 || low.len() != 24 {
+        return None;
+    }
+    let trace_id = TraceId::from_hex(&format!("{high}{low}")).ok()?;
+
+    // A missing Parent is normal for the first segment in a trace; joining the
+    // trace still matters, so fall back to an invalid (absent) parent span.
+    let span_id = parent
+        .and_then(|p| SpanId::from_hex(p).ok())
+        .unwrap_or(SpanId::INVALID);
+
+    let flags = if sampled {
+        opentelemetry::trace::TraceFlags::SAMPLED
+    } else {
+        opentelemetry::trace::TraceFlags::default()
+    };
+
+    Some(opentelemetry::trace::SpanContext::new(
+        trace_id,
+        span_id,
+        flags,
+        true, // remote
+        opentelemetry::trace::TraceState::default(),
+    ))
+}
+
+/// Set `span`'s parent to the remote trace context encoded in a W3C
+/// `traceparent` string (as produced by [`current_traceparent`]), so the span —
+/// and everything under it — joins the caller's trace. No-op when the string is
+/// empty or invalid, leaving the span with its own freshly generated trace.
+pub fn set_span_parent_from_traceparent(span: &tracing::Span, traceparent: &str) {
+    if traceparent.trim().is_empty() {
+        return;
+    }
+    let mut carrier = HashMap::new();
+    carrier.insert("traceparent".to_string(), traceparent.to_string());
+    let cx = TraceContextPropagator::new().extract(&carrier);
+    if cx.span().span_context().is_valid() {
+        span.set_parent(cx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A W3C traceparent with a known trace id, from the spec's own example.
+    const SAMPLE_TRACEPARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const SAMPLE_TRACE_ID: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
+
+    /// Run `f` with a subscriber that has a real (non-noop) tracer attached, so
+    /// spans get valid OTel contexts. No exporter, so nothing leaves the test.
+    fn with_otel_subscriber<T>(f: impl FnOnce() -> T) -> T {
+        let provider = TracerProvider::builder()
+            .with_id_generator(XrayIdGenerator::default())
+            .build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test")));
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
+    #[test]
+    fn xray_trace_ids_stamp_the_current_epoch_in_the_high_bits() {
+        let generator = XrayIdGenerator::default();
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
+        let bytes = generator.new_trace_id().to_bytes();
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
+
+        let stamped = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        assert!(
+            stamped >= before && stamped <= after,
+            "expected epoch in {before}..={after}, got {stamped} — X-Ray drops \
+             segments whose timestamp is outside a ~30 day window"
+        );
+    }
+
+    #[test]
+    fn xray_trace_ids_stay_valid_and_unique_in_the_low_bits() {
+        let generator = XrayIdGenerator::default();
+        let a = generator.new_trace_id();
+        let b = generator.new_trace_id();
+
+        assert_ne!(a, TraceId::INVALID);
+        assert_ne!(b, TraceId::INVALID);
+        // Only the first 4 bytes are the timestamp; the remaining 96 bits must
+        // still be random or trace ids would collide.
+        assert_ne!(a.to_bytes()[4..], b.to_bytes()[4..]);
+    }
+
+    #[test]
+    fn span_adopts_a_propagated_traceparent() {
+        let traceparent = with_otel_subscriber(|| {
+            let span = tracing::info_span!("runner");
+            set_span_parent_from_traceparent(&span, SAMPLE_TRACEPARENT);
+            let _entered = span.enter();
+            current_traceparent()
+        })
+        .expect("an active span should yield a traceparent");
+
+        assert!(
+            traceparent.contains(SAMPLE_TRACE_ID),
+            "span should have joined the caller's trace, got {traceparent}"
+        );
+    }
+
+    #[test]
+    fn blank_or_malformed_traceparent_leaves_the_span_on_its_own_trace() {
+        for input in [
+            "",
+            "   ",
+            "not-a-traceparent",
+            "00-invalid-00f067aa0ba902b7-01",
+        ] {
+            let traceparent = with_otel_subscriber(|| {
+                let span = tracing::info_span!("runner");
+                set_span_parent_from_traceparent(&span, input);
+                let _entered = span.enter();
+                current_traceparent()
+            });
+
+            if let Some(tp) = traceparent {
+                assert!(
+                    !tp.contains(SAMPLE_TRACE_ID),
+                    "input {input:?} must not adopt a foreign trace"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn xray_header_is_adopted_as_the_parent_trace() {
+        // Same request, one trace: without this the SDK starts its own trace and
+        // Lambda's built-in tracing records the invocation separately.
+        let header = "Root=1-6a954a81-14b68dfaffccd7e39d44814f;Parent=53995c3f42cd8ad8;Sampled=1";
+        let ctx = xray_header_to_span_context(header).expect("parses");
+        assert_eq!(
+            ctx.trace_id(),
+            TraceId::from_hex("6a954a8114b68dfaffccd7e39d44814f").unwrap()
+        );
+        assert_eq!(ctx.span_id(), SpanId::from_hex("53995c3f42cd8ad8").unwrap());
+        assert!(ctx.is_sampled());
+        assert!(ctx.is_remote());
+    }
+
+    #[test]
+    fn xray_header_fields_may_be_in_any_order_and_parent_is_optional() {
+        let ctx = xray_header_to_span_context("Sampled=0;Root=1-6a954a81-14b68dfaffccd7e39d44814f")
+            .expect("parses without Parent");
+        assert_eq!(ctx.span_id(), SpanId::INVALID);
+        assert!(!ctx.is_sampled());
+    }
+
+    #[test]
+    fn the_root_trace_id_is_extracted_in_xray_punctuation() {
+        // This is what goes on the `trace_id` log field and the `x-trace-id`
+        // response header, so it must stay in the form the X-Ray console uses
+        // rather than the OTel one.
+        assert_eq!(
+            xray_root_trace_id(
+                "Root=1-6a954a81-14b68dfaffccd7e39d44814f;Parent=53995c3f42cd8ad8;Sampled=1"
+            ),
+            Some("1-6a954a81-14b68dfaffccd7e39d44814f")
+        );
+        // Field order is not guaranteed; the old `split(';').next()` form only
+        // found Root when it happened to come first.
+        assert_eq!(
+            xray_root_trace_id("Sampled=1;Root=1-6a954a81-14b68dfaffccd7e39d44814f"),
+            Some("1-6a954a81-14b68dfaffccd7e39d44814f")
+        );
+    }
+
+    #[test]
+    fn a_malformed_root_yields_no_trace_id_to_correlate_on() {
+        for header in ["", "Parent=53995c3f42cd8ad8", "Root=", "Root=1-6a954a81"] {
+            assert_eq!(
+                xray_root_trace_id(header),
+                None,
+                "{header:?} should not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_xray_headers_are_ignored_rather_than_guessed_at() {
+        for header in [
+            "",
+            "Root=",
+            "Root=2-6a954a81-14b68dfaffccd7e39d44814f", // unknown version
+            "Root=1-6a954a81",                          // truncated
+            "Root=1-6a954a8-14b68dfaffccd7e39d44814f",  // wrong field widths
+            "Root=1-zzzzzzzz-14b68dfaffccd7e39d44814f", // not hex
+            "Parent=53995c3f42cd8ad8",                  // no Root
+        ] {
+            assert!(
+                xray_header_to_span_context(header).is_none(),
+                "{header:?} should not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn span_joins_the_lambda_trace_from_the_header() {
+        let traceparent = with_otel_subscriber(|| {
+            let span = tracing::info_span!("handler");
+            set_span_parent_from_xray_header(
+                &span,
+                "Root=1-6a954a81-14b68dfaffccd7e39d44814f;Parent=53995c3f42cd8ad8;Sampled=1",
+            );
+            let _entered = span.enter();
+            current_traceparent()
+        })
+        .expect("an active span yields a traceparent");
+        assert!(
+            traceparent.contains("6a954a8114b68dfaffccd7e39d44814f"),
+            "expected the Lambda trace id, got {traceparent}"
+        );
+    }
+
+    #[test]
+    fn force_flush_without_an_active_provider_is_a_noop() {
+        force_flush_tracing();
+    }
+
+    #[test]
+    fn appends_signal_path_to_a_base_url() {
+        assert_eq!(
+            normalize_traces_endpoint("http://localhost:4318"),
+            "http://localhost:4318/v1/traces"
+        );
+    }
+
+    #[test]
+    fn tolerates_a_trailing_slash() {
+        assert_eq!(
+            normalize_traces_endpoint("http://localhost:4318/"),
+            "http://localhost:4318/v1/traces"
+        );
+    }
+
+    #[test]
+    fn does_not_duplicate_an_existing_signal_path() {
+        assert_eq!(
+            normalize_traces_endpoint("https://vendor.example/v1/traces"),
+            "https://vendor.example/v1/traces"
+        );
+        assert_eq!(
+            normalize_traces_endpoint("https://vendor.example/v1/traces/"),
+            "https://vendor.example/v1/traces"
+        );
+    }
+
+    #[test]
+    fn keeps_a_vendor_path_prefix() {
+        assert_eq!(
+            normalize_traces_endpoint("https://vendor.example/otlp"),
+            "https://vendor.example/otlp/v1/traces"
+        );
+    }
+}
+
+#[cfg(test)]
+mod platform_tests {
+    use super::platform_resource_attributes;
+    use std::sync::Mutex;
+
+    // These read process-wide env vars, so they must not run concurrently.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn attrs_with(vars: &[(&str, &str)]) -> Vec<(String, String)> {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for key in [
+            "AWS_LAMBDA_FUNCTION_NAME",
+            "AWS_LAMBDA_FUNCTION_VERSION",
+            "ECS_CONTAINER_METADATA_URI_V4",
+            "ECS_CONTAINER_METADATA_URI",
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION",
+            "TELEMETRY_AWS_REGION",
+            "TELEMETRY_LOG_GROUP_NAMES",
+            "AWS_LAMBDA_LOG_GROUP_NAME",
+        ] {
+            std::env::remove_var(key);
+        }
+        for (k, v) in vars {
+            std::env::set_var(k, v);
+        }
+        let out = platform_resource_attributes("svc")
+            .into_iter()
+            .map(|kv| (kv.key.to_string(), kv.value.as_str().to_string()))
+            .collect();
+        for (k, _) in vars {
+            std::env::remove_var(k);
+        }
+        out
+    }
+
+    fn get<'a>(attrs: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        attrs
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn plain_process_reports_only_the_service() {
+        let attrs = attrs_with(&[]);
+        assert_eq!(get(&attrs, "service.name"), Some("svc"));
+        assert_eq!(get(&attrs, "cloud.platform"), None);
+    }
+
+    #[test]
+    fn lambda_is_detected_from_its_own_environment() {
+        // Without this Application Signals files the service under
+        // `generic:default` instead of `lambda:default`, putting its spans on a
+        // different console page from the function running them.
+        let attrs = attrs_with(&[
+            ("AWS_LAMBDA_FUNCTION_NAME", "infraweave-central-api-prod"),
+            ("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST"),
+            ("AWS_REGION", "us-west-2"),
+        ]);
+        assert_eq!(get(&attrs, "cloud.platform"), Some("aws_lambda"));
+        assert_eq!(get(&attrs, "cloud.provider"), Some("aws"));
+        assert_eq!(
+            get(&attrs, "faas.name"),
+            Some("infraweave-central-api-prod")
+        );
+        assert_eq!(get(&attrs, "faas.version"), Some("$LATEST"));
+        assert_eq!(get(&attrs, "cloud.region"), Some("us-west-2"));
+        assert_eq!(get(&attrs, "service.name"), Some("svc"));
+    }
+
+    #[test]
+    fn ecs_is_detected_and_not_mistaken_for_lambda() {
+        let attrs = attrs_with(&[
+            (
+                "ECS_CONTAINER_METADATA_URI_V4",
+                "http://169.254.170.2/v4/abc",
+            ),
+            ("TELEMETRY_AWS_REGION", "eu-central-1"),
+        ]);
+        assert_eq!(get(&attrs, "cloud.platform"), Some("aws_ecs"));
+        assert_eq!(get(&attrs, "faas.name"), None);
+        // ECS does not set AWS_REGION, so the task definition's variable is the
+        // only source of region there.
+        assert_eq!(get(&attrs, "cloud.region"), Some("eu-central-1"));
+    }
+
+    #[test]
+    fn an_explicit_telemetry_region_wins_over_the_ambient_one() {
+        // Lambda always sets AWS_REGION, so an override that lost to it could
+        // never take effect — spans would go to one region (the exporter reads
+        // TELEMETRY_AWS_REGION first) and be labelled with another.
+        let attrs = attrs_with(&[
+            ("AWS_LAMBDA_FUNCTION_NAME", "infraweave-central-api-prod"),
+            ("AWS_REGION", "us-west-2"),
+            ("TELEMETRY_AWS_REGION", "eu-west-1"),
+        ]);
+        assert_eq!(get(&attrs, "cloud.region"), Some("eu-west-1"));
+    }
+
+    #[test]
+    fn aws_default_region_is_the_last_resort() {
+        // The exporter accepts it, so the attribute must not go missing when it
+        // is the only region in the environment.
+        let attrs = attrs_with(&[("AWS_DEFAULT_REGION", "ap-southeast-2")]);
+        assert_eq!(get(&attrs, "cloud.region"), Some("ap-southeast-2"));
+    }
+
+    #[test]
+    fn lambda_contributes_its_own_log_group() {
+        // Application Signals' Logs tab follows aws.log.group.names; without it
+        // the tab is empty no matter what the group contains.
+        let attrs = attrs_with(&[
+            ("AWS_LAMBDA_FUNCTION_NAME", "infraweave-reconciler-prod"),
+            (
+                "AWS_LAMBDA_LOG_GROUP_NAME",
+                "/aws/lambda/infraweave-reconciler-prod",
+            ),
+        ]);
+        assert!(get(&attrs, "aws.log.group.names")
+            .is_some_and(|v| v.contains("/aws/lambda/infraweave-reconciler-prod")));
+    }
+
+    #[test]
+    fn ecs_takes_its_log_group_from_the_task_definition() {
+        // ECS only exposes the group via the metadata endpoint, so the
+        // deployment passes it in rather than the process fetching it.
+        let attrs = attrs_with(&[
+            (
+                "ECS_CONTAINER_METADATA_URI_V4",
+                "http://169.254.170.2/v4/abc",
+            ),
+            (
+                "TELEMETRY_LOG_GROUP_NAMES",
+                "/infraweave/us-west-2/prod/runner",
+            ),
+        ]);
+        assert!(get(&attrs, "aws.log.group.names")
+            .is_some_and(|v| v.contains("/infraweave/us-west-2/prod/runner")));
+    }
+
+    #[test]
+    fn an_explicit_list_wins_over_the_lambda_default_and_drops_blanks() {
+        let attrs = attrs_with(&[
+            ("AWS_LAMBDA_LOG_GROUP_NAME", "/aws/lambda/ignored"),
+            ("TELEMETRY_LOG_GROUP_NAMES", " /one , ,/two "),
+        ]);
+        let value = get(&attrs, "aws.log.group.names").expect("groups should be set");
+        assert!(value.contains("/one") && value.contains("/two"), "{value}");
+        assert!(!value.contains("ignored"), "{value}");
+    }
+
+    #[test]
+    fn no_log_group_configured_means_no_attribute() {
+        assert_eq!(get(&attrs_with(&[]), "aws.log.group.names"), None);
+    }
 }

--- a/utils/src/redact.rs
+++ b/utils/src/redact.rs
@@ -1,0 +1,205 @@
+//! Redaction helpers for values that end up in logs or on trace spans.
+//!
+//! Traces are useful in proportion to how much context they carry, but some of
+//! that context is secret — terraform is invoked with credentials inline
+//! (`-backend-config=secret_key=…`) and with deployment variables that can hold
+//! anything. These helpers keep enough of a value to correlate or eyeball it
+//! while dropping the part that matters.
+
+/// Characters kept at each end of a masked value.
+const KEEP: usize = 3;
+
+/// Values shorter than this are masked completely: revealing three characters
+/// from each end of, say, an eight-character secret gives away most of it.
+const MIN_LEN_TO_REVEAL: usize = 12;
+
+/// Mask a value, keeping the first and last few characters plus the length.
+///
+/// The length is included because it is often the useful signal — an empty or
+/// truncated credential is visible without exposing the value itself.
+pub fn mask_value(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    if chars.is_empty() {
+        return "(empty)".to_string();
+    }
+    let len = describe_len(chars.len());
+    if chars.len() < MIN_LEN_TO_REVEAL {
+        return format!("***({len})");
+    }
+    let head: String = chars[..KEEP].iter().collect();
+    let tail: String = chars[chars.len() - KEEP..].iter().collect();
+    format!("{head}***{tail}({len})")
+}
+
+fn describe_len(len: usize) -> String {
+    match len {
+        1 => "1 char".to_string(),
+        n => format!("{n} chars"),
+    }
+}
+
+/// Whether a key name suggests its value is a credential.
+///
+/// Deliberately does not match a bare `key`: terraform's
+/// `-backend-config=key=<state path>` is a useful, non-secret value, while
+/// `access_key` and `secret_key` are matched by their more specific prefixes.
+pub fn is_sensitive_key(key: &str) -> bool {
+    const NEEDLES: &[&str] = &[
+        "secret",
+        "password",
+        "passwd",
+        "token",
+        "credential",
+        "access_key",
+        "accesskey",
+        "api_key",
+        "apikey",
+        "private",
+        "auth",
+    ];
+    let lower = key.to_ascii_lowercase();
+    NEEDLES.iter().any(|needle| lower.contains(needle))
+}
+
+/// Render a command line for logging, masking any argument whose key looks like
+/// a credential. Nested forms are handled, so `-backend-config=secret_key=AKIA…`
+/// masks only the value.
+///
+/// Arguments without `=` (subcommands, bare flags) are passed through.
+pub fn sanitize_cli_args<I, S>(args: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter()
+        .map(|arg| {
+            let arg = arg.as_ref();
+            match split_at_sensitive_key(arg) {
+                Some((key, value)) => format!("{key}={}", mask_value(value)),
+                None => arg.to_string(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Split an argument at the *first* `=` whose left-hand side looks like a
+/// credential key, returning that key and everything after it.
+///
+/// Scanning left to right is what keeps a value containing `=` intact: a
+/// right-to-left split of `-backend-config=secret_key=aGVsbG8=` lands on the
+/// base64 padding, treats the whole secret as part of the key, and prints it
+/// verbatim. Padded base64 is what most credentials look like, so this is the
+/// common case rather than an edge one.
+///
+/// Taking the first match also means a needle anywhere in the prefix masks
+/// everything after it, which errs toward hiding too much rather than too
+/// little.
+fn split_at_sensitive_key(arg: &str) -> Option<(&str, &str)> {
+    arg.match_indices('=')
+        .map(|(at, _)| (&arg[..at], &arg[at + 1..]))
+        .find(|(key, _)| is_sensitive_key(key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_values_are_masked_completely() {
+        // Revealing 3+3 of an 8-char secret would leave almost nothing hidden.
+        assert_eq!(mask_value("hunter2"), "***(7 chars)");
+        assert_eq!(mask_value("a"), "***(1 char)");
+        assert_eq!(mask_value(""), "(empty)");
+    }
+
+    #[test]
+    fn long_values_keep_their_ends_and_length() {
+        assert_eq!(mask_value("AKIAIOSFODNN7EXAMPLE"), "AKI***PLE(20 chars)");
+    }
+
+    #[test]
+    fn masking_is_char_safe_not_byte_safe() {
+        // Slicing bytes here would panic on a multi-byte boundary.
+        let value = "ααααααααααααααα";
+        assert_eq!(mask_value(value), "ααα***ααα(15 chars)");
+    }
+
+    #[test]
+    fn credential_keys_are_recognised() {
+        for key in [
+            "-backend-config=secret_key",
+            "-backend-config=access_key",
+            "AWS_SESSION_TOKEN",
+            "my_password",
+            "API_KEY",
+            "private_key",
+        ] {
+            assert!(is_sensitive_key(key), "{key} should be sensitive");
+        }
+    }
+
+    #[test]
+    fn state_path_key_is_not_treated_as_a_credential() {
+        // `-backend-config=key=<path>` is the state object path, and useful.
+        assert!(!is_sensitive_key("-backend-config=key"));
+        assert!(!is_sensitive_key("-backend-config=bucket"));
+        assert!(!is_sensitive_key("-out"));
+    }
+
+    #[test]
+    fn sanitize_masks_only_the_credential_arguments() {
+        let args = [
+            "init",
+            "-no-color",
+            "-backend-config=bucket=tf-state-prod",
+            "-backend-config=key=cli/dev/s3bucket/terraform.tfstate",
+            "-backend-config=access_key=AKIAIOSFODNN7EXAMPLE",
+            "-backend-config=secret_key=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY",
+        ];
+        assert_eq!(
+            sanitize_cli_args(args),
+            "init -no-color \
+             -backend-config=bucket=tf-state-prod \
+             -backend-config=key=cli/dev/s3bucket/terraform.tfstate \
+             -backend-config=access_key=AKI***PLE(20 chars) \
+             -backend-config=secret_key=wJa***KEY(38 chars)"
+        );
+    }
+
+    #[test]
+    fn values_containing_equals_are_still_masked_whole() {
+        // Regression: splitting on the last `=` put the base64 padding on the
+        // value side, left the secret itself inside the "key", and printed it
+        // verbatim onto the span.
+        for (arg, secret, expected) in [
+            (
+                "-backend-config=secret_key=aGVsbG93b3JsZHNlY3JldA==",
+                "aGVsbG93b3JsZHNlY3JldA==",
+                "-backend-config=secret_key=aGV***A==(24 chars)",
+            ),
+            (
+                "-var=db_password=p@ss=word",
+                "p@ss=word",
+                "-var=db_password=***(9 chars)",
+            ),
+            (
+                "AWS_SESSION_TOKEN=FwoGZXIvYXdzEBYaDA==",
+                "FwoGZXIvYXdzEBYaDA==",
+                "AWS_SESSION_TOKEN=Fwo***A==(20 chars)",
+            ),
+        ] {
+            let masked = sanitize_cli_args([arg]);
+            assert_eq!(masked, expected);
+            assert!(!masked.contains(secret), "{arg} leaked its value: {masked}");
+        }
+    }
+
+    #[test]
+    fn plain_flags_pass_through_untouched() {
+        assert_eq!(
+            sanitize_cli_args(["plan", "-input=false", "-lock=false", "-out=planfile"]),
+            "plan -input=false -lock=false -out=planfile"
+        );
+    }
+}


### PR DESCRIPTION
`init_tracing` always built an OTLP/gRPC exporter aimed at `localhost:4317`.
Nothing listens there, so every process ran a batch processor that failed to
connect and never said so. It now takes an exporter; the caller decides.

- Trace ids put the start time in the high 32 bits. X-Ray drops ids outside a
  ~30 day window, so fully random ones never appeared.
- Flushing goes through our own provider handle; `global::shutdown_tracer_provider()`
  installs a no-op and exports nothing.
- `sanitize_cli_args` splits on the *first* credential-looking `=` - from the right
  it lands on base64 padding and prints the secret.

`cargo test -p env_utils --features otel`: 120 passing.
