### PR TITLE
feat(telemetry): select a span exporter per deployment

### DIFF
--- a/.github/vars/default.image_mirror.json
+++ b/.github/vars/default.image_mirror.json
@@ -26,5 +26,9 @@
     {
         "from": "localstack/localstack:3.0",
         "to": "localstack:3.0"
+    },
+    {
+        "from": "jaegertracing/all-in-one:1.62.0",
+        "to": "jaeger-all-in-one:1.62.0"
     }
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,10 @@ dependencies = [
  "env_defs",
  "env_utils",
  "log",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "pretty_assertions",
  "reqwest",
  "serde",
@@ -3882,6 +3886,7 @@ dependencies = [
  "operator",
  "pretty_assertions",
  "rand 0.10.1",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -3892,6 +3897,7 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tower 0.5.2",
+ "tracing",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: integration-tests build-images python-sdk-integration-test # Always run, disregard if files have been updated or not
+.PHONY: integration-tests build-images python-sdk-integration-test telemetry-integration-test # Always run, disregard if files have been updated or not
 
 generate-cli-docs:
 	@echo "Generating CLI documentation..."
@@ -55,6 +55,16 @@ python-sdk-integration-test:
 	@echo "Running Python SDK integration test (compiled module against local backend)..."
 	INFRAWEAVE_RUN_PY_SDK_TEST=1 \
 	cargo test -p integration-tests --test python_sdk -- --nocapture --test-threads=1
+
+# Self-contained: starts Jaeger via testcontainers, exports spans through the
+# real env_common::telemetry path, and asserts they arrive on the trace context
+# that was propagated in. The second suite covers the exit path the deployed
+# services rely on: shutdown alone must export the root span.
+# Requires only Docker (no cloud credentials).
+telemetry-integration-test:
+	@echo "Running telemetry integration test (OTLP spans -> Jaeger)..."
+	cargo test -p integration-tests --test telemetry -- --nocapture --test-threads=1
+	cargo test -p integration-tests --test telemetry_shutdown -- --nocapture --test-threads=1
 
 test: unit-tests integration-tests
 

--- a/env_aws_direct/Cargo.toml
+++ b/env_aws_direct/Cargo.toml
@@ -5,6 +5,17 @@ edition.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[features]
+# AWS X-Ray span exporter (SigV4-signed OTLP/HTTP). Off by default so consumers
+# that don't emit telemetry (cli, gitops, …) don't pull in OpenTelemetry.
+otel = [
+    "env_utils/otel",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-http",
+    "dep:opentelemetry-otlp",
+]
+
 [dependencies]
 async-trait = { workspace = true }
 aws-config.workspace = true
@@ -26,6 +37,11 @@ tokio = { workspace = true, features = ["full"] }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["gzip"] }
+
+opentelemetry = { version = "0.27", optional = true }
+opentelemetry_sdk = { version = "0.27", optional = true }
+opentelemetry-http = { version = "0.27", optional = true }
+opentelemetry-otlp = { version = "0.27", features = ["http-proto", "trace"], optional = true }
 
 env_defs = { path = "../defs" }
 env_utils = { path = "../utils" }

--- a/env_aws_direct/src/lib.rs
+++ b/env_aws_direct/src/lib.rs
@@ -6,6 +6,8 @@ mod http_auth;
 mod job_id;
 pub mod local_bootstrap;
 mod provider;
+#[cfg(feature = "otel")]
+pub mod telemetry;
 pub mod utils;
 
 pub use central_creds::{

--- a/env_aws_direct/src/telemetry.rs
+++ b/env_aws_direct/src/telemetry.rs
@@ -1,0 +1,137 @@
+//! AWS-specific OpenTelemetry span export: a SigV4-signing OTLP/HTTP client
+//! pointed at the AWS X-Ray endpoint. The generic tracing setup (log
+//! formatting, the OTLP/gRPC exporter, tracer provider wiring) lives in
+//! `env_utils::otel_tracing`; this module only provides the X-Ray exporter.
+
+use async_trait::async_trait;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sigv4::http_request::{sign, SignableBody, SignableRequest, SigningSettings};
+use env_utils::otel_tracing::SpanExporter;
+use opentelemetry_http::{Bytes, HttpClient, HttpError, Request, Response};
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+use std::fmt::Debug;
+use std::time::{Duration, SystemTime};
+
+#[derive(Debug)]
+struct AwsSigV4HttpClient {
+    service: &'static str,
+    region: String,
+    config: tokio::sync::OnceCell<aws_config::SdkConfig>,
+    client: reqwest::Client,
+}
+
+impl AwsSigV4HttpClient {
+    fn new(service: &'static str, region: String) -> Self {
+        Self {
+            service,
+            region,
+            config: tokio::sync::OnceCell::new(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    async fn sdk_config(&self) -> &aws_config::SdkConfig {
+        self.config
+            .get_or_init(|| async {
+                aws_config::from_env()
+                    .region(aws_config::Region::new(self.region.clone()))
+                    .load()
+                    .await
+            })
+            .await
+    }
+}
+
+#[async_trait]
+impl HttpClient for AwsSigV4HttpClient {
+    async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
+        let config = self.sdk_config().await;
+        let credentials_provider = config
+            .credentials_provider()
+            .ok_or("No AWS credentials provider found")?;
+        let credentials = credentials_provider.provide_credentials().await?;
+        let identity = aws_smithy_runtime_api::client::identity::Identity::new(credentials, None);
+
+        let (parts, body) = request.into_parts();
+        let method = parts.method.as_str().to_string();
+        let url = parts.uri.to_string();
+        let headers = parts
+            .headers
+            .iter()
+            .filter_map(|(name, value)| {
+                Some((name.as_str().to_string(), value.to_str().ok()?.to_string()))
+            })
+            .collect::<Vec<_>>();
+
+        let signing_settings = SigningSettings::default();
+        let signing_params = aws_sigv4::sign::v4::SigningParams::builder()
+            .identity(&identity)
+            .region(&self.region)
+            .name(self.service)
+            .time(SystemTime::now())
+            .settings(signing_settings)
+            .build()?;
+
+        let signable = SignableRequest::new(
+            &method,
+            &url,
+            headers
+                .iter()
+                .map(|(name, value)| (name.as_str(), value.as_str())),
+            SignableBody::Bytes(&body),
+        )?;
+        let (signing_instructions, _signature) =
+            sign(signable, &signing_params.into())?.into_parts();
+
+        let mut reqwest_request = self
+            .client
+            .request(reqwest::Method::from_bytes(method.as_bytes())?, &url);
+
+        for (name, value) in headers {
+            reqwest_request = reqwest_request.header(name, value);
+        }
+
+        for (name, value) in signing_instructions.headers() {
+            reqwest_request = reqwest_request.header(name, value);
+        }
+
+        for (name, value) in signing_instructions.params() {
+            reqwest_request = reqwest_request.query(&[(name, value.as_ref())]);
+        }
+
+        let mut response = reqwest_request.body(body).send().await?;
+        let headers = std::mem::take(response.headers_mut());
+        let mut http_response = Response::builder()
+            .status(response.status())
+            .body(response.bytes().await?)?;
+        *http_response.headers_mut() = headers;
+
+        Ok(http_response)
+    }
+}
+
+fn aws_region_from_env() -> anyhow::Result<String> {
+    std::env::var("TELEMETRY_AWS_REGION")
+        .or_else(|_| std::env::var("AWS_REGION"))
+        .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "TELEMETRY_EXPORTER=xray requires TELEMETRY_AWS_REGION, AWS_REGION, or AWS_DEFAULT_REGION"
+            )
+        })
+}
+
+/// Build a span exporter that ships spans to the AWS X-Ray OTLP/HTTP endpoint,
+/// signing each request with SigV4. The region is resolved from
+/// `TELEMETRY_AWS_REGION`, `AWS_REGION`, or `AWS_DEFAULT_REGION`.
+pub fn xray_span_exporter() -> anyhow::Result<env_utils::otel_tracing::BoxedSpanExporter> {
+    let region = aws_region_from_env()?;
+    let endpoint = format!("https://xray.{region}.amazonaws.com/v1/traces");
+    let exporter = SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint)
+        .with_timeout(Duration::from_secs(3))
+        .with_http_client(AwsSigV4HttpClient::new("xray", region))
+        .build()?;
+    Ok(env_utils::otel_tracing::BoxedSpanExporter::new(exporter))
+}

