### PR TITLE
feat(telemetry): export traces from every service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5810,13 +5810,13 @@ version = "0.1.0"
 dependencies = [
  "env_common",
  "env_defs",
- "env_utils",
  "futures",
  "lambda_runtime",
  "log",
  "openssl",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/env_aws_direct/src/api.rs
+++ b/env_aws_direct/src/api.rs
@@ -590,6 +590,34 @@ pub async fn start_runner(event: &Value) -> Result<Value, anyhow::Error> {
         .and_then(|v| v.as_str())
         .unwrap_or("512");
 
+    let runner_container = {
+        let builder = aws_sdk_ecs::types::ContainerOverride::builder()
+            .name("runner")
+            .cpu(cpu.parse::<i32>()?)
+            .memory(memory.parse::<i32>()?)
+            .environment(
+                aws_sdk_ecs::types::KeyValuePair::builder()
+                    .name("PAYLOAD")
+                    .value(serde_json::to_string(payload)?)
+                    .build(),
+            );
+
+        // Propagate the caller's trace context so the runner's spans join the
+        // same trace (internal-api / reconciler) instead of starting a new one.
+        #[cfg(feature = "otel")]
+        let builder = match env_utils::otel_tracing::current_traceparent() {
+            Some(traceparent) => builder.environment(
+                aws_sdk_ecs::types::KeyValuePair::builder()
+                    .name("TRACE_ID")
+                    .value(traceparent)
+                    .build(),
+            ),
+            None => builder,
+        };
+
+        builder.build()
+    };
+
     let res = client
         .run_task()
         .cluster(ecs_cluster_name)
@@ -599,19 +627,7 @@ pub async fn start_runner(event: &Value) -> Result<Value, anyhow::Error> {
             aws_sdk_ecs::types::TaskOverride::builder()
                 .cpu(cpu)
                 .memory(memory)
-                .container_overrides(
-                    aws_sdk_ecs::types::ContainerOverride::builder()
-                        .name("runner")
-                        .cpu(cpu.parse::<i32>()?)
-                        .memory(memory.parse::<i32>()?)
-                        .environment(
-                            aws_sdk_ecs::types::KeyValuePair::builder()
-                                .name("PAYLOAD")
-                                .value(serde_json::to_string(payload)?)
-                                .build(),
-                        )
-                        .build(),
-                )
+                .container_overrides(runner_container)
                 .build(),
         )
         .network_configuration(

--- a/env_aws_direct/src/direct_impl.rs
+++ b/env_aws_direct/src/direct_impl.rs
@@ -1053,6 +1053,18 @@ pub async fn start_runner_cross_account(data: &Value) -> Result<Value> {
         }
     }
 
+    // Propagate the caller's trace context so the runner's spans join the same
+    // trace (internal-api / reconciler) instead of starting a disconnected one.
+    #[cfg(feature = "otel")]
+    if let Some(traceparent) = env_utils::otel_tracing::current_traceparent() {
+        env_vars.push(
+            aws_sdk_ecs::types::KeyValuePair::builder()
+                .name("TRACE_ID")
+                .value(traceparent)
+                .build(),
+        );
+    }
+
     let network_config = aws_sdk_ecs::types::NetworkConfiguration::builder()
         .awsvpc_configuration(
             aws_sdk_ecs::types::AwsVpcConfiguration::builder()

--- a/env_common/src/telemetry.rs
+++ b/env_common/src/telemetry.rs
@@ -138,11 +138,18 @@ pub fn shutdown_tracing() {
     otel_tracing::shutdown_tracing();
 }
 
-/// Force-flush buffered spans. On Lambda, call at the end of each invocation so
-/// spans reach the collector/X-Ray before the execution environment freezes.
+/// Force-flush buffered spans. In a function-as-a-service runtime, call at the
+/// end of each invocation so spans are exported before the execution
+/// environment is frozen or torn down.
 pub fn force_flush_tracing() {
     otel_tracing::force_flush_tracing();
 }
+
+/// Root span for a service entry point, adopting whatever trace context the
+/// platform propagated. Re-exported so a binary gets its whole tracing setup
+/// from this one module; the span itself is cloud-agnostic, hence its home in
+/// `env_utils`.
+pub use otel_tracing::entry_span;
 
 #[cfg(test)]
 mod tests {

--- a/internal-api/Cargo.toml
+++ b/internal-api/Cargo.toml
@@ -19,8 +19,11 @@ serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-env_common = { path = "../env_common" }
+env_common = { path = "../env_common", features = ["otel"] }
 env_defs = { path = "../defs" }
+# `otel` for otel_tracing's trace-context helpers. env_common/otel enables it
+# too, but relying on that unification makes this crate fail to compile the
+# moment the feature moves.
 env_utils = { path = "../utils", features = ["otel"] }
 env_aws_direct = { path = "../env_aws_direct" }
 env_azure_direct = { path = "../env_azure_direct" }
@@ -41,8 +44,8 @@ urlencoding = { workspace = true }
 utoipa = { version = "5.2", optional = true }
 utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 
-# Tracing macros (`#[instrument]`, `Span`); OTel init lives in env_utils
-# behind the `otel` feature.
+# Tracing macros (`#[instrument]`, `Span`); OTel init lives in env_common's
+# `telemetry` module behind the `otel` feature.
 tracing = "0.1"
 
 # AWS dependencies (optional)

--- a/internal-api/Dockerfile.lambda.debian
+++ b/internal-api/Dockerfile.lambda.debian
@@ -4,6 +4,11 @@ ARG TARGETARCH
 
 COPY binaries/internal-api-aws-unified-${TARGETOS}-${TARGETARCH}-musl /usr/local/bin/bootstrap
 
+# No collector here on purpose. Spans are exported in-process; a collector
+# inside a Lambda loses them, because the sandbox freezes before its
+# asynchronous send completes. TELEMETRY_EXPORTER is set by the deployment
+# rather than baked in, so there is a single source of truth.
+
 ENV AWS_LAMBDA_RUNTIME_API="aws-runtime-interface.emulator"
 ENV CLOUD_PROVIDER=aws
 

--- a/internal-api/src/aws_handlers.rs
+++ b/internal-api/src/aws_handlers.rs
@@ -293,9 +293,23 @@ pub async fn generate_presigned_url(payload: &Value) -> Result<Value> {
     Ok(json!({"url": url}))
 }
 
+// The `infraweave.*` fields are the correlation keys shared with the reconciler
+// and the runner: one deployment's whole history is `infraweave.deployment_id`,
+// and a single run within it is `infraweave.job_id`. They are namespaced because
+// `deployment.environment` is an unrelated OTel resource attribute naming the AWS
+// account, and because this service's own install environment is a third thing
+// again.
 #[instrument(
     skip(payload),
-    fields(project_id, environment, region, task_definition)
+    fields(
+        infraweave.deployment_id = tracing::field::Empty,
+        infraweave.environment_id = tracing::field::Empty,
+        infraweave.project_id = tracing::field::Empty,
+        infraweave.job_id = tracing::field::Empty,
+        infraweave.install_environment = tracing::field::Empty,
+        region,
+        task_definition,
+    )
 )]
 pub async fn start_runner(payload: &Value) -> Result<Value> {
     info!(
@@ -312,10 +326,23 @@ pub async fn start_runner(payload: &Value) -> Result<Value> {
         .ok_or_else(|| anyhow!("Missing 'project_id' in payload"))?;
 
     let span = tracing::Span::current();
-    span.record("project_id", &project_id);
+    span.record("infraweave.project_id", &project_id);
 
+    // The deployment this run belongs to. Recorded here as well as on the
+    // runner's own root span so the launching call and the run it starts can be
+    // found by the same key — without it a trace search by deployment only ever
+    // returns the second half of the story.
+    if let Some(deployment_id) = data.get("deployment_id").and_then(|v| v.as_str()) {
+        span.record("infraweave.deployment_id", &deployment_id);
+    }
+    if let Some(environment_id) = data.get("environment").and_then(|v| v.as_str()) {
+        span.record("infraweave.environment_id", &environment_id);
+    }
+
+    // This service's own install environment, which is not the deployment's
+    // environment above and is constant for the life of the function.
     let environment = get_env_var("ENVIRONMENT")?;
-    span.record("environment", &environment.as_str());
+    span.record("infraweave.install_environment", &environment.as_str());
 
     let region = data
         .get("region")
@@ -330,13 +357,24 @@ pub async fn start_runner(payload: &Value) -> Result<Value> {
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let job_id = result.get("job_id").and_then(|v| v.as_str()).unwrap_or("");
+    // Only known once the task is launched, and it is what ties this span to the
+    // runner's root span for the same run.
+    span.record("infraweave.job_id", &job_id);
 
     info!(task_arn = %task_arn, job_id = %job_id, "ECS task launched successfully");
 
     Ok(result)
 }
 
-#[instrument(skip(payload), fields(job_id, project_id, region, task_status))]
+#[instrument(
+    skip(payload),
+    fields(
+        infraweave.job_id = tracing::field::Empty,
+        infraweave.project_id = tracing::field::Empty,
+        region,
+        task_status,
+    )
+)]
 pub async fn get_job_status(payload: &Value) -> Result<Value> {
     let data = payload
         .get("data")
@@ -355,8 +393,8 @@ pub async fn get_job_status(payload: &Value) -> Result<Value> {
         .ok_or_else(|| anyhow!("Missing 'region' parameter"))?;
 
     let span = tracing::Span::current();
-    span.record("job_id", &job_id);
-    span.record("project_id", &project_id);
+    span.record("infraweave.job_id", &job_id);
+    span.record("infraweave.project_id", &project_id);
     span.record("region", &region);
 
     let result = env_aws_direct::get_job_status_cross_account(job_id, project_id, region).await?;

--- a/internal-api/src/main.rs
+++ b/internal-api/src/main.rs
@@ -1,4 +1,5 @@
 use env_common::interface::initialize_project_id_and_region;
+use env_common::telemetry;
 use internal_api::http_router;
 #[cfg(feature = "local")]
 use internal_api::local_setup;
@@ -8,7 +9,14 @@ use tower_http::trace::TraceLayer;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    env_logger::init();
+    // Same tracing setup as the deployed binaries, so the TraceLayer spans below
+    // are actually recorded and can be exported locally (e.g.
+    // TELEMETRY_EXPORTER=otlp-http against a collector or Jaeger). Without an
+    // exporter configured this is just logging, as before.
+    if let Err(e) = telemetry::init_tracing("internal-api-scaffold").await {
+        eprintln!("Failed to initialize OpenTelemetry: {}", e);
+        env_logger::init();
+    }
 
     #[cfg(feature = "local")]
     let _infra = if local_setup::local_infra_enabled() {
@@ -48,9 +56,15 @@ async fn main() -> std::io::Result<()> {
     println!("  curl http://127.0.0.1:{}/api/v1/projects", port);
     println!("\nPress Ctrl+C to shut down.\n");
 
-    axum::serve(listener, app)
+    let served = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
-        .await?;
+        .await;
+
+    // Off the async worker: shutdown blocks until the batch processor drains,
+    // and that processor runs on this runtime.
+    let _ = tokio::task::spawn_blocking(telemetry::shutdown_tracing).await;
+
+    served?;
 
     println!("Shutting down... (containers will be stopped)");
     Ok(())

--- a/internal-api/src/main_aws_unified.rs
+++ b/internal-api/src/main_aws_unified.rs
@@ -2,15 +2,17 @@ use axum::body::Body;
 use axum::http::Request;
 use base64::{engine::general_purpose, Engine as _};
 use env_common::interface::initialize_project_id_and_region;
-use env_utils::otel_tracing;
+use env_common::telemetry;
 use internal_api::aws_handlers as handlers;
 use internal_api::http_router;
 use lambda_runtime::{service_fn, Error, LambdaEvent};
 use log::{debug, info, warn};
 use serde_json::Value;
 use tower_http::trace::TraceLayer;
-use tracing::{instrument, Span};
+use tracing::{instrument, Instrument, Span};
 
+// The service-entry span is `lambda_invocation` in main, which carries
+// otel.kind and the adopted Lambda trace context; this is its child.
 #[instrument(
     skip(event),
     fields(request_id, trace_id, user_id, http_method, http_path, event_type)
@@ -25,12 +27,8 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
     // Record the X-Ray trace ID so log lines can be correlated with the
     // `x-trace-id` header returned to the CLI.
     if let Ok(amzn_trace) = std::env::var("_X_AMZN_TRACE_ID") {
-        if let Some(root) = amzn_trace
-            .split(';')
-            .next()
-            .and_then(|s| s.strip_prefix("Root="))
-        {
-            span.record("trace_id", &root);
+        if let Some(root) = env_utils::otel_tracing::xray_root_trace_id(&amzn_trace) {
+            span.record("trace_id", root);
         }
     }
 
@@ -325,11 +323,8 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
 
     if is_authenticated {
         if let Ok(trace_id) = std::env::var("_X_AMZN_TRACE_ID") {
-            // Extract just the Root trace ID (format: Root=1-xxx-xxx;Parent=...;Sampled=...)
-            if let Some(root_part) = trace_id.split(';').next() {
-                if let Some(id) = root_part.strip_prefix("Root=") {
-                    headers_map.insert("X-Trace-Id".to_string(), Value::String(id.to_string()));
-                }
+            if let Some(id) = env_utils::otel_tracing::xray_root_trace_id(&trace_id) {
+                headers_map.insert("X-Trace-Id".to_string(), Value::String(id.to_string()));
             }
         }
     } else {
@@ -350,7 +345,7 @@ async fn unified_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize OTEL tracing first
-    if let Err(e) = otel_tracing::init_tracing("internal-api", None) {
+    if let Err(e) = telemetry::init_tracing("internal-api").await {
         eprintln!("Failed to initialize OpenTelemetry: {}", e);
         // Fall back to env_logger if OTEL init fails
         env_logger::init();
@@ -363,10 +358,37 @@ async fn main() -> Result<(), Error> {
         "Starting unified internal-api Lambda handler (supports both direct invocation and HTTP)"
     );
 
-    let result = lambda_runtime::run(service_fn(unified_handler)).await;
+    let result = lambda_runtime::run(service_fn(|event| async move {
+        // Join the trace Lambda already started for this invocation, instead of
+        // beginning a separate one. Lambda's built-in active tracing records the
+        // invocation under its own trace id; without adopting it here, one
+        // request produces two unrelated traces that cannot be lined up.
+        //
+        // This has to wrap the handler rather than live on its #[instrument]:
+        // a span's parent is fixed when the span is created, so it must be set
+        // before the instrumented span exists.
+        let root = tracing::info_span!("lambda_invocation", otel.kind = "server");
+        if let Ok(header) = std::env::var("_X_AMZN_TRACE_ID") {
+            env_utils::otel_tracing::set_span_parent_from_xray_header(&root, &header);
+        }
 
-    // Shutdown tracing gracefully
-    otel_tracing::shutdown_tracing();
+        let response = unified_handler(event).instrument(root).await;
+        // Flush this invocation's spans to the in-image collector before the
+        // Lambda execution environment freezes, otherwise they never reach
+        // X-Ray and there's no `api` segment for downstream traces to join.
+        //
+        // Must run off the async worker: force_flush blocks the calling thread
+        // until the batch processor drains, and that processor runs on this
+        // same runtime. Calling it inline deadlocks outright on a
+        // current-thread runtime and starves a worker on a multi-threaded one.
+        let _ = tokio::task::spawn_blocking(telemetry::force_flush_tracing).await;
+        response
+    }))
+    .await;
+
+    // Shutdown tracing gracefully. Blocking, so off the async worker for the
+    // same reason as the per-invocation flush above.
+    let _ = tokio::task::spawn_blocking(telemetry::shutdown_tracing).await;
 
     result
 }

--- a/internal-api/src/main_azure_unified.rs
+++ b/internal-api/src/main_azure_unified.rs
@@ -1,6 +1,6 @@
 // Azure Functions Custom Handler - Simple HTTP server for Azure Functions
 use env_common::interface::initialize_project_id_and_region;
-use env_utils::otel_tracing;
+use env_common::telemetry;
 use internal_api::http_router;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
@@ -37,7 +37,7 @@ async fn normalize_azure_headers(mut req: Request, next: Next) -> Response {
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    if let Err(e) = otel_tracing::init_tracing("internal-api-azure", None) {
+    if let Err(e) = telemetry::init_tracing("internal-api-azure").await {
         eprintln!("Failed to initialize OpenTelemetry: {}", e);
         env_logger::init();
     }
@@ -64,5 +64,41 @@ async fn main() -> std::io::Result<()> {
     );
     println!("Azure Functions custom handler running on port {}", port);
 
-    axum::serve(listener, app).await
+    // Graceful shutdown exists so the tracer provider gets flushed below. The
+    // root span of each request closes last and is still queued at exit; without
+    // this the process is torn down with it undelivered, and Application Signals
+    // derives a service's existence from those entry-point spans.
+    let served = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await;
+
+    // Off the async worker: shutdown blocks until the batch processor drains,
+    // and that processor runs on this runtime.
+    let _ = tokio::task::spawn_blocking(telemetry::shutdown_tracing).await;
+
+    served
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }

--- a/internal-api/src/main_local_http.rs
+++ b/internal-api/src/main_local_http.rs
@@ -1,4 +1,5 @@
 use env_common::interface::initialize_project_id_and_region;
+use env_common::telemetry;
 use internal_api::http_router;
 #[cfg(feature = "local")]
 use internal_api::local_setup;
@@ -8,7 +9,14 @@ use tower_http::trace::TraceLayer;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    env_logger::init();
+    // Same tracing setup as the deployed binaries, so the TraceLayer spans below
+    // are actually recorded and can be exported locally (e.g.
+    // TELEMETRY_EXPORTER=otlp-http against a collector or Jaeger). Without an
+    // exporter configured this is just logging, as before.
+    if let Err(e) = telemetry::init_tracing("internal-api-local").await {
+        eprintln!("Failed to initialize OpenTelemetry: {}", e);
+        env_logger::init();
+    }
 
     #[cfg(feature = "local")]
     let _infra = if local_setup::local_infra_enabled() {
@@ -45,9 +53,15 @@ async fn main() -> std::io::Result<()> {
     println!("  curl http://127.0.0.1:{}/api/v1/modules", port);
     println!("  curl http://127.0.0.1:{}/api/v1/projects", port);
 
-    axum::serve(listener, app)
+    let served = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
-        .await
+        .await;
+
+    // Off the async worker: shutdown blocks until the batch processor drains,
+    // and that processor runs on this runtime.
+    let _ = tokio::task::spawn_blocking(telemetry::shutdown_tracing).await;
+
+    served
 }
 
 async fn shutdown_signal() {

--- a/reconciler/Cargo.toml
+++ b/reconciler/Cargo.toml
@@ -8,9 +8,11 @@ publish.workspace = true
 [dependencies]
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }
-env_common = { path = "../env_common" }
+env_common = { path = "../env_common", features = ["otel"] }
 env_defs = { path = "../defs" }
-env_utils = { path = "../utils" }
+
+# Spans around the drift checks; the tracing setup itself is env_common's.
+tracing = { workspace = true }
 log = { workspace = true }
 lambda_runtime = { workspace = true }
 futures = { workspace = true }

--- a/reconciler/Dockerfile.lambda.debian
+++ b/reconciler/Dockerfile.lambda.debian
@@ -4,6 +4,11 @@ ARG TARGETARCH
 
 COPY binaries/reconciler-${TARGETOS}-${TARGETARCH}-musl /usr/local/bin/bootstrap
 
+# No collector here on purpose. Spans are exported in-process; a collector
+# inside a Lambda loses them, because the sandbox freezes before its
+# asynchronous send completes. TELEMETRY_EXPORTER is set by the deployment
+# rather than baked in, so there is a single source of truth.
+
 # Lambda requires this
 ENV AWS_LAMBDA_RUNTIME_API="aws-runtime-interface.emulator"
 

--- a/reconciler/src/main.rs
+++ b/reconciler/src/main.rs
@@ -1,12 +1,16 @@
 use env_common::interface::{initialize_project_id_and_region, GenericCloudHandler};
 use env_common::logic::driftcheck_infra;
+use env_common::telemetry;
 use env_defs::{CloudProvider, ExtraData};
-use env_utils::setup_logging;
 use futures::future::join_all;
 use lambda_runtime::{service_fn, Error, LambdaEvent};
 use log::{error, info};
 use serde_json::{json, Value};
+use tracing::Instrument;
 
+// The service-entry span is the one main wraps this in, which carries otel.kind
+// and the adopted trace context; this is its child.
+#[tracing::instrument(skip(event))]
 async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
     let (_event, _context) = event.into_parts();
 
@@ -30,6 +34,18 @@ async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
     let drift_checks = deployments.clone().into_iter().map(|deployment| {
         let deployment_id = deployment.deployment_id.clone();
         let environment = deployment.environment.clone();
+
+        // One span per deployment rather than one for the whole invocation.
+        // Drift checks run concurrently, so without this their work interleaves
+        // under a single span and a trace search by deployment cannot tell which
+        // of them failed. These are the same correlation keys internal-api and
+        // the runner use, so one deployment's history spans all three services.
+        let span = tracing::info_span!(
+            "driftcheck",
+            infraweave.deployment_id = %deployment_id,
+            infraweave.environment_id = %environment,
+        );
+
         async move {
             let remediate = deployment.drift_detection.auto_remediate;
             info!(
@@ -54,6 +70,7 @@ async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
                 }
             }
         }
+        .instrument(span)
     });
 
     join_all(drift_checks).await;
@@ -80,11 +97,35 @@ async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    setup_logging().expect("Failed to initialize logging.");
+    telemetry::init_tracing("reconciler")
+        .await
+        .expect("Failed to initialize tracing.");
     initialize_project_id_and_region().await;
 
-    let fun = service_fn(func);
-    lambda_runtime::run(fun).await?;
+    let fun = service_fn(|event| async move {
+        // Service-entry span for this run, joined to whatever trace the runtime
+        // propagated; entry_span resolves that per platform so nothing here is
+        // tied to one cloud.
+        let response = func(event).instrument(telemetry::entry_span()).await;
+
+        // Export this run's spans before the execution environment is frozen or
+        // torn down. shutdown_tracing() below only runs when the serving loop
+        // exits, which for a hosted function is effectively never, so without
+        // this the spans are lost.
+        //
+        // Off the async worker: force_flush blocks until the batch processor
+        // drains, and that processor runs on this same runtime, so calling it
+        // inline deadlocks on a current-thread runtime and starves a worker on
+        // a multi-threaded one.
+        let _ = tokio::task::spawn_blocking(telemetry::force_flush_tracing).await;
+        response
+    });
+    let result = lambda_runtime::run(fun).await;
+
+    // Blocking, so off the async worker for the same reason as the
+    // per-invocation flush above.
+    let _ = tokio::task::spawn_blocking(telemetry::shutdown_tracing).await;
+    result?;
 
     Ok(())
 }

--- a/terraform_runner/Cargo.toml
+++ b/terraform_runner/Cargo.toml
@@ -14,7 +14,7 @@ log = { workspace = true }
 reqwest = { workspace = true }
 futures = { workspace = true }
 
-env_common = { path = "../env_common" }
+env_common = { path = "../env_common", features = ["otel"] }
 env_defs = { path = "../defs" }
 env_utils = { path = "../utils", features = ["otel"] }
 tracing = "0.1"

--- a/terraform_runner/Dockerfile.runner.alpine
+++ b/terraform_runner/Dockerfile.runner.alpine
@@ -4,6 +4,12 @@ ARG TARGETARCH
 ARG REGISTRY_API_HOSTNAME
 ENV REGISTRY_API_HOSTNAME=${REGISTRY_API_HOSTNAME}
 
+# TELEMETRY_EXPORTER is set by the deployment (the ECS task definition) rather
+# than baked in, so there is a single source of truth. The task also supplies
+# TELEMETRY_AWS_REGION, which ECS does not set automatically the way Lambda does.
+# A task that adds a collector sidecar must also set TELEMETRY_DRAIN_SECONDS, or
+# the task tears down before the sidecar can forward the runner's root segment.
+
 COPY --from=terraform /usr/local/bin/terraform /usr/local/bin/terraform
 COPY --from=opa /usr/local/bin/opa /usr/local/bin/opa
 COPY binaries/terraform_runner-${TARGETOS}-${TARGETARCH}-musl /usr/local/bin/terraform_runner

--- a/terraform_runner/src/main.rs
+++ b/terraform_runner/src/main.rs
@@ -2,19 +2,46 @@ mod read;
 
 use anyhow::Result;
 use env_common::interface::{initialize_project_id_and_region, GenericCloudHandler};
-use env_utils::otel_tracing;
+use env_common::telemetry;
 use terraform_runner::{run_terraform_runner, setup_misc};
 use tracing::Instrument;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    otel_tracing::init_tracing("terraform-runner", None).expect("Failed to initialize tracing");
+    telemetry::init_tracing("terraform-runner")
+        .await
+        .expect("Failed to initialize tracing");
 
-    // Wrap the whole runner in a span carrying the upstream trace id so
-    // every log line / OTel span is tagged with it. The API sets TRACE_ID
-    // on the ECS container override.
+    // Wrap the whole runner in a root span. If the launching service
+    // (internal-api / reconciler) propagated its trace context via the TRACE_ID
+    // container override, adopt it as the parent so the runner's spans join the
+    // caller's trace instead of starting a disconnected one.
+    //
+    // `otel.kind = "server"` makes the X-Ray exporter emit this as a top-level
+    // *segment* (a service entry point), so the runner stays visible as its own
+    // node under the caller's trace rather than becoming an orphaned subsegment.
+    // With nothing propagated it is simply a root.
+    // Declared empty and filled in once the payload is parsed, so the root span
+    // can be filtered on without drilling into children.
     let trace_id = std::env::var("TRACE_ID").unwrap_or_default();
-    let root_span = tracing::info_span!("terraform_runner", trace_id = %trace_id);
+    let root_span = tracing::info_span!(
+        "terraform_runner",
+        otel.kind = "server",
+        infraweave.job_id = tracing::field::Empty,
+        // Namespaced because `deployment.environment` is an OTel resource
+        // attribute naming the AWS account, while this one is InfraWeave's own
+        // environment id. Two unrelated meanings that otherwise read alike on
+        // the same span.
+        infraweave.deployment_id = tracing::field::Empty,
+        infraweave.environment_id = tracing::field::Empty,
+        infraweave.project_id = tracing::field::Empty,
+        region = tracing::field::Empty,
+        module = tracing::field::Empty,
+        version = tracing::field::Empty,
+        command = tracing::field::Empty,
+        initiated_by = tracing::field::Empty,
+    );
+    env_utils::otel_tracing::set_span_parent_from_traceparent(&root_span, &trace_id);
 
     let result = async {
         initialize_project_id_and_region().await;
@@ -25,7 +52,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .instrument(root_span)
     .await;
 
-    otel_tracing::shutdown_tracing();
+    // The root span above closed when its future was dropped at the end of that
+    // statement, so this flush is what actually exports it. Off the async worker
+    // for the same reason as in the Lambda handlers: shutdown blocks until the
+    // batch processor drains, and that processor runs on this runtime.
+    let _ = tokio::task::spawn_blocking(telemetry::shutdown_tracing).await;
+
+    if let Some(drain) = collector_drain_wait() {
+        tokio::time::sleep(drain).await;
+    }
+
     result?;
     Ok(())
+}
+
+/// How long to stay alive after flushing, for a collector sidecar to drain.
+///
+/// With one in front of `otlp-http`, the ECS task tears down the moment this
+/// (essential) container exits — which kills the collector before it can export
+/// the root `terraform_runner` segment that just closed and flushed. Without
+/// that root segment X-Ray drops the whole trace as orphaned subsegments.
+///
+/// No image bundles a collector, so the default is not to wait; a deployment
+/// that adds a sidecar sets `TELEMETRY_DRAIN_SECONDS`. Exporting in-process
+/// needs no wait at all — `shutdown_tracing` has already drained.
+fn collector_drain_wait() -> Option<std::time::Duration> {
+    let raw = std::env::var("TELEMETRY_DRAIN_SECONDS").ok()?;
+    match raw.trim().parse::<u64>() {
+        Ok(0) => None,
+        Ok(seconds) => Some(std::time::Duration::from_secs(seconds)),
+        Err(e) => {
+            eprintln!("Ignoring TELEMETRY_DRAIN_SECONDS={raw:?}: {e}");
+            None
+        }
+    }
 }

--- a/terraform_runner/src/runner.rs
+++ b/terraform_runner/src/runner.rs
@@ -30,6 +30,19 @@ pub async fn run_terraform_runner(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let payload = parse_payload_env_var();
 
+    // Fill in the root span declared in main, so a trace can be found by
+    // deployment or job rather than only by span name. Deliberately excludes
+    // the deployment variables, which are fetched later and can hold secrets.
+    let root_span = tracing::Span::current();
+    root_span.record("infraweave.deployment_id", payload.deployment_id.as_str());
+    root_span.record("infraweave.environment_id", payload.environment.as_str());
+    root_span.record("infraweave.project_id", payload.project_id.as_str());
+    root_span.record("region", payload.region.as_str());
+    root_span.record("module", payload.module.as_str());
+    root_span.record("version", payload.module_version.as_str());
+    root_span.record("command", payload.command.as_str());
+    root_span.record("initiated_by", payload.initiated_by.as_str());
+
     // Skeleton with empty variables; real values are fetched from the DB
     // inside the guarded section below and patched in via set_variables.
     let payload_with_variables = ApiInfraPayloadWithVariables {
@@ -44,6 +57,16 @@ pub async fn run_terraform_runner(
         &payload_with_variables.payload,
     )
     .await;
+
+    // Only now does the handler hold a real job id. It starts out as the
+    // "unknown_jobid" placeholder and is replaced from the cloud provider inside
+    // the flow above, so recording this any earlier captures the placeholder.
+    //
+    // The root span is still open — it closes when main's instrumented future
+    // ends — so a field recorded here is exported with it. A flow that fails
+    // before reaching that point leaves the placeholder, which is the honest
+    // answer: the runner never learned which job it was.
+    root_span.record("infraweave.job_id", status_handler.get_job_id());
     let completion = finish_runner_flow(handler, &mut status_handler, flow_result).await;
 
     publish_runner_notification(

--- a/terraform_runner/src/terraform.rs
+++ b/terraform_runner/src/terraform.rs
@@ -20,7 +20,15 @@ use anyhow::{anyhow, Context, Result};
 use crate::{post_webhook, run_generic_command, CommandResult};
 
 #[allow(clippy::too_many_arguments)]
-#[tracing::instrument(skip_all, fields(command = %command))]
+#[tracing::instrument(skip_all, fields(
+    command = %command,
+    args = tracing::field::Empty,
+    tf_vars = tracing::field::Empty,
+    ok = tracing::field::Empty,
+    stdout_bytes = tracing::field::Empty,
+    stderr_bytes = tracing::field::Empty,
+    error = tracing::field::Empty,
+))]
 pub async fn run_terraform_command(
     command: &str,
     refresh_only: bool,
@@ -93,9 +101,48 @@ pub async fn run_terraform_command(
             .await;
     }
 
+    // Record the command line only once every argument is in place, including
+    // the backend config — which carries credentials inline, so the values are
+    // masked. Deployment variables are passed as TF_VAR_* environment
+    // variables and can hold anything, so only their names are recorded.
+    let span = tracing::Span::current();
+    span.record(
+        "args",
+        tracing::field::display(env_utils::redact::sanitize_cli_args(
+            exec.as_std()
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned()),
+        )),
+    );
+    if let Some(env_vars) = extra_environment_variables {
+        let mut names: Vec<&str> = env_vars.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        span.record("tf_vars", tracing::field::display(names.join(",")));
+    }
+
     // Don't print output for graph, show, or state commands to avoid cluttering
     let print_output = !["graph", "show", "state"].contains(&command);
-    run_generic_command(&mut exec, max_output_lines, print_output).await
+    let result = run_generic_command(&mut exec, max_output_lines, print_output).await;
+
+    // Without this a failed command is just a span with no reason attached.
+    match &result {
+        Ok(output) => {
+            span.record("ok", true);
+            span.record("stdout_bytes", output.stdout.len() as u64);
+            span.record("stderr_bytes", output.stderr.len() as u64);
+        }
+        Err(e) => {
+            span.record("ok", false);
+            // Bounded: this is terraform's own output, which has no size limit
+            // and would otherwise be able to fail the export it travels in.
+            span.record(
+                "error",
+                env_utils::redact::truncate_for_span(&e.to_string()).as_str(),
+            );
+        }
+    }
+
+    result
 }
 
 #[tracing::instrument(skip_all, fields(cmd = %payload.command, module = %payload.module, version = %payload.module_version))]
@@ -318,7 +365,7 @@ pub async fn terraform_plan(
     }
 }
 
-#[tracing::instrument(skip_all, fields(cmd = %payload.command, job_id = %job_id, module = %module.module, version = %module.version))]
+#[tracing::instrument(skip_all, fields(cmd = %payload.command, infraweave.job_id = %job_id, module = %module.module, version = %module.version))]
 pub async fn terraform_show(
     payload: &ApiInfraPayload,
     job_id: &str,
@@ -486,7 +533,7 @@ pub async fn terraform_show(
     }
 }
 
-#[tracing::instrument(skip_all, fields(cmd = %payload.command, job_id = %job_id, module = %module.module, version = %module.version))]
+#[tracing::instrument(skip_all, fields(cmd = %payload.command, infraweave.job_id = %job_id, module = %module.module, version = %module.version))]
 pub async fn record_apply_destroy_changes(
     payload: &ApiInfraPayload,
     job_id: &str,

--- a/utils/src/otel_tracing.rs
+++ b/utils/src/otel_tracing.rs
@@ -578,6 +578,47 @@ pub fn set_span_parent_from_traceparent(span: &tracing::Span, traceparent: &str)
     }
 }
 
+/// Root span for one unit of work — an invocation, a request, a scheduled run —
+/// joined to the trace the surrounding runtime already started when there is
+/// one.
+///
+/// Platforms hand the caller's trace context in through the process
+/// environment, each spelling it differently: W3C `TRACEPARENT` is the portable
+/// form (and what InfraWeave propagates itself), AWS Lambda writes its own
+/// `_X_AMZN_TRACE_ID`. Doing the lookup here keeps entry points free of any one
+/// cloud's spelling. With nothing propagated the span is simply a root, which
+/// is the right outcome when running as a plain container.
+///
+/// `otel.kind = "server"` marks it as a service entry point. That is
+/// load-bearing rather than cosmetic under X-Ray, whose exporter turns
+/// Server/Consumer spans into *segments* and everything else into
+/// *subsegments*: a subsegment whose parent segment never arrived is dropped
+/// silently, taking the service's spans with it.
+pub fn entry_span() -> tracing::Span {
+    let span = tracing::info_span!("invocation", otel.kind = "server");
+    let traceparent = std::env::var("TRACEPARENT").ok();
+    let xray = std::env::var("_X_AMZN_TRACE_ID").ok();
+    adopt_ambient_context(&span, traceparent.as_deref(), xray.as_deref());
+    span
+}
+
+/// Adopt whichever propagated context is present as `span`'s parent, portable
+/// spelling first: when both are set, `TRACEPARENT` is a trace a caller of ours
+/// put there deliberately, while the platform's own variable describes just
+/// this invocation. Split out from [`entry_span`] so the precedence is testable
+/// without process-wide environment variables.
+fn adopt_ambient_context(span: &tracing::Span, traceparent: Option<&str>, xray: Option<&str>) {
+    match (traceparent, xray) {
+        // Blank is absent, not a context: an empty TRACEPARENT must not shadow
+        // a platform variable that is set.
+        (Some(traceparent), _) if !traceparent.trim().is_empty() => {
+            set_span_parent_from_traceparent(span, traceparent)
+        }
+        (_, Some(header)) => set_span_parent_from_xray_header(span, header),
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -757,6 +798,60 @@ mod tests {
         assert!(
             traceparent.contains("6a954a8114b68dfaffccd7e39d44814f"),
             "expected the Lambda trace id, got {traceparent}"
+        );
+    }
+
+    // An `_X_AMZN_TRACE_ID` header and the trace id it encodes.
+    const SAMPLE_XRAY_HEADER: &str =
+        "Root=1-6a954a81-14b68dfaffccd7e39d44814f;Parent=53995c3f42cd8ad8;Sampled=1";
+    const SAMPLE_XRAY_TRACE_ID: &str = "6a954a8114b68dfaffccd7e39d44814f";
+
+    /// The trace an entry span ends up in, given what the platform propagated.
+    fn adopted_trace(traceparent: Option<&str>, xray: Option<&str>) -> String {
+        with_otel_subscriber(|| {
+            let span = tracing::info_span!("invocation");
+            adopt_ambient_context(&span, traceparent, xray);
+            let _entered = span.enter();
+            current_traceparent()
+        })
+        .expect("an active span yields a traceparent")
+    }
+
+    #[test]
+    fn an_entry_point_prefers_a_propagated_traceparent_over_the_platforms_own() {
+        // Both are set when we invoke a hosted function ourselves: the
+        // platform's variable describes only that invocation, while the
+        // traceparent carries the trace of whoever asked for the work. Joining
+        // the latter is what keeps one operation in one trace.
+        let adopted = adopted_trace(Some(SAMPLE_TRACEPARENT), Some(SAMPLE_XRAY_HEADER));
+        assert!(
+            adopted.contains(SAMPLE_TRACE_ID),
+            "expected the caller's trace, got {adopted}"
+        );
+    }
+
+    #[test]
+    fn an_entry_point_falls_back_to_the_platforms_context_when_nothing_was_propagated() {
+        // A scheduled run has no caller of ours, but the platform still started
+        // a trace that its spans belong under.
+        let adopted = adopted_trace(None, Some(SAMPLE_XRAY_HEADER));
+        assert!(
+            adopted.contains(SAMPLE_XRAY_TRACE_ID),
+            "expected the platform's trace, got {adopted}"
+        );
+        // Blank is absent, not a context: an empty variable must not shadow the
+        // one that is set.
+        assert!(adopted_trace(Some("  "), Some(SAMPLE_XRAY_HEADER)).contains(SAMPLE_XRAY_TRACE_ID));
+    }
+
+    #[test]
+    fn an_entry_point_with_nothing_propagated_starts_its_own_trace() {
+        // The plain-container case: no variables at all, so the span roots a
+        // trace of its own rather than joining a foreign one.
+        let adopted = adopted_trace(None, None);
+        assert!(
+            !adopted.contains(SAMPLE_TRACE_ID) && !adopted.contains(SAMPLE_XRAY_TRACE_ID),
+            "expected a fresh trace, got {adopted}"
         );
     }
 

--- a/utils/src/redact.rs
+++ b/utils/src/redact.rs
@@ -83,6 +83,33 @@ where
         .join(" ")
 }
 
+/// Longest free-form text recorded on a span, in characters.
+const MAX_SPAN_TEXT: usize = 512;
+
+/// Shorten free-form text for a span attribute, noting what was dropped.
+///
+/// Terraform hands back the last N lines of its output on failure and nothing
+/// bounds how long a line is, so an error carrying a plan fragment or a
+/// provider's JSON response can run to tens of kilobytes. That is worth
+/// bounding rather than hoping about: the batch processor does not retry, so an
+/// export rejected for size loses every span in that batch — for the runner,
+/// the batch flushed at shutdown, which is the whole run. The failure it
+/// describes is exactly when the trace is worth having.
+///
+/// Enough is kept to tell one failure from another; the full text is already in
+/// the logs, which is where a reader goes next either way.
+pub fn truncate_for_span(text: &str) -> String {
+    let text = text.trim();
+    let mut chars = text.chars();
+    // Counting the remainder rather than the whole is what keeps this from
+    // walking a huge string twice.
+    let kept: String = chars.by_ref().take(MAX_SPAN_TEXT).collect();
+    match chars.count() {
+        0 => kept,
+        dropped => format!("{kept}... (+{dropped} chars, see logs)"),
+    }
+}
+
 /// Split an argument at the *first* `=` whose left-hand side looks like a
 /// credential key, returning that key and everything after it.
 ///
@@ -123,6 +150,38 @@ mod tests {
         // Slicing bytes here would panic on a multi-byte boundary.
         let value = "ααααααααααααααα";
         assert_eq!(mask_value(value), "ααα***ααα(15 chars)");
+    }
+
+    #[test]
+    fn short_text_reaches_the_span_intact() {
+        // The common case is a one-line terraform error, which must not be
+        // dressed up with a truncation marker it didn't earn.
+        assert_eq!(
+            truncate_for_span("Error: Invalid provider configuration\n"),
+            "Error: Invalid provider configuration"
+        );
+        assert_eq!(truncate_for_span(""), "");
+    }
+
+    #[test]
+    fn long_text_is_capped_and_says_how_much_it_dropped() {
+        let text = "x".repeat(MAX_SPAN_TEXT + 100);
+        let truncated = truncate_for_span(&text);
+        assert!(truncated.starts_with(&"x".repeat(MAX_SPAN_TEXT)));
+        assert!(
+            truncated.ends_with("... (+100 chars, see logs)"),
+            "expected a truncation marker, got {truncated}"
+        );
+        // The point of the cap: what lands on the span stays near the limit
+        // however large terraform's output was.
+        assert!(truncated.chars().count() < MAX_SPAN_TEXT + 40);
+    }
+
+    #[test]
+    fn truncation_is_char_safe_not_byte_safe() {
+        // Cutting on a byte boundary here would panic mid-character.
+        let text = "α".repeat(MAX_SPAN_TEXT + 1);
+        assert!(truncate_for_span(&text).ends_with("... (+1 chars, see logs)"));
     }
 
     #[test]


### PR DESCRIPTION
Each service initializes through `env_common::telemetry`, opens a root span 
for its entry point, and flushes before it stops running.

- Only SERVER-kind spans become segments, and a subsegment whose parent never
  arrived is dropped silently, so each entry point needs its own root.
- Four `infraweave.*` fields mean the same thing in all three services, so one
  deployment's history is a single query. `internal-api` recorded no deployment
  id at all before this, and the reconciler had one span covering every
  concurrent drift check.
- The runner's job id is recorded after the flow rather than before it. The
  status handler starts out holding an `unknown_jobid` placeholder and only
  receives the real one partway through.

Trace context crosses process boundaries: a W3C traceparent into the runner's
ECS task, and Lambda's `_X_AMZN_TRACE_ID` adopted as the parent, so a plan is
one trace spanning both accounts.