--- a/env_common/Cargo.toml
+++ b/env_common/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[features]
+# Enables the `telemetry` orchestrator (`init_tracing`/`shutdown_tracing`),
+# pulling in the generic tracing setup plus the AWS X-Ray exporter. Off by
+# default so non-telemetry consumers stay lightweight.
+otel = ["env_utils/otel", "env_aws_direct/otel"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/env_common/src/lib.rs
+++ b/env_common/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod errors;
 pub mod interface;
 pub mod logic;
+#[cfg(feature = "otel")]
+pub mod telemetry;
 
 pub use interface::DeploymentStatusHandler;
 

--- a/env_common/src/telemetry.rs
+++ b/env_common/src/telemetry.rs
@@ -1,0 +1,263 @@
+//! Telemetry orchestration: selects a span exporter based on the
+//! `TELEMETRY_EXPORTER` environment variable and hands it to the generic
+//! tracing setup in `env_utils`. Cloud-specific exporters live in the
+//! respective `env_*_direct` crate (e.g. AWS X-Ray in `env_aws_direct`).
+
+use env_utils::otel_tracing::{self, BoxedSpanExporter};
+
+/// Conventional local collector endpoint, used when `otlp-http` is selected
+/// without an explicit `OTEL_EXPORTER_OTLP_ENDPOINT`.
+const DEFAULT_OTLP_HTTP_ENDPOINT: &str = "http://localhost:4318";
+
+/// Which backend the configuration resolves to, before any exporter is built.
+/// Separated from [`select_exporter`] so the dispatch can be tested without
+/// touching process-wide environment variables or contacting a backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExporterChoice {
+    /// No span export; logging only.
+    Disabled,
+    /// AWS X-Ray via its OTLP endpoint.
+    Xray,
+    /// OTLP/HTTP to the given endpoint.
+    OtlpHttp(String),
+    /// OTLP/gRPC to the given endpoint.
+    OtlpGrpc(String),
+}
+
+/// Trim a setting, treating whitespace-only as absent.
+fn non_blank(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+/// Map `TELEMETRY_EXPORTER` (and the OTLP endpoints, where relevant) onto a
+/// backend choice. Anything unrecognised, blank, or missing a required endpoint
+/// degrades to [`ExporterChoice::Disabled`] with a warning, so a telemetry
+/// misconfiguration never stops a service from starting.
+fn choose_exporter(
+    setting: Option<&str>,
+    otlp_endpoint: Option<&str>,
+    otlp_traces_endpoint: Option<&str>,
+) -> ExporterChoice {
+    let endpoint = non_blank(otlp_endpoint);
+
+    match non_blank(setting) {
+        // `aws` and `xray-otlp` are retained as aliases so deployments that
+        // predate the rename keep working.
+        Some("xray") | Some("xray-otlp") | Some("aws") => {
+            // opentelemetry-otlp resolves OTEL_EXPORTER_OTLP_(TRACES_)ENDPOINT
+            // ahead of the endpoint handed to the builder, so leaving either set
+            // does not merely redirect the spans: the requests are still signed
+            // with SigV4 for the X-Ray host, and the third party receives an
+            // Authorization header naming our access key. Refuse rather than
+            // export, since the spans would not reach X-Ray either way.
+            if let Some(redirect) = endpoint.or(non_blank(otlp_traces_endpoint)) {
+                eprintln!(
+                    "TELEMETRY_EXPORTER=xray but OTEL_EXPORTER_OTLP_ENDPOINT / \
+                     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set ({redirect}); that endpoint \
+                     takes precedence over the X-Ray one, so SigV4-signed requests would go \
+                     there instead. Continuing without OTLP export — unset it, or select \
+                     TELEMETRY_EXPORTER=otlp-http to use it deliberately"
+                );
+                return ExporterChoice::Disabled;
+            }
+            ExporterChoice::Xray
+        }
+        // Defaults to the conventional local collector endpoint so a sidecar or
+        // agent needs no extra configuration.
+        Some("otlp-http") => {
+            ExporterChoice::OtlpHttp(endpoint.unwrap_or(DEFAULT_OTLP_HTTP_ENDPOINT).to_string())
+        }
+        Some("otlp-grpc") => match endpoint {
+            Some(endpoint) => ExporterChoice::OtlpGrpc(endpoint.to_string()),
+            None => {
+                eprintln!(
+                    "TELEMETRY_EXPORTER=otlp-grpc requires OTEL_EXPORTER_OTLP_ENDPOINT; continuing without OTLP export"
+                );
+                ExporterChoice::Disabled
+            }
+        },
+        Some("none") | None => ExporterChoice::Disabled,
+        Some(other) => {
+            eprintln!("Unknown TELEMETRY_EXPORTER value ({other}); continuing without OTLP export");
+            ExporterChoice::Disabled
+        }
+    }
+}
+
+/// Resolve the configured span exporter, if any.
+///
+/// - `TELEMETRY_EXPORTER=xray` → AWS X-Ray via its OTLP endpoint. Requires
+///   X-Ray Transaction Search on the account; `xray-otlp` and `aws` are
+///   accepted as aliases. Refuses to export if an `OTEL_EXPORTER_OTLP_*`
+///   endpoint is also set, since that would take precedence.
+/// - `TELEMETRY_EXPORTER=otlp-http` → OTLP/HTTP to `OTEL_EXPORTER_OTLP_ENDPOINT`
+///   (default `http://localhost:4318`).
+/// - `TELEMETRY_EXPORTER=otlp-grpc` → OTLP/gRPC to `OTEL_EXPORTER_OTLP_ENDPOINT`.
+/// - unset / `none` / unknown → no exporter (local logging only).
+///
+/// The two `otlp-*` modes are vendor neutral: point them at a collector, a
+/// vendor agent, or a hosted OTLP intake (Datadog, Grafana Cloud, Honeycomb, …).
+/// API keys travel via the standard `OTEL_EXPORTER_OTLP_HEADERS`, which the
+/// exporter reads directly.
+///
+/// Failures to build an exporter are logged and downgraded to `None` so a
+/// telemetry misconfiguration never prevents the service from starting.
+fn select_exporter() -> Option<BoxedSpanExporter> {
+    let setting = std::env::var("TELEMETRY_EXPORTER").ok();
+    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+    let otlp_traces_endpoint = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").ok();
+
+    let built = match choose_exporter(
+        setting.as_deref(),
+        otlp_endpoint.as_deref(),
+        otlp_traces_endpoint.as_deref(),
+    ) {
+        ExporterChoice::Disabled => return None,
+        ExporterChoice::Xray => env_aws_direct::telemetry::xray_span_exporter(),
+        ExporterChoice::OtlpHttp(endpoint) => otel_tracing::otlp_http_exporter(&endpoint),
+        ExporterChoice::OtlpGrpc(endpoint) => otel_tracing::otlp_grpc_exporter(&endpoint),
+    };
+
+    match built {
+        Ok(exporter) => Some(exporter),
+        Err(e) => {
+            eprintln!("OpenTelemetry exporter init failed ({e}); continuing without OTLP export");
+            None
+        }
+    }
+}
+
+/// Initialize tracing/logging for a service, wiring up the configured span
+/// exporter (see [`select_exporter`]). Call once at startup.
+pub async fn init_tracing(service_name: &str) -> anyhow::Result<()> {
+    otel_tracing::init_tracing(service_name, select_exporter())
+}
+
+/// Flush and shut down the global tracer provider. Call once at process exit.
+pub fn shutdown_tracing() {
+    otel_tracing::shutdown_tracing();
+}
+
+/// Force-flush buffered spans. On Lambda, call at the end of each invocation so
+/// spans reach the collector/X-Ray before the execution environment freezes.
+pub fn force_flush_tracing() {
+    otel_tracing::force_flush_tracing();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{choose_exporter, ExporterChoice, DEFAULT_OTLP_HTTP_ENDPOINT};
+
+    /// `choose_exporter` with no OTLP endpoints in the environment.
+    fn choose(setting: Option<&str>) -> ExporterChoice {
+        choose_exporter(setting, None, None)
+    }
+
+    #[test]
+    fn xray_and_its_legacy_aliases_all_select_the_same_exporter() {
+        // There is one AWS mode; `xray-otlp` and `aws` are names earlier
+        // deployments used and must keep resolving.
+        for name in ["xray", "xray-otlp", "aws"] {
+            assert_eq!(choose(Some(name)), ExporterChoice::Xray);
+        }
+    }
+
+    #[test]
+    fn xray_refuses_to_export_when_an_otlp_endpoint_would_override_it() {
+        // opentelemetry-otlp prefers these over the endpoint we hand it, so the
+        // spans would miss X-Ray while the requests — signed with SigV4 for the
+        // X-Ray host — go to whoever owns the configured one.
+        for (endpoint, traces_endpoint) in [
+            (Some("https://vendor.example"), None),
+            (None, Some("https://vendor.example/v1/traces")),
+            (Some("https://a.example"), Some("https://b.example")),
+        ] {
+            assert_eq!(
+                choose_exporter(Some("xray"), endpoint, traces_endpoint),
+                ExporterChoice::Disabled,
+                "xray with endpoint={endpoint:?} traces_endpoint={traces_endpoint:?} \
+                 must not export"
+            );
+        }
+        // Blank is not a redirect, so it must not disable a valid setup.
+        assert_eq!(
+            choose_exporter(Some("xray"), Some("  "), Some("")),
+            ExporterChoice::Xray
+        );
+    }
+
+    #[test]
+    fn the_traces_endpoint_only_constrains_xray() {
+        // The otlp-* modes let opentelemetry-otlp read it directly, which is the
+        // documented way to point at a vendor's full trace URL.
+        assert_eq!(
+            choose_exporter(
+                Some("otlp-http"),
+                None,
+                Some("https://vendor.example/v1/traces")
+            ),
+            ExporterChoice::OtlpHttp(DEFAULT_OTLP_HTTP_ENDPOINT.to_string())
+        );
+    }
+
+    #[test]
+    fn otlp_http_falls_back_to_the_local_collector() {
+        assert_eq!(
+            choose(Some("otlp-http")),
+            ExporterChoice::OtlpHttp(DEFAULT_OTLP_HTTP_ENDPOINT.to_string())
+        );
+    }
+
+    #[test]
+    fn otlp_http_honours_an_explicit_endpoint() {
+        assert_eq!(
+            choose_exporter(Some("otlp-http"), Some("https://vendor.example"), None),
+            ExporterChoice::OtlpHttp("https://vendor.example".to_string())
+        );
+    }
+
+    #[test]
+    fn otlp_grpc_requires_an_endpoint() {
+        assert_eq!(
+            choose_exporter(Some("otlp-grpc"), Some("http://localhost:4317"), None),
+            ExporterChoice::OtlpGrpc("http://localhost:4317".to_string())
+        );
+        // Unlike http there is no sensible default, so this must not silently
+        // export to the wrong place.
+        assert_eq!(choose(Some("otlp-grpc")), ExporterChoice::Disabled);
+    }
+
+    #[test]
+    fn unset_none_and_unknown_values_disable_export() {
+        for setting in [None, Some("none"), Some("datadog"), Some("AWS")] {
+            assert_eq!(
+                choose(setting),
+                ExporterChoice::Disabled,
+                "setting {setting:?} should disable export"
+            );
+        }
+    }
+
+    #[test]
+    fn blank_values_are_treated_as_unset() {
+        assert_eq!(choose(Some("   ")), ExporterChoice::Disabled);
+        // A blank endpoint must not become the literal endpoint.
+        assert_eq!(
+            choose_exporter(Some("otlp-http"), Some("  "), None),
+            ExporterChoice::OtlpHttp(DEFAULT_OTLP_HTTP_ENDPOINT.to_string())
+        );
+        assert_eq!(
+            choose_exporter(Some("otlp-grpc"), Some("  "), None),
+            ExporterChoice::Disabled
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_tolerated() {
+        assert_eq!(choose(Some(" xray ")), ExporterChoice::Xray);
+        assert_eq!(
+            choose_exporter(Some("otlp-http"), Some(" https://vendor.example "), None),
+            ExporterChoice::OtlpHttp("https://vendor.example".to_string())
+        );
+    }
+}

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -22,7 +22,7 @@ testcontainers-modules = { workspace = true, features = ["dynamodb", "k3s", "loc
 
 env_defs = { path = "../defs" }
 env_azure = { path = "../env_azure", features = ["test-mode"] }
-env_common = { path = "../env_common" }
+env_common = { path = "../env_common", features = ["otel"] }
 terraform_runner = { path = "../terraform_runner" }
 
 [dev-dependencies]
@@ -30,7 +30,9 @@ pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 bollard = { workspace = true }
 futures = { workspace = true }
-env_utils = { path = "../utils" }
+env_utils = { path = "../utils", features = ["otel"] }
+reqwest = { workspace = true }
+tracing = "0.1"
 http_client = { path = "../http_client" }
 internal-api = { path = "../internal-api", features = ["local"] }
 kube = { workspace = true }

--- a/integration-tests/src/scaffold.rs
+++ b/integration-tests/src/scaffold.rs
@@ -11,6 +11,10 @@ use testcontainers_modules::localstack::LocalStack;
 
 pub const DYNAMODB_IMAGE: &str = "amazon/dynamodb-local";
 pub const MINIO_IMAGE: &str = "minio/minio";
+/// Trace backend used by the telemetry integration test: accepts OTLP and
+/// exposes a query API to assert on what actually arrived.
+pub const JAEGER_IMAGE: &str = "jaegertracing/all-in-one";
+pub const JAEGER_TAG: &str = "1.62.0";
 pub const ALL_IMAGES: &[&str] = &[DYNAMODB_IMAGE, MINIO_IMAGE];
 
 /// Returns the path to the integration-tests directory (resolved at compile time).
@@ -33,6 +37,7 @@ fn get_image_name(original_image: &str, tag: &str) -> (String, String) {
         "mcr.microsoft.com/azure-storage/azurite" => "azurite",
         DYNAMODB_IMAGE => "dynamodb-local",
         "localstack/localstack" => "localstack",
+        JAEGER_IMAGE => "jaeger-all-in-one",
         _ => return (original_image.to_string(), tag.to_string()),
     };
 
@@ -418,6 +423,32 @@ pub async fn start_local_localstack(
     let localstack_endpoint = format!("http://127.0.0.1:{}", localstack_host_port);
 
     (localstack, localstack_endpoint)
+}
+
+/// Start a Jaeger all-in-one container, which accepts OTLP/HTTP on 4318 and
+/// exposes a query API on 16686. Lets a test assert on the spans a service
+/// actually exported, rather than trusting that export was configured.
+///
+/// Returns the container (keep it alive for the duration of the test), the OTLP
+/// endpoint to point `OTEL_EXPORTER_OTLP_ENDPOINT` at, and the query base URL.
+pub async fn start_jaeger() -> (ContainerAsync<GenericImage>, String, String) {
+    let (image_name, image_tag) = get_image_name(JAEGER_IMAGE, JAEGER_TAG);
+    let jaeger = GenericImage::new(&image_name, &image_tag)
+        .with_exposed_port(4318.tcp())
+        .with_exposed_port(16686.tcp())
+        .with_env_var("COLLECTOR_OTLP_ENABLED", "true")
+        .start()
+        .await
+        .unwrap();
+
+    let otlp_port = jaeger.get_host_port_ipv4(4318).await.unwrap();
+    let query_port = jaeger.get_host_port_ipv4(16686).await.unwrap();
+
+    (
+        jaeger,
+        format!("http://127.0.0.1:{}", otlp_port),
+        format!("http://127.0.0.1:{}", query_port),
+    )
 }
 
 #[allow(dead_code)]

--- a/integration-tests/tests/telemetry.rs
+++ b/integration-tests/tests/telemetry.rs
@@ -1,0 +1,162 @@
+//! End-to-end check that configured telemetry actually leaves the process.
+//!
+//! The unit tests in `env_utils`/`env_common` cover the pieces in isolation —
+//! trace id generation, traceparent round-tripping, exporter selection — but
+//! they all stop short of the wire. This starts a real trace backend, exports
+//! into it over OTLP, and asserts on what arrived, which is the only way to
+//! catch a wrong endpoint path, a broken flush, or spans that never build.
+
+#[cfg(test)]
+mod telemetry_tests {
+    use env_common::telemetry;
+    use env_utils::otel_tracing::set_span_parent_from_traceparent;
+    use integration_tests::scaffold::start_jaeger;
+    use serde_json::Value;
+    use std::time::Duration;
+    use tracing::Instrument;
+
+    /// A traceparent standing in for one propagated by internal-api / the
+    /// reconciler through the runner's `TRACE_ID` container override.
+    const UPSTREAM_TRACEPARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const UPSTREAM_TRACE_ID: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const SERVICE_NAME: &str = "telemetry-itest";
+
+    const ROOT_SPAN: &str = "runner_root";
+    const CHILD_SPAN: &str = "child_work";
+
+    /// Poll `f` until it yields a value or the deadline passes.
+    async fn poll_until<F, Fut, T>(what: &str, timeout: Duration, mut f: F) -> T
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Option<T>>,
+    {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(value) = f().await {
+                return value;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out after {timeout:?} waiting for {what}"
+            );
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    /// Fetch the traces Jaeger holds for our service, if the query API is up.
+    async fn fetch_traces(client: &reqwest::Client, query_url: &str) -> Option<Vec<Value>> {
+        let response = client
+            .get(format!("{query_url}/api/traces"))
+            .query(&[("service", SERVICE_NAME)])
+            .send()
+            .await
+            .ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        let body: Value = response.json().await.ok()?;
+        let traces = body.get("data")?.as_array()?.clone();
+        if traces.is_empty() {
+            return None;
+        }
+        Some(traces)
+    }
+
+    fn span_names(trace: &Value) -> Vec<String> {
+        trace
+            .get("spans")
+            .and_then(Value::as_array)
+            .map(|spans| {
+                spans
+                    .iter()
+                    .filter_map(|span| {
+                        span.get("operationName")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    // Multi-threaded on purpose: flushing the batch span processor blocks the
+    // calling thread while the exporter task drains, which would deadlock on a
+    // current-thread runtime.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exported_spans_reach_the_backend_on_the_callers_trace() {
+        let (_jaeger, otlp_endpoint, query_url) = start_jaeger().await;
+        let client = reqwest::Client::new();
+
+        poll_until("jaeger query api", Duration::from_secs(60), || async {
+            client
+                .get(format!("{query_url}/api/services"))
+                .send()
+                .await
+                .ok()
+                .filter(|response| response.status().is_success())
+                .map(|_| ())
+        })
+        .await;
+
+        // Configure exactly the way a deployed service would: through the
+        // environment, resolved by env_common::telemetry.
+        std::env::set_var("TELEMETRY_EXPORTER", "otlp-http");
+        std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", &otlp_endpoint);
+        telemetry::init_tracing(SERVICE_NAME)
+            .await
+            .expect("tracing should initialize");
+
+        // Mirror terraform_runner: adopt the propagated trace context as the
+        // parent of the root span, then do nested work under it.
+        let root = tracing::info_span!(ROOT_SPAN, otel.kind = "server");
+        set_span_parent_from_traceparent(&root, UPSTREAM_TRACEPARENT);
+        async {
+            tracing::info_span!(CHILD_SPAN).in_scope(|| {
+                tracing::info!("work happening inside the runner");
+            });
+        }
+        .instrument(root)
+        .await;
+
+        // Blocking flush, off the async worker threads.
+        tokio::task::spawn_blocking(telemetry::force_flush_tracing)
+            .await
+            .expect("flush should not panic");
+
+        let traces = poll_until("exported spans", Duration::from_secs(60), || async {
+            fetch_traces(&client, &query_url).await
+        })
+        .await;
+
+        // The whole point of propagation: the spans must land on the caller's
+        // trace, not a fresh one the runner invented.
+        let trace = traces
+            .iter()
+            .find(|trace| trace.get("traceID").and_then(Value::as_str) == Some(UPSTREAM_TRACE_ID))
+            .unwrap_or_else(|| {
+                let seen: Vec<_> = traces
+                    .iter()
+                    .filter_map(|t| t.get("traceID").and_then(Value::as_str))
+                    .collect();
+                panic!(
+                    "no trace with the propagated id {UPSTREAM_TRACE_ID}; \
+                     the runner started its own trace instead. Saw: {seen:?}"
+                )
+            });
+
+        let names = span_names(trace);
+        assert!(
+            names.iter().any(|name| name == ROOT_SPAN),
+            "expected the root span {ROOT_SPAN:?} to be exported, got {names:?}"
+        );
+        assert!(
+            names.iter().any(|name| name == CHILD_SPAN),
+            "expected nested work {CHILD_SPAN:?} on the same trace, got {names:?}"
+        );
+
+        // Off the async worker, for the same reason as the flush above.
+        tokio::task::spawn_blocking(telemetry::shutdown_tracing)
+            .await
+            .expect("shutdown should not panic");
+    }
+}

--- a/integration-tests/tests/telemetry_shutdown.rs
+++ b/integration-tests/tests/telemetry_shutdown.rs
@@ -1,0 +1,134 @@
+//! Regression test: a process that only calls `shutdown_tracing()` on its way
+//! out must still export the spans sitting in the batch queue.
+//!
+//! This is the terraform runner's exit path, and it was silently broken. The
+//! runner closes its root `terraform_runner` span last, then shuts down and
+//! exits — but `shutdown_tracing()` only called
+//! `global::shutdown_tracer_provider()`, which in opentelemetry 0.27 swaps the
+//! global for a no-op and exports nothing. Every child span still arrived,
+//! because the batch processor's periodic flush had already shipped them during
+//! the multi-second terraform run, so traces looked complete. Only the root
+//! span went missing — and with it the runner's entry in CloudWatch Application
+//! Signals, which is derived from entry-point (SERVER-kind) spans.
+//!
+//! Lives in its own test binary because `init_tracing` installs process-global
+//! state (tracing subscriber, tracer provider) exactly once, and this test then
+//! shuts that provider down.
+
+#[cfg(test)]
+mod telemetry_shutdown_tests {
+    use env_common::telemetry;
+    use integration_tests::scaffold::start_jaeger;
+    use serde_json::Value;
+    use std::time::Duration;
+    use tracing::Instrument;
+
+    const SERVICE_NAME: &str = "telemetry-shutdown-itest";
+    const ROOT_SPAN: &str = "runner_root";
+
+    /// Long enough that the batch processor's periodic flush cannot rescue the
+    /// span within the test's lifetime. Without this the scheduled flush (5s by
+    /// default) would export the root span a moment later and the test would
+    /// pass even with a `shutdown_tracing()` that flushes nothing — exactly the
+    /// bug being guarded against.
+    const NO_PERIODIC_FLUSH_MS: &str = "600000";
+
+    async fn fetch_traces(client: &reqwest::Client, query_url: &str) -> Option<Vec<Value>> {
+        let response = client
+            .get(format!("{query_url}/api/traces"))
+            .query(&[("service", SERVICE_NAME)])
+            .send()
+            .await
+            .ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        let body: Value = response.json().await.ok()?;
+        let traces = body.get("data")?.as_array()?.clone();
+        if traces.is_empty() {
+            return None;
+        }
+        Some(traces)
+    }
+
+    async fn wait_for_jaeger(client: &reqwest::Client, query_url: &str) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        loop {
+            let up = client
+                .get(format!("{query_url}/api/services"))
+                .send()
+                .await
+                .is_ok_and(|response| response.status().is_success());
+            if up {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for the jaeger query api"
+            );
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    // Multi-threaded for the same reason the runner flushes off the async
+    // worker: shutdown blocks until the batch processor drains, and that
+    // processor runs on this runtime.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_alone_exports_the_root_span() {
+        let (_jaeger, otlp_endpoint, query_url) = start_jaeger().await;
+        let client = reqwest::Client::new();
+        wait_for_jaeger(&client, &query_url).await;
+
+        std::env::set_var("OTEL_BSP_SCHEDULE_DELAY", NO_PERIODIC_FLUSH_MS);
+        std::env::set_var("TELEMETRY_EXPORTER", "otlp-http");
+        std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", &otlp_endpoint);
+        telemetry::init_tracing(SERVICE_NAME)
+            .await
+            .expect("tracing should initialize");
+
+        // Mirror terraform_runner's main: a server-kind root span wrapping the
+        // work, closed by dropping the instrumented future.
+        let root = tracing::info_span!(ROOT_SPAN, otel.kind = "server");
+        async {
+            tracing::info!("work happening inside the runner");
+        }
+        .instrument(root)
+        .await;
+
+        // The only flush on this path — no force_flush_tracing() beforehand,
+        // because the runner has none either.
+        tokio::task::spawn_blocking(telemetry::shutdown_tracing)
+            .await
+            .expect("shutdown should not panic");
+
+        // A short window on purpose: shutdown is supposed to have drained
+        // before it returned, so this is only absorbing Jaeger's ingest lag.
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let traces = loop {
+            if let Some(traces) = fetch_traces(&client, &query_url).await {
+                break traces;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "shutdown_tracing() returned without exporting anything; \
+                 the root span {ROOT_SPAN:?} was dropped with the batch queue"
+            );
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        };
+
+        let names: Vec<String> = traces
+            .iter()
+            .filter_map(|trace| trace.get("spans").and_then(Value::as_array))
+            .flatten()
+            .filter_map(|span| {
+                span.get("operationName")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect();
+        assert!(
+            names.iter().any(|name| name == ROOT_SPAN),
+            "expected shutdown to export the root span {ROOT_SPAN:?}, got {names:?}"
+        );
+    }
+}

--- a/utils/README.md
+++ b/utils/README.md
@@ -12,28 +12,44 @@ The `otel` feature enables `env_utils::otel_tracing`, which initializes:
 
 Telemetry export is disabled by default. This keeps the default runtime path at zero extra infrastructure and avoids trying to contact a local collector when no exporter is configured.
 
+`TELEMETRY_EXPORTER` is set by the deployment (Terraform), not baked into the images, so there is a single source of truth per function/task.
+
+> **Do not put a collector inside a Lambda.** It accepts spans over OTLP,
+> queues them, and returns — then the execution environment freezes before its
+> asynchronous send completes, and they are lost with no error on either side.
+> Both the service and the collector report success and nothing arrives. This is
+> a property of the freeze, not of any backend: a collector fronting Datadog
+> fails the same way, and the usual mitigations are unavailable (the ADOT Lambda
+> build has no `decouple` processor and rejects `sending_queue: enabled: false`).
+>
+> Every mode here exports **in-process**, so `force_flush_tracing()` completes
+> before the handler returns. ECS is unaffected — nothing freezes — so a
+> collector sidecar remains viable there with a short post-shutdown wait.
+
+There is one AWS mode (`xray`) and two vendor-neutral ones (`otlp-http`, `otlp-grpc`). All export in-process; no image bundles a collector.
+
 ### Basic usage
 
-`env_utils::otel_tracing` is the low-level, cloud-agnostic API: it sets up log
-formatting and takes an already-built span exporter
-(`init_tracing(service_name, exporter)`). It pulls in no cloud SDK — a
-cloud-specific exporter belongs in the matching `env_*_direct` crate.
+`env_utils::otel_tracing` is the low-level, cloud-agnostic API: it sets up
+log formatting and takes an already-built span exporter
+(`init_tracing(service_name, exporter)`). Selecting an exporter from the
+`TELEMETRY_EXPORTER` environment variable is orchestrated by
+`env_common::telemetry`, which is what services normally call:
 
 ```rust
-use env_utils::otel_tracing;
+use env_common::telemetry;
 
-// Logging only.
-otel_tracing::init_tracing("my-service", None)?;
-
-// Or exporting spans to a collector.
-let exporter = otel_tracing::otlp_http_exporter("http://localhost:4318")?;
-otel_tracing::init_tracing("my-service", Some(exporter))?;
+telemetry::init_tracing("my-service").await?;
 
 // Run application work here.
 
 // Blocking, and off the async worker — see below.
-let _ = tokio::task::spawn_blocking(otel_tracing::shutdown_tracing).await;
+let _ = tokio::task::spawn_blocking(telemetry::shutdown_tracing).await;
 ```
+
+Cloud-specific exporters live in the matching `env_*_direct` crate
+(e.g. AWS X-Ray with SigV4 in `env_aws_direct::telemetry`), so `env_utils`
+stays free of any cloud SDK dependency.
 
 Call `shutdown_tracing()` once before process exit so batched spans can be
 flushed. It blocks until the batch processor drains, so from an async context
@@ -53,6 +69,12 @@ appears in the Services list.
 Set `LOG_FORMAT=plain` for human-readable logs in CloudWatch/ECS/Lambda. Plain logs are a minimal one-liner — `<timestamp> <LEVEL> <message>` — with no span context, module target, or ANSI color codes, since that detail is available in the exported traces. Set `LOG_FORMAT=json` for compact JSON logs. If `LOG_FORMAT` is not set, logs are JSON when stderr is not a TTY and pretty/ANSI locally.
 
 Trace export is independent from log formatting, so `LOG_FORMAT=plain` can be used together with any exporter.
+
+```sh
+LOG_FORMAT=plain
+TELEMETRY_EXPORTER=xray
+TELEMETRY_AWS_REGION=eu-west-1
+```
 
 JSON logs do not include the full active span stack by default.
 
@@ -129,6 +151,166 @@ task metadata endpoint, so the task definition passes it in instead of the
 process making an HTTP call at startup.
 
 These are useful while debugging tracing, but they make CloudWatch log lines much noisier.
+
+### AWS X-Ray
+
+The single AWS mode. `xray-otlp` and `aws` are accepted as aliases for
+deployments that predate the rename.
+
+```sh
+TELEMETRY_EXPORTER=xray
+AWS_REGION=eu-west-1
+```
+
+The exporter sends OTLP HTTP/protobuf traces directly to:
+
+```text
+https://xray.{region}.amazonaws.com/v1/traces
+```
+
+Requests are signed with AWS SigV4 using the normal AWS credential provider chain. The region is read from the first available variable:
+
+```sh
+TELEMETRY_AWS_REGION
+AWS_REGION
+AWS_DEFAULT_REGION
+```
+
+The runtime role/user needs permission to put traces into X-Ray, for example:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "xray:PutTraceSegments",
+    "xray:PutTelemetryRecords"
+  ],
+  "Resource": "*"
+}
+```
+
+If AWS telemetry is configured without a region, tracing initialization logs a warning and continues without span export.
+
+> **Note:** The `https://xray.{region}.amazonaws.com/v1/traces` OTLP endpoint is
+> part of X-Ray **Transaction Search**, and the account must have it enabled:
+>
+> ```sh
+> aws xray update-trace-segment-destination --destination CloudWatchLogs
+> aws xray get-trace-segment-destination   # must report CloudWatchLogs, not XRay
+> ```
+>
+> Without it every export fails with a 400 — *"The OTLP API is supported with
+> CloudWatch Logs as a Trace Segment Destination"* — visible in the service's own
+> logs. Note that Lambda functions with `tracing_config { mode = "Active" }` keep
+> producing their own segments regardless, named after the function rather than
+> the `service.name` set here, so X-Ray can look healthy while none of these
+> spans are arriving. If you can't enable Transaction Search (it bills ingested
+> spans through CloudWatch Logs), use `otlp-http` against a non-AWS backend
+> instead — see below.
+>
+> Enable it in Terraform with `aws_xray_trace_segment_destination` and
+> `aws_xray_indexing_rule` (AWS provider >= 6.62.0). Indexing is the billed
+> portion and is what the CloudWatch Traces view queries: at 0% spans are stored
+> but never searchable, so that view reads empty.
+
+On Lambda this mode depends on `force_flush_tracing()` running at the end of each
+invocation (see `internal-api`'s handler). The execution environment freezes as
+soon as the response is returned, so anything left in the batch processor is
+otherwise lost. On ECS, `shutdown_tracing()` at process exit does the same job.
+
+Note that ECS does not set `AWS_REGION` the way Lambda does — the runner's task
+definition has to provide `AWS_REGION` or `TELEMETRY_AWS_REGION`, or startup logs
+a warning and continues without export.
+
+### OTLP HTTP — any vendor or collector
+
+`xray` is one option, not the only one. The `otlp-http` mode is vendor neutral and
+speaks standard OTLP/HTTP, so it works with Datadog, Grafana Cloud, Honeycomb,
+New Relic, Jaeger, Tempo, or a plain OpenTelemetry Collector — nothing about the
+service is AWS-specific.
+
+```sh
+TELEMETRY_EXPORTER=otlp-http
+# Optional; defaults to http://localhost:4318
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+**Against a local agent or collector** — the usual shape for Datadog (the Agent's
+OTLP intake) or a sidecar/ADOT collector, which then forwards to the real
+backend using its own credentials:
+
+```sh
+TELEMETRY_EXPORTER=otlp-http
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+**Straight at a hosted OTLP intake**, no collector in between. Vendor API keys go
+in `OTEL_EXPORTER_OTLP_HEADERS`, which the exporter reads on its own — there is
+no code change or per-vendor support needed:
+
+```sh
+TELEMETRY_EXPORTER=otlp-http
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://<vendor-otlp-host>/v1/traces
+OTEL_EXPORTER_OTLP_HEADERS=<vendor-api-key-header>=<key>
+```
+
+> **Endpoint paths.** `OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a *base* URL and
+> gets `/v1/traces` appended; `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is used exactly
+> as given. Use the `_TRACES_` form when your vendor documents a full trace URL,
+> otherwise you end up posting to `/v1/traces/v1/traces`.
+
+Note that `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+take precedence over the endpoint any mode configures internally, including
+`xray`. Setting either alongside `TELEMETRY_EXPORTER=xray` is therefore refused:
+export is disabled and startup logs why. Spans would not have reached X-Ray in
+any case, and the requests would still have been SigV4-signed for the X-Ray host
+— handing whoever owns the configured endpoint an `Authorization` header naming
+the runtime role's access key. Unset it, or select `otlp-http` to use it
+deliberately.
+
+No collector is bundled in any image; every service exports directly. On ECS a
+collector sidecar is still workable if you want one, provided the task sets
+`TELEMETRY_DRAIN_SECONDS` so the runner waits after `shutdown_tracing()` for the
+sidecar to drain before the task tears down:
+
+```sh
+TELEMETRY_DRAIN_SECONDS=3   # default 0; only needed with a collector sidecar
+```
+
+Without it the task stops the moment the (essential) runner container exits,
+killing the sidecar before it forwards the root `terraform_runner` segment — and
+X-Ray then drops the whole trace as orphaned subsegments. In-process export needs
+no wait, since `shutdown_tracing()` has already drained. On Lambda a sidecar is
+not workable at all — see the note at the top.
+
+### OTLP gRPC export
+
+Same vendor-neutral story over gRPC, for a collector, local development, or any
+endpoint that accepts OTLP gRPC. `OTEL_EXPORTER_OTLP_HEADERS` applies here too.
+Unlike HTTP there is no signal path to append, so the endpoint is used as given.
+
+```sh
+TELEMETRY_EXPORTER=otlp-grpc
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317   # required, no default
+```
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` is **required** here — unlike `otlp-http` there is
+no conventional default port to fall back to, so a missing endpoint logs a
+warning and disables export rather than guessing.
+
+### Disable export explicitly
+
+```sh
+TELEMETRY_EXPORTER=none
+```
+
+Logs still work normally; only span export is disabled.
+
+Anything else — an unset, blank, or unrecognised `TELEMETRY_EXPORTER` — behaves
+the same way, logging a warning first when the value was non-empty. Telemetry is
+never allowed to stop a service from starting, so every misconfiguration in this
+document degrades to logging-only rather than failing startup.
+
 ## Redaction
 
 `env_utils::redact` (always available, no feature flag) masks values that would


### PR DESCRIPTION
`TELEMETRY_EXPORTER` picks between `xray` (OTLP/HTTP signed with SigV4) and the
vendor-neutral `otlp-http` and `otlp-grpc`, so the backend is a deployment
decision rather than a code one.

- `env_common::telemetry` does the selection and `env_aws_direct::telemetry`
  holds the X-Ray exporter, so `env_utils` stays free of any cloud SDK. Both sit
  behind an `otel` feature that is off by default.
- Misconfiguration degrades to logging-only, with one deliberate refusal:
  `OTEL_EXPORTER_OTLP_ENDPOINT` outranks the endpoint handed to the builder, so
  setting it alongside `xray` would send SigV4-signed requests to a third party
  whose Authorization header names our access key.

Integration tests export into a real Jaeger container and assert the spans
arrive on the propagated trace context. `make telemetry-integration-test`, needs
only Docker.
